### PR TITLE
fix: config validation, error sanitization, and safe defaults

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -71,6 +71,24 @@ builtins:
 #   notify_shutdown: true   # Notify users when workspace stops
 #   notify_auto_compact: true  # Notify users on auto-compact
 
+# Conversation memory (vector search)
+# Disabled by default — requires embedding API key
+# memory:
+#   enabled: true
+#   embedding:
+#     provider: openai
+#     model: text-embedding-3-small
+#     api_key: ${OPENAI_API_KEY}
+
+# Per-workspace model config (in agent.yaml, not here)
+# Two equivalent formats:
+#   Combined: model: "anthropic:claude-sonnet-4-20250514"
+#   Explicit:
+#     model:
+#       provider: anthropic
+#       model: claude-sonnet-4-20250514
+#       temperature: 0.5
+
 # Per-workspace channel settings (in agent.yaml, not here)
 # channel:
 #   type: telegram

--- a/openpaw/builtins/tools/browser/session.py
+++ b/openpaw/builtins/tools/browser/session.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -629,7 +629,7 @@ class BrowserSession:
 
         try:
             # Generate filename with timestamp
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
             filename = f"screenshot_{timestamp}.png"
             file_path = self.screenshots_dir / filename
 

--- a/openpaw/channels/telegram.py
+++ b/openpaw/channels/telegram.py
@@ -3,7 +3,7 @@
 import logging
 import os
 from collections.abc import Callable, Coroutine
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
@@ -134,7 +134,7 @@ class TelegramChannel(ChannelAdapter):
             user_id=str(self._app.bot.id),
             content=content,
             direction=MessageDirection.OUTBOUND,
-            timestamp=datetime.now(),
+            timestamp=datetime.now(UTC),
         )
 
     async def _send_with_html_fallback(
@@ -272,7 +272,7 @@ class TelegramChannel(ChannelAdapter):
             user_id=str(self._app.bot.id),
             content=f"[Audio: {filename}]",
             direction=MessageDirection.OUTBOUND,
-            timestamp=datetime.now(),
+            timestamp=datetime.now(UTC),
         )
 
     # Telegram file size limit
@@ -381,7 +381,7 @@ class TelegramChannel(ChannelAdapter):
             user_id=str(update.effective_user.id),
             content=update.message.text or "",
             direction=MessageDirection.INBOUND,
-            timestamp=update.message.date or datetime.now(),
+            timestamp=update.message.date or datetime.now(UTC),
             reply_to_id=str(update.message.reply_to_message.message_id) if update.message.reply_to_message else None,
             metadata={
                 "chat_type": update.effective_chat.type,
@@ -513,7 +513,7 @@ class TelegramChannel(ChannelAdapter):
             user_id=str(update.effective_user.id),
             content=update.message.caption or "",
             direction=MessageDirection.INBOUND,
-            timestamp=update.message.date or datetime.now(),
+            timestamp=update.message.date or datetime.now(UTC),
             reply_to_id=str(update.message.reply_to_message.message_id) if update.message.reply_to_message else None,
             metadata={
                 "chat_type": update.effective_chat.type,
@@ -577,7 +577,7 @@ class TelegramChannel(ChannelAdapter):
             user_id=str(update.effective_user.id),
             content=update.message.caption or "",
             direction=MessageDirection.INBOUND,
-            timestamp=update.message.date or datetime.now(),
+            timestamp=update.message.date or datetime.now(UTC),
             reply_to_id=str(update.message.reply_to_message.message_id) if update.message.reply_to_message else None,
             metadata={
                 "chat_type": update.effective_chat.type,
@@ -641,7 +641,7 @@ class TelegramChannel(ChannelAdapter):
             user_id=str(update.effective_user.id),
             content="",  # Will be filled by Whisper processor
             direction=MessageDirection.INBOUND,
-            timestamp=update.message.date or datetime.now(),
+            timestamp=update.message.date or datetime.now(UTC),
             reply_to_id=str(update.message.reply_to_message.message_id) if update.message.reply_to_message else None,
             metadata={
                 "chat_type": update.effective_chat.type,

--- a/openpaw/cli.py
+++ b/openpaw/cli.py
@@ -4,7 +4,10 @@ import argparse
 import asyncio
 import logging
 import signal
+import sys
 from pathlib import Path
+
+import yaml
 
 from openpaw.core.config import load_config
 from openpaw.core.logging import setup_logging
@@ -103,7 +106,22 @@ async def main() -> None:
 
 def run() -> None:
     """Entry point for poetry scripts."""
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except yaml.YAMLError as e:
+        print(f"Invalid YAML in config: {e}", file=sys.stderr)
+        sys.exit(1)
+    except ValueError as e:
+        print(f"Configuration error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Startup failed: {e}\nUse -v for verbose logging.", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/openpaw/core/config/__init__.py
+++ b/openpaw/core/config/__init__.py
@@ -7,6 +7,7 @@ All models and functions are re-exported at the package level for backward compa
 # Import all models
 # Import loading utilities
 from openpaw.core.config.loader import (
+    check_unexpanded_vars,
     expand_env_vars,
     expand_env_vars_recursive,
     load_config,
@@ -56,6 +57,7 @@ __all__ = [
     "WorkspaceQueueConfig",
     "WorkspaceToolsConfig",
     # Loaders
+    "check_unexpanded_vars",
     "expand_env_vars",
     "expand_env_vars_recursive",
     "load_config",

--- a/openpaw/core/utils.py
+++ b/openpaw/core/utils.py
@@ -137,3 +137,22 @@ def resolve_user_name(
         return str(username)
 
     return None
+
+
+def sanitize_error_for_user(error: Exception) -> str:
+    """Convert an exception to a user-safe error message.
+
+    Maps known exception types to friendly messages. Prevents internal
+    details (tracebacks, file paths, credentials) from leaking to users.
+
+    Args:
+        error: The caught exception.
+
+    Returns:
+        A user-friendly error message string.
+    """
+    if isinstance(error, TimeoutError):
+        return "The request timed out. Please try again."
+    if isinstance(error, ConnectionError):
+        return "A connection error occurred. Please try again shortly."
+    return "Something went wrong processing your message. Please try again."

--- a/openpaw/model/message.py
+++ b/openpaw/model/message.py
@@ -1,7 +1,7 @@
 """Domain models for messaging."""
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
@@ -49,7 +49,7 @@ class Message:
     user_id: str
     content: str
     direction: MessageDirection = MessageDirection.INBOUND
-    timestamp: datetime = field(default_factory=datetime.now)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
     reply_to_id: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
     attachments: list[Attachment] = field(default_factory=list)

--- a/openpaw/runtime/scheduling/loader.py
+++ b/openpaw/runtime/scheduling/loader.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import yaml
 
-from openpaw.core.config import expand_env_vars_recursive
+from openpaw.core.config import check_unexpanded_vars, expand_env_vars_recursive
 from openpaw.core.config.models import CronDefinition
 
 
@@ -42,6 +42,7 @@ class CronLoader:
                     raw_data: dict[str, Any] = yaml.safe_load(f) or {}
 
                 expanded_data = expand_env_vars_recursive(raw_data)
+                check_unexpanded_vars(expanded_data, source=f"crons/{cron_file.name}")
 
                 cron_def = CronDefinition(**expanded_data)
                 cron_definitions.append(cron_def)
@@ -72,5 +73,6 @@ class CronLoader:
             raw_data: dict[str, Any] = yaml.safe_load(f) or {}
 
         expanded_data = expand_env_vars_recursive(raw_data)
+        check_unexpanded_vars(expanded_data, source=f"crons/{name}")
 
         return CronDefinition(**expanded_data)

--- a/openpaw/workspace/loader.py
+++ b/openpaw/workspace/loader.py
@@ -114,10 +114,11 @@ class WorkspaceLoader:
             data = yaml.safe_load(f) or {}
 
         # Import expand_env_vars_recursive at runtime to avoid circular imports
-        from openpaw.core.config import WorkspaceConfig, expand_env_vars_recursive
+        from openpaw.core.config import WorkspaceConfig, check_unexpanded_vars, expand_env_vars_recursive
 
         # Apply environment variable substitution
         data = expand_env_vars_recursive(data)
+        check_unexpanded_vars(data, source=f"{workspace_path.name}/agent.yaml")
 
         return WorkspaceConfig(**data)
 
@@ -135,7 +136,7 @@ class WorkspaceLoader:
             return []
 
         # Import at runtime to avoid circular import
-        from openpaw.core.config import expand_env_vars_recursive
+        from openpaw.core.config import check_unexpanded_vars, expand_env_vars_recursive
         from openpaw.core.config.models import CronDefinition
 
         cron_definitions = []
@@ -148,6 +149,7 @@ class WorkspaceLoader:
 
                 # Apply environment variable substitution
                 data = expand_env_vars_recursive(data)
+                check_unexpanded_vars(data, source=f"{workspace_path.name}/crons/{cron_file.name}")
 
                 cron_definitions.append(CronDefinition(**data))
             except Exception as e:

--- a/openpaw/workspace/message_processor.py
+++ b/openpaw/workspace/message_processor.py
@@ -16,7 +16,7 @@ from openpaw.core.prompts.system_events import (
     INTERRUPT_NOTIFICATION,
     TOOL_DENIED_TEMPLATE,
 )
-from openpaw.core.utils import resolve_user_name
+from openpaw.core.utils import resolve_user_name, sanitize_error_for_user
 from openpaw.model.message import Message
 from openpaw.runtime.approval import ApprovalGateManager
 from openpaw.runtime.queue.lane import QueueMode
@@ -341,7 +341,7 @@ class MessageProcessor:
             except Exception as e:
                 self._logger.error(f"Error processing messages for {session_key}: {e}", exc_info=True)
                 if channel:
-                    await channel.send_message(session_key, f"Error: {e}")
+                    await channel.send_message(session_key, sanitize_error_for_user(e))
                 break  # Don't continue followup chain on error
 
             finally:

--- a/tests/test_check_unexpanded_vars.py
+++ b/tests/test_check_unexpanded_vars.py
@@ -1,0 +1,84 @@
+"""Tests for check_unexpanded_vars validation."""
+
+import pytest
+
+from openpaw.core.config.loader import check_unexpanded_vars
+
+
+class TestCheckUnexpandedVars:
+    """Tests for unresolved ${VAR} pattern detection."""
+
+    def test_no_vars_passes(self):
+        """Fully expanded config raises nothing."""
+        data = {"key": "value", "nested": {"inner": "resolved"}}
+        check_unexpanded_vars(data, source="test.yaml")
+
+    def test_simple_string_passes(self):
+        """Plain strings with no ${} patterns pass."""
+        check_unexpanded_vars("just a string", source="test.yaml")
+
+    def test_unresolved_var_raises(self):
+        """Single unresolved ${VAR} raises ValueError."""
+        data = {"api_key": "${MISSING_KEY}"}
+        with pytest.raises(ValueError, match="MISSING_KEY"):
+            check_unexpanded_vars(data, source="test.yaml")
+
+    def test_source_label_in_error(self):
+        """Error message includes the source label."""
+        data = {"key": "${MISSING}"}
+        with pytest.raises(ValueError, match="config.yaml"):
+            check_unexpanded_vars(data, source="config.yaml")
+
+    def test_nested_dict_detection(self):
+        """Unresolved var in nested dict is detected."""
+        data = {"outer": {"inner": {"deep": "${DEEP_VAR}"}}}
+        with pytest.raises(ValueError, match="DEEP_VAR"):
+            check_unexpanded_vars(data, source="test.yaml")
+
+    def test_list_detection(self):
+        """Unresolved var in list is detected."""
+        data = {"items": ["ok", "${MISSING_ITEM}"]}
+        with pytest.raises(ValueError, match="MISSING_ITEM"):
+            check_unexpanded_vars(data, source="test.yaml")
+
+    def test_multiple_unresolved_vars(self):
+        """Multiple unresolved vars are all reported."""
+        data = {"a": "${VAR_A}", "b": "${VAR_B}"}
+        with pytest.raises(ValueError, match="VAR_A") as exc_info:
+            check_unexpanded_vars(data, source="test.yaml")
+        assert "VAR_B" in str(exc_info.value)
+
+    def test_none_value_passes(self):
+        """None values do not cause errors."""
+        data = {"key": None}
+        check_unexpanded_vars(data, source="test.yaml")
+
+    def test_numeric_value_passes(self):
+        """Numeric values do not cause errors."""
+        data = {"port": 8080, "ratio": 0.5}
+        check_unexpanded_vars(data, source="test.yaml")
+
+    def test_bool_value_passes(self):
+        """Boolean values do not cause errors."""
+        data = {"enabled": True}
+        check_unexpanded_vars(data, source="test.yaml")
+
+    def test_empty_dict_passes(self):
+        """Empty dict raises nothing."""
+        check_unexpanded_vars({}, source="test.yaml")
+
+    def test_empty_list_passes(self):
+        """Empty list raises nothing."""
+        check_unexpanded_vars([], source="test.yaml")
+
+    def test_mixed_resolved_and_unresolved(self):
+        """Only unresolved vars are reported, resolved ones pass."""
+        data = {"good": "resolved_value", "bad": "${UNSET_VAR}"}
+        with pytest.raises(ValueError, match="UNSET_VAR"):
+            check_unexpanded_vars(data, source="test.yaml")
+
+    def test_partial_expansion_detected(self):
+        """Partially expanded string like 'prefix_${VAR}_suffix' is caught."""
+        data = {"url": "https://api.example.com/${API_VERSION}/endpoint"}
+        with pytest.raises(ValueError, match="API_VERSION"):
+            check_unexpanded_vars(data, source="test.yaml")

--- a/tests/test_cli_error_handling.py
+++ b/tests/test_cli_error_handling.py
@@ -1,0 +1,59 @@
+"""Tests for CLI error handling in run() entry point."""
+
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from openpaw.cli import run
+
+
+class TestCliErrorHandling:
+    """Tests for clean error reporting in the CLI entry point."""
+
+    def test_keyboard_interrupt_exits_cleanly(self):
+        """KeyboardInterrupt exits without traceback."""
+        with patch("openpaw.cli.asyncio.run", side_effect=KeyboardInterrupt):
+            # Should not raise
+            run()
+
+    def test_file_not_found_prints_error(self, capsys):
+        """FileNotFoundError prints clean message and exits 1."""
+        with patch("openpaw.cli.asyncio.run", side_effect=FileNotFoundError("Config file not found: config.yaml")):
+            with pytest.raises(SystemExit) as exc_info:
+                run()
+            assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Config file not found" in captured.err
+
+    def test_yaml_error_prints_message(self, capsys):
+        """yaml.YAMLError prints clean message and exits 1."""
+        with patch("openpaw.cli.asyncio.run", side_effect=yaml.YAMLError("bad yaml")):
+            with pytest.raises(SystemExit) as exc_info:
+                run()
+            assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Invalid YAML" in captured.err
+
+    def test_value_error_prints_config_error(self, capsys):
+        """ValueError (e.g., from env var validation) prints config error and exits 1."""
+        with patch(
+            "openpaw.cli.asyncio.run",
+            side_effect=ValueError("Unresolved environment variable(s) in config.yaml: ${MISSING_KEY}"),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                run()
+            assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Configuration error" in captured.err
+        assert "MISSING_KEY" in captured.err
+
+    def test_generic_exception_prints_startup_failed(self, capsys):
+        """Unknown exceptions print generic message with -v hint."""
+        with patch("openpaw.cli.asyncio.run", side_effect=RuntimeError("something broke")):
+            with pytest.raises(SystemExit) as exc_info:
+                run()
+            assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Startup failed" in captured.err
+        assert "-v" in captured.err

--- a/tests/test_memory_search_availability.py
+++ b/tests/test_memory_search_availability.py
@@ -5,7 +5,7 @@ the vector store only initialized when memory.enabled=True. Agents saw a broken
 tool when the vector store was not available.
 
 Changes tested:
-- MemoryConfig.enabled defaults to True
+- MemoryConfig.enabled defaults to False
 - AgentFactory.remove_builtin_tools() filters tools by LangChain name
 - AgentFactory.remove_enabled_builtin() removes name from enabled list
 - WorkspaceRunner._connect_memory_search_tool() removes broken tool when
@@ -72,10 +72,10 @@ def _make_agent_factory(
 class TestMemoryConfigDefaults:
     """MemoryConfig default value tests."""
 
-    def test_enabled_defaults_to_true(self):
-        """MemoryConfig with no args should have enabled=True."""
+    def test_enabled_defaults_to_false(self):
+        """MemoryConfig with no args should have enabled=False."""
         config = MemoryConfig()
-        assert config.enabled is True
+        assert config.enabled is False
 
     def test_enabled_can_be_set_to_false(self):
         """MemoryConfig(enabled=False) should work."""

--- a/tests/test_model_config_normalization.py
+++ b/tests/test_model_config_normalization.py
@@ -1,0 +1,65 @@
+"""Tests for WorkspaceModelConfig provider:model auto-split."""
+
+from openpaw.core.config.models import WorkspaceModelConfig
+
+
+class TestWorkspaceModelConfigNormalization:
+    """Tests for the model_validator that splits combined model strings."""
+
+    def test_combined_string_splits(self):
+        """'provider:model' string is split into separate fields."""
+        config = WorkspaceModelConfig(model="anthropic:claude-sonnet-4-20250514")
+        assert config.provider == "anthropic"
+        assert config.model == "claude-sonnet-4-20250514"
+
+    def test_separate_fields_preserved(self):
+        """Explicit provider + model fields are not modified."""
+        config = WorkspaceModelConfig(provider="openai", model="gpt-4o")
+        assert config.provider == "openai"
+        assert config.model == "gpt-4o"
+
+    def test_no_split_when_provider_set(self):
+        """Combined string is NOT split when provider is already set."""
+        config = WorkspaceModelConfig(provider="custom", model="custom:special-model")
+        assert config.provider == "custom"
+        assert config.model == "custom:special-model"
+
+    def test_bedrock_colon_in_model_handled(self):
+        """Bedrock IDs like 'us.anthropic.claude-haiku:v1:0' split correctly on first colon."""
+        config = WorkspaceModelConfig(model="bedrock_converse:us.anthropic.claude-haiku:v1:0")
+        assert config.provider == "bedrock_converse"
+        assert config.model == "us.anthropic.claude-haiku:v1:0"
+
+    def test_no_colon_no_split(self):
+        """Model without colon remains as-is (no provider inferred)."""
+        config = WorkspaceModelConfig(model="gpt-4o")
+        assert config.provider is None
+        assert config.model == "gpt-4o"
+
+    def test_empty_model_no_error(self):
+        """Empty/None model does not error."""
+        config = WorkspaceModelConfig()
+        assert config.provider is None
+        assert config.model is None
+
+    def test_xai_combined_string(self):
+        """xAI provider splits correctly."""
+        config = WorkspaceModelConfig(model="xai:grok-3-mini")
+        assert config.provider == "xai"
+        assert config.model == "grok-3-mini"
+
+    def test_extra_kwargs_preserved(self):
+        """Extra kwargs (like base_url) are preserved through normalization."""
+        config = WorkspaceModelConfig(
+            model="openai:kimi-k2.5",
+            base_url="https://api.moonshot.ai/v1",
+        )
+        assert config.provider == "openai"
+        assert config.model == "kimi-k2.5"
+        assert config.base_url == "https://api.moonshot.ai/v1"
+
+    def test_empty_string_provider_not_split(self):
+        """Empty string provider should not trigger auto-split."""
+        config = WorkspaceModelConfig(provider="", model="provider:model-id")
+        assert config.provider == ""
+        assert config.model == "provider:model-id"

--- a/tests/test_sanitize_error.py
+++ b/tests/test_sanitize_error.py
@@ -1,0 +1,46 @@
+"""Tests for sanitize_error_for_user utility."""
+
+from openpaw.core.utils import sanitize_error_for_user
+
+
+class TestSanitizeErrorForUser:
+    """Tests for user-facing error message sanitization."""
+
+    def test_timeout_error(self):
+        """TimeoutError maps to timeout message."""
+        msg = sanitize_error_for_user(TimeoutError("operation timed out after 30s"))
+        assert msg == "The request timed out. Please try again."
+
+    def test_connection_error(self):
+        """ConnectionError maps to connection message."""
+        msg = sanitize_error_for_user(ConnectionError("refused"))
+        assert msg == "A connection error occurred. Please try again shortly."
+
+    def test_generic_exception(self):
+        """Unknown exceptions get generic message."""
+        msg = sanitize_error_for_user(RuntimeError("NullPointerException at /internal/path"))
+        assert msg == "Something went wrong processing your message. Please try again."
+
+    def test_value_error_is_generic(self):
+        """ValueError should not leak internal details."""
+        msg = sanitize_error_for_user(ValueError("invalid config at /etc/secrets"))
+        assert msg == "Something went wrong processing your message. Please try again."
+        assert "/etc/secrets" not in msg
+
+    def test_no_internal_details_leak(self):
+        """Error message should not contain the original exception text."""
+        original = "SQLSTATE[42000]: Syntax error at line 42 in /app/db.py"
+        msg = sanitize_error_for_user(Exception(original))
+        assert original not in msg
+        assert "SQLSTATE" not in msg
+
+    def test_async_timeout_error(self):
+        """asyncio.TimeoutError (subclass of TimeoutError) maps correctly."""
+        import asyncio
+        msg = sanitize_error_for_user(asyncio.TimeoutError())
+        assert msg == "The request timed out. Please try again."
+
+    def test_os_error_subclass_connection(self):
+        """ConnectionRefusedError (subclass of ConnectionError) maps correctly."""
+        msg = sanitize_error_for_user(ConnectionRefusedError("refused"))
+        assert msg == "A connection error occurred. Please try again shortly."


### PR DESCRIPTION
## Summary

Closes #9. Addresses 6 user-facing config/error handling gaps identified in audit.

- **Safe memory default**: `memory.enabled` defaults to `false` (requires embedding API key to opt in)
- **Timezone-aware timestamps**: All `datetime.now()` calls replaced with `datetime.now(UTC)` across model, channel, and browser layers
- **Fail-fast env vars**: Unresolved `${VAR}` patterns now raise `ValueError` at startup naming the missing variable(s) and source file
- **Error sanitization**: Agent errors sent to users via channels are mapped to friendly messages — internal details never leak
- **Model config normalization**: `WorkspaceModelConfig` auto-splits `"provider:model_id"` strings so both formats work interchangeably
- **CLI error handling**: `run()` entry point wraps startup with structured try-except producing clean stderr messages instead of tracebacks

## Test plan

- [ ] `poetry run pytest` — 1289 tests pass (35 new)
- [ ] `poetry run ruff check openpaw/` — clean
- [ ] Manual: start with unresolved `${MISSING}` in config → clear error message, no traceback
- [ ] Manual: start with missing config file → `Error: Config file not found: ...`
- [ ] Manual: start with bad YAML → `Invalid YAML in config: ...`
- [ ] Verify existing workspaces start without issue (env vars must be set)