### PR TITLE
feat: add xai (Grok) model provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,6 +337,27 @@ aws configure
 
 **Region Availability** (Kimi K2): `us-east-1`, `us-east-2`, `us-west-2`, `ap-northeast-1`, `ap-south-1`, `sa-east-1`
 
+#### xAI (Grok) Configuration
+
+OpenPaw supports xAI Grok models via the dedicated `langchain-xai` package (`ChatXAI`).
+
+**Per-workspace (`agent.yaml`)**:
+
+```yaml
+model:
+  provider: xai
+  model: grok-3-mini
+  api_key: ${XAI_API_KEY}
+  temperature: 0.7
+```
+
+**Available xAI Models**:
+- `grok-3` - Grok 3 (full reasoning)
+- `grok-3-mini` - Grok 3 Mini (lightweight, fast)
+- `grok-2-1212` - Grok 2
+
+**Credentials**: Set `XAI_API_KEY` in environment or workspace `.env`.
+
 #### OpenAI-Compatible APIs
 
 Any OpenAI-compatible provider can be used by specifying `base_url` in the workspace model config. Extra kwargs beyond the standard set (`provider`, `model`, `api_key`, `temperature`, `max_turns`, `timeout_seconds`, `region`) are passed through to `init_chat_model()`.
@@ -376,7 +397,7 @@ The `/model` command enables live model switching without restarting the workspa
 - `/model provider:model` — Validate and switch to a new model (e.g., `/model openai:gpt-4o`)
 - `/model reset` — Revert to the configured model from agent.yaml
 
-**API Key Resolution**: When switching providers at runtime, the factory resolves API keys from environment variables. Supported mappings: `anthropic` → `ANTHROPIC_API_KEY`, `openai` → `OPENAI_API_KEY`, `bedrock_converse` → no key required (uses AWS credentials).
+**API Key Resolution**: When switching providers at runtime, the factory resolves API keys from environment variables. Supported mappings: `anthropic` → `ANTHROPIC_API_KEY`, `openai` → `OPENAI_API_KEY`, `xai` → `XAI_API_KEY`, `bedrock_converse` → no key required (uses AWS credentials).
 
 ### Auto-Compact
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -30,6 +30,7 @@ lanes:
 # Examples:
 #   anthropic:claude-sonnet-4-20250514
 #   openai:gpt-4o
+#   xai:grok-3-mini
 #   bedrock_converse:moonshot.kimi-k2-thinking
 agent:
   model: anthropic:claude-sonnet-4-20250514

--- a/openpaw/agent/runner.py
+++ b/openpaw/agent/runner.py
@@ -111,9 +111,17 @@ def create_chat_model(
         logger.info(f"Creating ChatBedrockConverse: model={model_name}, kwargs_keys={list(kwargs.keys())}")
         return ChatBedrockConverse(**kwargs)
 
+    if provider == "xai":
+        from langchain_xai import ChatXAI
+
+        if api_key:
+            kwargs["xai_api_key"] = api_key
+        logger.info(f"Creating ChatXAI: model={model_name}")
+        return ChatXAI(**kwargs)
+
     raise ValueError(
         f"Unsupported model provider: '{provider}'. "
-        f"Supported: openai, anthropic, bedrock_converse"
+        f"Supported: openai, anthropic, bedrock_converse, xai"
     )
 
 

--- a/openpaw/workspace/agent_factory.py
+++ b/openpaw/workspace/agent_factory.py
@@ -25,6 +25,7 @@ class AgentFactory:
         "openai": "OPENAI_API_KEY",
         "bedrock_converse": None,
         "bedrock": None,
+        "xai": "XAI_API_KEY",
     }
 
     def __init__(
@@ -121,7 +122,7 @@ class AgentFactory:
         else:
             provider = "openai"
 
-        supported = {"openai", "anthropic", "bedrock_converse", "bedrock"}
+        supported = {"openai", "anthropic", "bedrock_converse", "bedrock", "xai"}
         if provider not in supported:
             return False, f"Unsupported provider: '{provider}'. Supported: {', '.join(sorted(supported))}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     "docling (>=2.72.0,<3.0.0)",
     "playwright (>=1.58.0,<2.0.0)",
     "easyocr (>=1.7.2,<2.0.0)",
-    "opencv-python-headless (>=4.13.0.92,<5.0.0.0)"
+    "opencv-python-headless (>=4.13.0.92,<5.0.0.0)",
+    "langchain-xai (>=1.2.2,<2.0.0)"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Add `xai` as a first-class model provider using `langchain-xai` (`ChatXAI`)
- Register `XAI_API_KEY` in `AgentFactory._PROVIDER_KEY_ENV_VARS` for `/model` runtime switching
- Add `langchain-xai ^1.2.2` dependency
- Update docs and example config

## Configuration

```yaml
model:
  provider: xai
  model: grok-4-latest
  api_key: ${XAI_API_KEY}
```

Or switch live: `/model xai:grok-3-mini`

## Test plan

- [ ] 1226 tests passing, ruff clean
- [ ] Gilfoyle workspace configured with `xai:grok-4-latest` — manual smoke test
- [ ] `/model xai:grok-3-mini` runtime switch works