### PR TITLE
feat: workspace identity for agent spatial orientation

### DIFF
--- a/openpaw/agent/runner.py
+++ b/openpaw/agent/runner.py
@@ -510,7 +510,11 @@ class AgentRunner:
         # Get timezone from workspace config, defaulting to UTC
         timezone = self.workspace.config.timezone if self.workspace.config else "UTC"
 
-        fs_tools_manager = FilesystemTools(workspace_root=workspace_root, timezone=timezone)
+        fs_tools_manager = FilesystemTools(
+            workspace_root=workspace_root,
+            timezone=timezone,
+            workspace_name=self.workspace.name,
+        )
         filesystem_tools = fs_tools_manager.get_tools()
 
         # 3. Combine all tools (filesystem + additional tools)

--- a/openpaw/core/prompts/framework.py
+++ b/openpaw/core/prompts/framework.py
@@ -1,6 +1,8 @@
 """Framework orientation and capability sections for agent system prompts."""
 
 # Core framework orientation - always included
+# NOTE: Keep this constant unchanged for backward compatibility.
+# Tests and __init__.py import it directly.
 FRAMEWORK_ORIENTATION = (
     "You are a persistent autonomous agent running in the OpenPaw framework. "
     "Your workspace directory is your long-term memory—files you write today will "
@@ -9,6 +11,41 @@ FRAMEWORK_ORIENTATION = (
     "and edit files in your workspace. This is YOUR space—use it to stay organized "
     "and maintain continuity across conversations."
 )
+
+# Template version with workspace name injection placeholder.
+# Identical to FRAMEWORK_ORIENTATION but inserts workspace identity after the first sentence.
+FRAMEWORK_ORIENTATION_TEMPLATE = (
+    "You are a persistent autonomous agent running in the OpenPaw framework. "
+    "Your workspace name is '{workspace_name}'. "
+    "All filesystem tools operate relative to your workspace root directory. "
+    "Your workspace directory is your long-term memory—files you write today will "
+    "be there tomorrow. You are encouraged to organize your workspace: create "
+    "subdirectories, maintain notes, keep state files. You can freely read, write, "
+    "and edit files in your workspace. This is YOUR space—use it to stay organized "
+    "and maintain continuity across conversations."
+)
+
+# Workspace filesystem orientation - always included (filesystem tools always available)
+SECTION_WORKSPACE_FILESYSTEM = (
+    "\n\n## Workspace Filesystem\n\n"
+    "Your workspace is NOT a code repository—it is your personal workspace directory. "
+    "All filesystem tool paths are relative to your workspace root. "
+    "Use relative paths like 'notes.md' or 'research/report.txt'. "
+    "Use ls('.') to see your workspace contents."
+)
+
+
+def build_framework_orientation(workspace_name: str) -> str:
+    """Build the framework orientation string with workspace name injected.
+
+    Args:
+        workspace_name: The name of the agent's workspace directory.
+
+    Returns:
+        Formatted orientation string with workspace name embedded.
+    """
+    return FRAMEWORK_ORIENTATION_TEMPLATE.format(workspace_name=workspace_name)
+
 
 # Heartbeat system - conditional on HEARTBEAT.md content
 SECTION_HEARTBEAT = (

--- a/tests/test_file_info.py
+++ b/tests/test_file_info.py
@@ -129,7 +129,7 @@ def test_file_info_file_not_found(fs_tools, workspace):
 
     assert data["path"] == "nonexistent.txt"
     assert data["exists"] is False
-    assert data["error"] == "File not found"
+    assert data["error"].startswith("File not found")
 
 
 def test_file_info_directory(fs_tools, workspace):

--- a/tests/test_filesystem_tools.py
+++ b/tests/test_filesystem_tools.py
@@ -108,3 +108,116 @@ def test_existing_security_checks_still_work(tmp_path: Path):
     # Home directory expansion should still be blocked
     with pytest.raises(ValueError, match="Home directory"):
         fs._resolve_path("~/secrets.txt")
+
+
+# ---------------------------------------------------------------------------
+# Workspace name enrichment tests
+# ---------------------------------------------------------------------------
+
+class TestWorkspaceNameEnrichment:
+    """Tests for workspace_name-driven output enrichment."""
+
+    def _make_fs(self, tmp_path: Path, workspace_name: str = "test_agent") -> FilesystemTools:
+        """Create a FilesystemTools instance with a workspace name."""
+        return FilesystemTools(tmp_path, workspace_name=workspace_name)
+
+    def test_ls_header_includes_workspace_name(self, tmp_path: Path):
+        """ls output starts with [Workspace: <name>] header when workspace_name is set."""
+        (tmp_path / "notes.md").write_text("hello")
+        fs = self._make_fs(tmp_path)
+        tools = {t.name: t for t in fs.get_tools()}
+
+        result = tools["ls"].invoke({"path": "."})
+
+        assert result.startswith("[Workspace: test_agent]")
+        assert "Contents of ./:" in result
+        assert "notes.md" in result
+
+    def test_tool_descriptions_include_workspace_name(self, tmp_path: Path):
+        """All tool descriptions are prefixed with [<name> workspace] when workspace_name is set."""
+        fs = self._make_fs(tmp_path)
+        tools = fs.get_tools()
+
+        for tool_instance in tools:
+            assert tool_instance.description.startswith("[test_agent workspace] "), (
+                f"Tool '{tool_instance.name}' description missing workspace prefix: "
+                f"{tool_instance.description[:60]}"
+            )
+
+    def test_write_success_includes_workspace(self, tmp_path: Path):
+        """write_file success message includes workspace name when set."""
+        fs = self._make_fs(tmp_path)
+        tools = {t.name: t for t in fs.get_tools()}
+
+        result = tools["write_file"].invoke({
+            "file_path": "new_note.md",
+            "content": "line one\nline two\n",
+        })
+
+        assert "Successfully wrote" in result
+        assert "(workspace: test_agent)" in result
+
+    def test_overwrite_success_includes_workspace(self, tmp_path: Path):
+        """overwrite_file success message includes workspace name when set."""
+        (tmp_path / "existing.md").write_text("original")
+        fs = self._make_fs(tmp_path)
+        tools = {t.name: t for t in fs.get_tools()}
+
+        result = tools["overwrite_file"].invoke({
+            "file_path": "existing.md",
+            "content": "replaced content\n",
+        })
+
+        assert "Successfully wrote" in result
+        assert "(workspace: test_agent)" in result
+
+    def test_sandbox_error_includes_hint(self, tmp_path: Path):
+        """ValueError from _resolve_path includes workspace name hint."""
+        fs = self._make_fs(tmp_path)
+        tools = {t.name: t for t in fs.get_tools()}
+
+        # Path traversal triggers a ValueError in _resolve_path
+        result = tools["read_file"].invoke({"file_path": "../etc/passwd"})
+
+        assert "Error:" in result
+        assert "Hint:" in result
+        assert "test_agent" in result
+        assert "notes.md" in result  # example path in hint
+
+    def test_not_found_includes_ls_hint(self, tmp_path: Path):
+        """'not found' errors include ls('.') suggestion."""
+        fs = self._make_fs(tmp_path)
+        tools = {t.name: t for t in fs.get_tools()}
+
+        result = tools["read_file"].invoke({"file_path": "does_not_exist.txt"})
+
+        assert "not found" in result
+        assert "ls('.')" in result
+
+    def test_backward_compat_no_workspace_name(self, tmp_path: Path):
+        """FilesystemTools without workspace_name works identically — no prefixes or hints."""
+        (tmp_path / "file.txt").write_text("content")
+        fs = FilesystemTools(tmp_path)  # no workspace_name
+        tools = {t.name: t for t in fs.get_tools()}
+
+        # ls output has no workspace header
+        ls_result = tools["ls"].invoke({"path": "."})
+        assert "[Workspace:" not in ls_result
+        assert "file.txt" in ls_result
+
+        # Tool descriptions have no workspace prefix
+        for tool_instance in fs.get_tools():
+            assert not tool_instance.description.startswith("[")
+
+        # write_file success has no workspace suffix
+        write_result = tools["write_file"].invoke({
+            "file_path": "new.txt",
+            "content": "hello\n",
+        })
+        assert "(workspace:" not in write_result
+        assert "Successfully wrote" in write_result
+
+        # Path error has no hint
+        error_result = tools["read_file"].invoke({"file_path": "../escape.txt"})
+        assert "Error:" in error_result
+        assert "Hint:" not in error_result


### PR DESCRIPTION
## Summary

- Agents now receive their workspace name in the system prompt framework orientation and a live `<workspace_context>` directory listing at startup
- `FilesystemTools` enriches `ls` headers, tool descriptions, write success messages, and error hints with workspace identity
- Sandbox errors guide agents back with relative path examples; "not found" errors suggest `ls('.')` for discovery
- All enrichments are conditional on `workspace_name` being set — backward compatible with empty default

## Test plan

- [ ] Verify agents can answer "what workspace are you in?" correctly
- [ ] Verify `ls` output shows `[Workspace: name]` header
- [ ] Verify write success messages include workspace name
- [ ] Verify path traversal errors include workspace-relative hints
- [ ] Verify "file not found" errors suggest `ls('.')`
- [ ] 1226 tests passing, ruff clean, no new mypy errors