### PR TITLE
fix: resolve orphaned tool_calls after approval gate interruption

### DIFF
--- a/openpaw/agent/middleware/approval.py
+++ b/openpaw/agent/middleware/approval.py
@@ -14,10 +14,11 @@ logger = logging.getLogger(__name__)
 class ApprovalRequiredError(Exception):
     """Raised when a tool call requires approval and must pause execution."""
 
-    def __init__(self, approval_id: str, tool_name: str, tool_args: dict):
+    def __init__(self, approval_id: str, tool_name: str, tool_args: dict, tool_call_id: str):
         self.approval_id = approval_id
         self.tool_name = tool_name
         self.tool_args = tool_args
+        self.tool_call_id = tool_call_id
         super().__init__(f"Approval required for {tool_name}")
 
 
@@ -108,4 +109,5 @@ class ApprovalToolMiddleware:
             approval_id=approval.id,
             tool_name=tool_name,
             tool_args=tool_args,
+            tool_call_id=request.tool_call.get("id", ""),
         )

--- a/openpaw/channels/telegram.py
+++ b/openpaw/channels/telegram.py
@@ -717,12 +717,14 @@ class TelegramChannel(ChannelAdapter):
         approved = action == "approve"
 
         # Update the button message to show result
-        result_text = "✅ Approved" if approved else "❌ Denied"
+        result_text = "Approved" if approved else "Denied"
         if query.message and query.message.text:
-            await query.edit_message_text(
-                text=f"{query.message.text}\n\n**Result: {result_text}**",
-                parse_mode="Markdown",
-            )
+            try:
+                await query.edit_message_text(
+                    text=f"{query.message.text}\n\nResult: {result_text}",
+                )
+            except Exception:
+                logger.debug("Failed to update approval message", exc_info=True)
 
         # Invoke the callback
         if self._approval_callback:


### PR DESCRIPTION
## Summary

- **Orphaned tool_calls**: When approval middleware raises `ApprovalRequiredError`, LangGraph has already checkpointed the `AIMessage(tool_calls=[...])` with no corresponding `ToolMessage`s. OpenAI-compatible APIs reject this on the next agent run. New `AgentRunner.resolve_orphaned_tool_calls()` injects synthetic `ToolMessage`s via `aupdate_state(as_node="tools")` before re-running.
- **Telegram markdown parse error**: `_handle_approval_callback` used `parse_mode="Markdown"` on text containing unescaped markdown characters from tool args, causing `BadRequest`. Dropped parse mode and wrapped in try/except.
- **Silent loop death**: Wrapped orphan resolution calls in try/except inside `MessageProcessor` so failures don't propagate out of the `except ApprovalRequiredError` block and silently kill the processing loop.

## Test plan

- [x] Unit tests: 22 approval gate tests passing (4 new for orphan resolution)
- [x] Full suite: 1216/1216 passing
- [x] Manual: triggered `overwrite_file` approval gate with live agent, approved — agent resumed and completed the tool call
- [x] Manual: Telegram approval message updates cleanly without `BadRequest`