### PR TITLE
feat: openpaw init and openpaw list CLI commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Install dependencies
 poetry install
 
+# Scaffold a new workspace
+poetry run openpaw init <workspace_name>
+poetry run openpaw init my_agent --model anthropic:claude-sonnet-4-20250514 --channel telegram
+
+# List available workspaces
+poetry run openpaw list
+poetry run openpaw list --path /custom/workspaces/dir
+
 # Run single workspace
 poetry run openpaw -c config.yaml -w <workspace_name>
 poetry run openpaw -c config.yaml -w gilfoyle -v  # verbose

--- a/README.md
+++ b/README.md
@@ -1,258 +1,117 @@
 # OpenPaw
 
-**A LangGraph-native framework for building autonomous AI personal assistants.**
+Multi-channel AI agent framework built on [LangGraph](https://langchain-ai.github.io/langgraph/).
 
-> **Note:** This is a hobby project, mostly built for personal use. It was developed collaboratively with a Claude Code AI engineering team. Contributions and ideas welcome, but expect rough edges.
+## Features
 
-OpenPaw gives your AI agents real agency -- they can spawn sub-agents, browse the web, schedule their own follow-ups, process documents, manage persistent tasks, and ask for human approval before taking dangerous actions. Built on [LangGraph](https://langchain-ai.github.io/langgraph/) and [LangChain](https://www.langchain.com/), it plays natively with the `@tool` ecosystem you already know.
-
-## What is OpenPaw?
-
-Each agent runs in an isolated workspace with its own personality, communication channel, scheduled tasks, filesystem, and tool loadout. Run one assistant or a dozen -- they stay completely independent.
-
-```mermaid
-graph TD
-    O[OpenPawOrchestrator] --> W1[WorkspaceRunner: agent1]
-    O --> W2[WorkspaceRunner: agent2]
-    O --> W3[WorkspaceRunner: agent3]
-
-    W1 --> C1[Channel<br/>Telegram]
-    W1 --> Q1[QueueManager<br/>Lane FIFO]
-    W1 --> A1[AgentRunner<br/>LangGraph ReAct]
-    W1 --> S1[Schedulers<br/>Cron + Heartbeat]
-
-    style O fill:#4a9eff,color:#fff
-    style W1 fill:#2d2d2d,color:#fff
-    style W2 fill:#2d2d2d,color:#fff
-    style W3 fill:#2d2d2d,color:#fff
-```
-
-## Key Features
-
-### Autonomy
-- **Sub-agent spawning** — Agents spawn concurrent background workers for parallel tasks
-- **Self-scheduling** — Agents create their own cron jobs that persist across restarts
-- **Self-continuation** — Multi-step autonomous workflows via followup tool with depth limiting
-- **Task tracking** — Persistent TASKS.yaml for long-running work across sessions
-
-### Intelligence
-- **Browser automation** — Playwright-based web interaction with accessibility tree navigation
-- **Web search** — Brave Search API integration
-- **Document processing** — Automatic PDF/DOCX/PPTX to markdown with OCR ([Docling](https://github.com/docling-project/docling))
-- **Voice transcription** — Audio message transcription via [Whisper](https://openai.com/index/whisper/)
-
-### Safety
-- **Approval gates** — Human-in-the-loop authorization for dangerous operations
-- **Sandboxed filesystem** — Path traversal protection, `.openpaw/` isolation
-- **Domain security** — Per-workspace allowlists/blocklists for web browsing
-
-### Operations
-- **Conversation persistence** — Durable conversations that survive restarts (AsyncSqliteSaver)
-- **Token tracking** — Per-invocation metrics with today/session aggregation
-- **Slash commands** — `/new`, `/compact`, `/status`, `/queue`, `/help`
-- **Timezone awareness** — Per-workspace IANA timezone for scheduling and display
-- **Multi-model support** — Anthropic, OpenAI, AWS Bedrock, or any OpenAI-compatible API
-
-## Message Flow
-
-```mermaid
-sequenceDiagram
-    participant U as User
-    participant C as Channel
-    participant Q as Queue
-    participant M as Middleware
-    participant A as Agent
-    participant T as Tools
-
-    U->>C: Message
-    C->>Q: Enqueue
-    Q->>M: Dequeue + debounce
-    M->>A: Process
-    A->>T: Tool calls
-    T-->>A: Results
-    A-->>C: Response
-    C-->>U: Reply
-```
+- **Isolated workspaces** -- Each agent runs with its own personality, channel, tools, and conversation history
+- **Multi-provider LLM support** -- Anthropic, OpenAI, AWS Bedrock, xAI, and any OpenAI-compatible API
+- **Telegram integration** -- Communicate with agents via Telegram bots with allowlist-based access control
+- **Scheduled tasks and heartbeats** -- Cron-based scheduling and proactive agent check-ins
+- **Sandboxed filesystem** -- Agents read and write files within their workspace with path traversal protection
+- **Sub-agent spawning** -- Background workers for concurrent task execution with lifecycle management
+- **Browser automation** -- Playwright-based web interaction using accessibility tree navigation
 
 ## Quick Start
 
-### Prerequisites
-
-- Python 3.11+
-- [Poetry](https://python-poetry.org/) 2.0+
-- A Telegram bot token ([create one via BotFather](https://core.telegram.org/bots#botfather))
-- At least one model provider credential (Anthropic, OpenAI, or AWS Bedrock)
-
-### Installation
+### 1. Install
 
 ```bash
-# Clone the repository
-git clone https://github.com/jsosoka/OpenPaw.git
-cd OpenPaw
-
-# Install core dependencies (includes Docling + Playwright)
+git clone https://github.com/johnsosoka/openpaw.git
+cd openpaw
 poetry install
-
-# Install Playwright browser
-poetry run playwright install chromium
-
-# Optional extras for additional builtins
-poetry install -E voice          # Whisper transcription + ElevenLabs TTS
-poetry install -E web            # Brave Search
-poetry install -E system         # SSH remote execution
-poetry install -E memory         # Semantic memory search (sqlite-vec)
-poetry install -E all-builtins   # Everything above
 ```
 
-### Configuration
+### 2. Scaffold a workspace
 
-1. Copy the example configuration:
+```bash
+poetry run openpaw init my_agent \
+  --model anthropic:claude-sonnet-4-20250514 \
+  --channel telegram
+```
+
+### 3. Configure
 
 ```bash
 cp config.example.yaml config.yaml
 ```
 
-2. Set required environment variables:
+Add your API keys to `agent_workspaces/my_agent/.env`:
 
 ```bash
-# Channel
-export TELEGRAM_BOT_TOKEN="your-telegram-token"
-
-# Model provider (choose one or more)
-export ANTHROPIC_API_KEY="your-key"
-export OPENAI_API_KEY="your-openai-key"  # Also used by Whisper
-# Or AWS Bedrock
-export AWS_ACCESS_KEY_ID="your-access-key"
-export AWS_SECRET_ACCESS_KEY="your-secret-key"
-export AWS_REGION="us-east-1"
-
-# Optional builtin API keys
-export BRAVE_API_KEY="your-brave-key"
-export ELEVENLABS_API_KEY="your-key"
+ANTHROPIC_API_KEY=your-key-here
+TELEGRAM_BOT_TOKEN=your-token-here
 ```
 
-3. Edit `config.yaml` with your preferences. See `config.example.yaml` for all options.
-
-### Create Your First Workspace
-
-Copy one of the example workspaces to get started:
+### 4. Run
 
 ```bash
-# Minimal assistant workspace
-cp -r example_agent_workspaces/assistant agent_workspaces/my-agent
-
-# Advanced research assistant with custom tools
-cp -r example_agent_workspaces/research_assistant_krieger agent_workspaces/my-researcher
+poetry run openpaw -c config.yaml -w my_agent
 ```
 
-Each workspace requires four markdown files that define the agent's identity:
+## CLI Commands
 
-| File | Purpose |
-|------|---------|
-| `AGENT.md` | Capabilities and behavior guidelines |
-| `USER.md` | User context and preferences |
-| `SOUL.md` | Core personality and values |
-| `HEARTBEAT.md` | Scratchpad for proactive check-ins (can start empty) |
+| Command | Description |
+|---------|-------------|
+| `openpaw init <name>` | Scaffold a new agent workspace |
+| `openpaw init <name> --model <provider:model>` | Scaffold with a pre-configured model |
+| `openpaw init <name> --channel telegram` | Scaffold with Telegram channel pre-configured |
+| `openpaw list` | List available workspaces |
+| `openpaw -c config.yaml -w <name>` | Run a single workspace |
+| `openpaw -c config.yaml -w name1,name2` | Run multiple workspaces |
+| `openpaw -c config.yaml --all` | Run all discovered workspaces |
+| `openpaw -c config.yaml -w <name> -v` | Run with verbose logging |
 
-Optional workspace files include `agent.yaml` (per-workspace config), `.env` (secrets), `tools/` (custom LangChain tools), and `crons/` (scheduled tasks).
+All commands should be prefixed with `poetry run` when running from the project directory.
 
-### Run
+## Workspace Structure
 
-```bash
-# Single workspace
-poetry run openpaw -c config.yaml -w my-agent
+Each workspace lives under `agent_workspaces/<name>/` and requires four markdown files that define the agent's identity:
 
-# Multiple workspaces
-poetry run openpaw -c config.yaml -w agent1,agent2
-
-# All workspaces
-poetry run openpaw -c config.yaml --all
-
-# Verbose logging
-poetry run openpaw -c config.yaml -w my-agent -v
+```
+agent_workspaces/my_agent/
+├── AGENT.md          # Capabilities and behavior guidelines
+├── USER.md           # User context and preferences
+├── SOUL.md           # Core personality and values
+├── HEARTBEAT.md      # Session state scratchpad (can start empty)
+├── agent.yaml        # Per-workspace configuration (optional)
+├── .env              # API keys and secrets (optional)
+├── tools/            # Custom LangChain @tool functions (optional)
+└── crons/            # Scheduled task definitions (optional)
 ```
 
-## Example Workspaces
+The `openpaw init` command generates all required files with starter templates. Customize the markdown files to shape your agent's personality and purpose. Configure model, channel, and queue behavior in `agent.yaml`.
 
-**`example_agent_workspaces/assistant/`** — Minimal workspace demonstrating the core personality system (AGENT.md, USER.md, SOUL.md, HEARTBEAT.md). Good starting point for building your own agent.
+## In-Chat Commands
 
-**`example_agent_workspaces/research_assistant_krieger/`** — Advanced workspace showcasing custom tools integration:
-- GPT Researcher for web research reports
-- PDF generation for report output
-- Multi-model vision analysis
-- Workspace-specific `.env` and tool dependencies
+Once running, agents respond to framework commands in Telegram:
 
-## Builtins
-
-Tools and processors conditionally loaded based on available packages and API keys:
-
-| Builtin | Type | Description |
-|---------|------|-------------|
-| `browser` | Tool | Web automation via Playwright with accessibility tree |
-| `brave_search` | Tool | Web search via Brave API |
-| `spawn` | Tool | Sub-agent spawning for concurrent background tasks |
-| `cron` | Tool | Agent self-scheduling (one-time and recurring) |
-| `task_tracker` | Tool | Persistent task management via TASKS.yaml |
-| `send_message` | Tool | Mid-execution user messaging |
-| `send_file` | Tool | Send workspace files to users |
-| `followup` | Tool | Self-continuation for multi-step workflows |
-| `memory_search` | Tool | Semantic search over past conversations |
-| `shell` | Tool | Local shell command execution |
-| `ssh` | Tool | Remote SSH execution |
-| `elevenlabs` | Tool | Text-to-speech voice responses |
-| `file_persistence` | Processor | Universal file upload handling with date partitions |
-| `docling` | Processor | PDF/DOCX/PPTX to markdown with OCR |
-| `whisper` | Processor | Audio/voice transcription |
-| `timestamp` | Processor | Message timestamp injection |
-
-See [Builtins Documentation](docs/builtins.md) for configuration details and adding custom builtins.
-
-## Custom Tools
-
-Drop any LangChain `@tool` into the `tools/` directory:
-
-```python
-# agent_workspaces/my-agent/tools/weather.py
-from langchain_core.tools import tool
-
-@tool
-def get_weather(city: str) -> str:
-    """Get current weather for a city."""
-    # Your implementation here
-    return fetch_weather(city)
-```
-
-Add tool-specific dependencies to `tools/requirements.txt` — they auto-install at startup. See [Workspaces Documentation](docs/workspaces.md) for details.
+| Command | Description |
+|---------|-------------|
+| `/help` | List available commands |
+| `/status` | Show model, context usage, tasks, and token usage |
+| `/new` | Archive conversation and start fresh |
+| `/compact` | Summarize, archive, and continue with summary |
+| `/model <provider:model>` | Switch LLM model at runtime |
 
 ## Documentation
 
-- [Getting Started](docs/getting-started.md) — Installation and first workspace setup
-- [Configuration](docs/configuration.md) — Global and workspace configuration reference
-- [Workspaces](docs/workspaces.md) — Workspace structure and personality files
-- [Channels](docs/channels.md) — Channel system and Telegram setup
-- [Queue System](docs/queue-system.md) — Queue modes, lanes, and concurrency
-- [Cron Scheduler](docs/cron-scheduler.md) — Scheduled task configuration
-- [Builtins](docs/builtins.md) — Available tools, processors, and adding custom ones
-- [Architecture](docs/architecture.md) — System design and component interactions
+- [Getting Started](docs/getting-started.md) -- Installation, first workspace, and troubleshooting
+- [Configuration](docs/configuration.md) -- Global and per-workspace configuration reference
+- [Workspaces](docs/workspaces.md) -- Workspace structure, custom tools, and cron jobs
+- [Architecture](docs/architecture.md) -- System design and component interactions
+- [Channels](docs/channels.md) -- Channel system and access control
+- [Queue System](docs/queue-system.md) -- Queue modes and message handling
+- [Cron Scheduler](docs/cron-scheduler.md) -- Scheduled tasks and heartbeat system
+- [Built-ins](docs/builtins.md) -- Web search, browser automation, voice, sub-agents, and more
 
-## Development
+## Prerequisites
 
-```bash
-# Run the full test suite (1,000+ tests)
-poetry run pytest
-
-# Lint
-poetry run ruff check openpaw/
-poetry run ruff check openpaw/ --fix
-
-# Type check
-poetry run mypy openpaw/
-```
+- Python 3.11+
+- [Poetry 2.0+](https://python-poetry.org/docs/#installation)
+- A Telegram bot token ([via BotFather](https://core.telegram.org/bots#botfather))
+- At least one model provider API key (Anthropic, OpenAI, or AWS credentials for Bedrock)
 
 ## License
 
 [PolyForm Noncommercial 1.0.0](LICENSE)
-
-## Credits
-
-OpenPaw draws architectural inspiration from [OpenClaw](https://github.com/openclaw)'s command queue and channel patterns. Built on [LangGraph](https://langchain-ai.github.io/langgraph/) and [LangChain](https://www.langchain.com/). Developed with [Claude Code](https://claude.ai/code).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,120 +122,77 @@ See [configuration.md](configuration.md) for detailed reference.
 
 ## Creating Your First Workspace
 
-Each workspace represents an isolated agent with its own personality, tools, and conversation state.
+Each workspace represents an isolated agent with its own personality, tools, and conversation state. The fastest way to create one is with `openpaw init`:
 
-### 1. Create Workspace Directory
+### 1. Scaffold a Workspace
 
 ```bash
-mkdir -p agent_workspaces/my-agent
-cd agent_workspaces/my-agent
+# Basic scaffold
+poetry run openpaw init my_agent
+
+# With model and channel pre-configured
+poetry run openpaw init my_agent --model anthropic:claude-sonnet-4-20250514 --channel telegram
 ```
 
-### 2. Create Required Markdown Files
+This creates `agent_workspaces/my_agent/` with all required files:
 
-Every workspace needs four markdown files:
+| File | Purpose |
+|------|---------|
+| `AGENT.md` | Capabilities, behavior guidelines |
+| `USER.md` | User context and preferences |
+| `SOUL.md` | Core personality and values |
+| `HEARTBEAT.md` | Session state scratchpad |
+| `agent.yaml` | Model, channel, and queue config |
+| `.env` | API key placeholders |
 
-**AGENT.md** - Capabilities and behavior guidelines
+Each file includes TODO markers to guide customization.
 
-```markdown
-# Agent Profile
+### 2. Configure Your Workspace
 
-You are a helpful AI assistant with the following capabilities:
-- Answering questions and providing information
-- Managing tasks via the TASKS.yaml system
-- Processing uploaded documents (PDF, DOCX, PPTX)
-- Browsing the web when needed
-- Scheduling your own follow-up actions
-
-## Communication Style
-
-Be concise and friendly. Use clear, straightforward language.
-When working on complex tasks, use send_message to keep the user informed of progress.
-```
-
-**USER.md** - User context and preferences
-
-```markdown
-# User Profile
-
-## Name
-John
-
-## Preferences
-- Prefers brief, actionable responses
-- Works in Pacific Time (America/Los_Angeles)
-- Values transparency and proactive updates
-
-## Context
-Primary use cases include research, document analysis, and task management.
-```
-
-**SOUL.md** - Core personality and values
-
-```markdown
-# Core Values
-
-Be helpful, honest, and respectful.
-Prioritize clarity over cleverness.
-When uncertain, ask for clarification rather than making assumptions.
-
-## Operating Principles
-
-- Break complex tasks into manageable steps
-- Maintain organized workspace files for continuity
-- Use HEARTBEAT.md to track session state and ongoing work
-```
-
-**HEARTBEAT.md** - Current state and session notes
-
-This file is the agent's scratchpad for maintaining context across sessions and heartbeats. It can start empty or with minimal content:
-
-```markdown
-# Current State
-
-No active tasks.
-```
-
-**Note:** The agent can modify HEARTBEAT.md during conversations to track state. This file is also used by the heartbeat system (if enabled) to determine what to check during proactive check-ins.
-
-### 3. Optional: Per-Workspace Configuration
-
-Create `agent.yaml` to override global defaults:
+Edit `agent.yaml` with your model and channel settings. If you used `--model` and `--channel` flags, the relevant sections are already populated:
 
 ```yaml
-name: My Agent
-description: A helpful personal assistant
-timezone: America/Los_Angeles  # IANA timezone identifier (default: UTC)
+name: my_agent
+description: ""
 
 model:
   provider: anthropic
   model: claude-sonnet-4-20250514
   api_key: ${ANTHROPIC_API_KEY}
-  temperature: 0.5
-  max_turns: 50
+  temperature: 0.7
 
 channel:
   type: telegram
   token: ${TELEGRAM_BOT_TOKEN}
-  allowed_users: [123456789]  # Your Telegram user ID (optional, empty = allow all)
-  allowed_groups: []
+  allowed_users: []
 
 queue:
   mode: collect
   debounce_ms: 1000
-
-heartbeat:
-  enabled: false  # Set to true for proactive check-ins
-  interval_minutes: 30
-  active_hours: "09:00-17:00"
-  suppress_ok: true
 ```
 
-**Timezone:** The `timezone` field uses IANA identifiers (e.g., `America/New_York`, `Europe/London`, `Asia/Tokyo`). This controls:
-- Cron schedule timing
-- Heartbeat active hours
-- File upload date partitions
-- Display timestamps in `/status` and conversation archives
+Add your API keys to `.env`:
+
+```bash
+ANTHROPIC_API_KEY=your-key-here
+TELEGRAM_BOT_TOKEN=your-bot-token
+```
+
+**Timezone:** Add a `timezone` field (IANA identifier, e.g., `America/New_York`) to control cron timing, heartbeat hours, and display timestamps. Defaults to UTC.
+
+### 3. Customize Personality
+
+Edit the markdown files to define your agent's identity:
+
+- **AGENT.md** — What the agent can do and how it should behave
+- **USER.md** — Context about the user(s) who will interact with it
+- **SOUL.md** — Core personality, values, and communication style
+- **HEARTBEAT.md** — Can start empty; the agent updates it to track session state
+
+See [workspaces.md](workspaces.md) for detailed examples of each file.
+
+!!! tip "List existing workspaces"
+    Use `poetry run openpaw list` to see all valid workspaces in `agent_workspaces/`.
 
 ### 4. Optional: Custom Tools
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -449,44 +449,40 @@ Agents can read archived conversations to maintain long-term memory across conve
 
 ## Creating a New Workspace
 
-1. **Create directory structure:**
+The fastest way to create a workspace is with the `init` command:
 
 ```bash
-mkdir -p agent_workspaces/my-agent/tools agent_workspaces/my-agent/crons
+# Basic scaffold with TODO markers
+poetry run openpaw init my_agent
+
+# Pre-configure model and channel
+poetry run openpaw init my_agent --model anthropic:claude-sonnet-4-20250514 --channel telegram
+
+# Scaffold in a custom directory
+poetry run openpaw init my_agent --path /path/to/workspaces
 ```
 
-2. **Create required markdown files:**
+This creates the workspace directory with all required files (AGENT.md, USER.md, SOUL.md, HEARTBEAT.md, agent.yaml, .env) pre-populated with templates and TODO markers.
+
+**After scaffolding:**
+
+1. Edit `agent.yaml` with your model and channel settings
+2. Add API keys to `.env`
+3. Customize AGENT.md, USER.md, and SOUL.md to define personality
+4. Optionally add custom tools in `tools/` and cron jobs in `crons/`
+5. Run the workspace:
 
 ```bash
-cd agent_workspaces/my-agent
-touch AGENT.md USER.md SOUL.md HEARTBEAT.md
+poetry run openpaw -c config.yaml -w my_agent
 ```
 
-3. **Define personality:**
-
-Edit each markdown file to define the agent's capabilities, user context, values, and initial state.
-
-4. **Add configuration (optional):**
-
-Create `agent.yaml` if you need to override global settings.
-
-5. **Add custom tools (optional):**
-
-Create Python files in `tools/` with `@tool` decorated functions and a `requirements.txt` for dependencies.
-
-6. **Add cron jobs (optional):**
-
-Create YAML files in `crons/` for scheduled tasks.
-
-7. **Add workspace environment variables (optional):**
-
-Create `.env` for workspace-specific API keys and configuration.
-
-8. **Run the workspace:**
+**List available workspaces:**
 
 ```bash
-poetry run openpaw -c config.yaml -w my-agent
+poetry run openpaw list
 ```
+
+**Name requirements:** Workspace names must be 2-64 characters, start with a lowercase letter, and contain only lowercase letters, digits, hyphens, and underscores (e.g., `my_agent`, `test-bot`, `gilfoyle`).
 
 ## Example Workspaces
 

--- a/openpaw/cli.py
+++ b/openpaw/cli.py
@@ -106,6 +106,13 @@ async def main() -> None:
 
 def run() -> None:
     """Entry point for poetry scripts."""
+    # Early dispatch for init/list commands — no async or heavy imports needed.
+    if len(sys.argv) >= 2 and sys.argv[1] in ("init", "list"):
+        from openpaw.cli_init import dispatch_command
+
+        dispatch_command(sys.argv[1], sys.argv[2:])
+        return
+
     try:
         asyncio.run(main())
     except KeyboardInterrupt:

--- a/openpaw/cli_init.py
+++ b/openpaw/cli_init.py
@@ -1,0 +1,452 @@
+"""CLI commands for workspace scaffolding: `openpaw init` and `openpaw list`."""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Template constants
+# ---------------------------------------------------------------------------
+
+TEMPLATE_AGENT_MD = """\
+# AGENT: {name}
+
+## Role
+
+<!-- TODO: Define this agent's role and responsibilities -->
+
+## Mission
+
+<!-- TODO: What is this agent's core mission? -->
+
+## Guidelines
+
+- Be clear and concise
+- Ask for clarification when unsure
+- Track multi-step work with tasks
+"""
+
+TEMPLATE_USER_MD = """\
+# USER CONTEXT
+
+<!-- TODO: Describe the user(s) who will interact with this agent -->
+
+## Preferences
+
+- Communication style preferences
+- Domain expertise level
+"""
+
+TEMPLATE_SOUL_MD = """\
+# SOUL: {name}
+
+## Identity
+
+<!-- TODO: Define this agent's personality and character -->
+
+## Core Values
+
+- Accuracy over speed
+- Clarity over cleverness
+- Helpfulness without overstepping
+
+## Voice
+
+<!-- TODO: How should this agent communicate? Formal? Casual? Technical? -->
+"""
+
+TEMPLATE_HEARTBEAT_MD = """\
+<!-- Heartbeat scratchpad: notes for proactive check-ins -->
+<!-- Leave empty if heartbeat is not configured -->
+"""
+
+TEMPLATE_ENV = """\
+# API keys for this workspace
+# ANTHROPIC_API_KEY=
+# OPENAI_API_KEY=
+# XAI_API_KEY=
+# BRAVE_API_KEY=
+"""
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_-]*$")
+_NAME_MIN_LEN = 2
+_NAME_MAX_LEN = 64
+
+
+def _validate_workspace_name(name: str) -> None:
+    """Validate that name is a legal workspace identifier.
+
+    Rules:
+    - 2-64 characters
+    - Starts with a lowercase letter
+    - Contains only lowercase letters, digits, hyphens, and underscores
+
+    Args:
+        name: Workspace name candidate.
+
+    Raises:
+        ValueError: If the name does not meet the requirements.
+    """
+    if not name:
+        raise ValueError("Workspace name cannot be empty.")
+
+    if len(name) < _NAME_MIN_LEN:
+        raise ValueError(
+            f"Workspace name '{name}' is too short (minimum {_NAME_MIN_LEN} characters)."
+        )
+
+    if len(name) > _NAME_MAX_LEN:
+        raise ValueError(
+            f"Workspace name '{name}' is too long (maximum {_NAME_MAX_LEN} characters)."
+        )
+
+    if not _NAME_PATTERN.match(name):
+        raise ValueError(
+            f"Workspace name '{name}' is invalid. "
+            "Names must start with a lowercase letter and contain only "
+            "lowercase letters, digits, hyphens (-), and underscores (_)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# agent.yaml generation
+# ---------------------------------------------------------------------------
+
+def _parse_model_string(model: str) -> tuple[str, str]:
+    """Parse a combined model string into (provider, model_id).
+
+    Args:
+        model: Model string, e.g. ``anthropic:claude-sonnet-4-20250514`` or bare ``gpt-4o``.
+
+    Returns:
+        Tuple of (provider, model_id).
+
+    Raises:
+        ValueError: If provider or model_id is empty after splitting.
+    """
+    if ":" in model:
+        provider, _, model_id = model.partition(":")
+    else:
+        provider = "anthropic"
+        model_id = model
+
+    if not provider:
+        raise ValueError(f"Invalid model string '{model}': provider is empty.")
+    if not model_id:
+        raise ValueError(f"Invalid model string '{model}': model ID is empty.")
+    return provider, model_id
+
+
+def _build_agent_yaml(name: str, channel: str | None, model: str | None) -> str:
+    """Build agent.yaml content for a new workspace.
+
+    When --model is provided the model section is uncommented and populated.
+    When --channel is provided the channel section is uncommented with
+    placeholder values.  Both, one, or neither may be supplied.
+
+    Args:
+        name: Workspace name (used in the ``name`` field).
+        channel: Optional channel type string (e.g., ``telegram``).
+        model: Optional combined model string (e.g., ``anthropic:claude-sonnet-4-20250514``).
+
+    Returns:
+        YAML string suitable for writing to ``agent.yaml``.
+    """
+    lines: list[str] = [
+        f"name: {name}",
+        'description: ""',
+        "",
+    ]
+
+    # Model section
+    if model:
+        provider, model_id = _parse_model_string(model)
+        api_key_env = _provider_api_key_env(provider)
+
+        lines += [
+            "model:",
+            f"  provider: {provider}",
+            f"  model: {model_id}",
+        ]
+        if api_key_env:
+            lines.append(f"  api_key: ${{{api_key_env}}}")
+        lines += [
+            "  temperature: 0.7",
+            "",
+        ]
+    else:
+        lines += [
+            "# model:",
+            "#   provider: anthropic",
+            "#   model: claude-sonnet-4-20250514",
+            "#   api_key: ${ANTHROPIC_API_KEY}",
+            "#   temperature: 0.7",
+            "",
+        ]
+
+    # Channel section
+    if channel:
+        if channel == "telegram":
+            lines += [
+                "channel:",
+                f"  type: {channel}",
+                "  token: ${TELEGRAM_BOT_TOKEN}",
+                "  allowed_users: []",
+                "",
+            ]
+        else:
+            lines += [
+                "channel:",
+                f"  type: {channel}",
+                "",
+            ]
+    else:
+        lines += [
+            "# channel:",
+            "#   type: telegram",
+            "#   token: ${TELEGRAM_BOT_TOKEN}",
+            "#   allowed_users: []",
+            "",
+        ]
+
+    # Queue section (always included, valid defaults)
+    lines += [
+        "queue:",
+        "  mode: collect",
+        "  debounce_ms: 1000",
+    ]
+
+    return "\n".join(lines) + "\n"
+
+
+_PROVIDER_API_KEY_ENV: dict[str, str | None] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "xai": "XAI_API_KEY",
+    "bedrock_converse": None,
+    "bedrock": None,
+}
+
+
+def _provider_api_key_env(provider: str) -> str | None:
+    """Map a provider name to its conventional API key environment variable.
+
+    Args:
+        provider: Provider identifier (e.g., ``anthropic``, ``openai``).
+
+    Returns:
+        Environment variable name string, or None for providers that use
+        external credentials (e.g., Bedrock uses AWS IAM, not an api_key).
+    """
+    if provider in _PROVIDER_API_KEY_ENV:
+        return _PROVIDER_API_KEY_ENV[provider]
+    return f"{provider.upper()}_API_KEY"
+
+
+# ---------------------------------------------------------------------------
+# Workspace creation
+# ---------------------------------------------------------------------------
+
+def _create_workspace(
+    workspaces_path: Path,
+    name: str,
+    channel: str | None,
+    model: str | None,
+) -> Path:
+    """Create a new workspace directory with all required template files.
+
+    Args:
+        workspaces_path: Parent directory that contains workspaces.
+        name: Workspace name (used as the directory name and in templates).
+        channel: Optional channel type for agent.yaml.
+        model: Optional model string for agent.yaml.
+
+    Returns:
+        Path to the newly created workspace directory.
+
+    Raises:
+        FileExistsError: If the workspace directory already exists.
+        OSError: If the directory or any file cannot be created.
+    """
+    workspace_path = workspaces_path / name
+
+    if workspace_path.exists():
+        raise FileExistsError(
+            f"Workspace '{name}' already exists at {workspace_path}"
+        )
+
+    workspace_path.mkdir(parents=True, exist_ok=False)
+
+    # Write the four required markdown files, substituting {name} where used.
+    (workspace_path / "AGENT.md").write_text(
+        TEMPLATE_AGENT_MD.format(name=name), encoding="utf-8"
+    )
+    (workspace_path / "USER.md").write_text(TEMPLATE_USER_MD, encoding="utf-8")
+    (workspace_path / "SOUL.md").write_text(
+        TEMPLATE_SOUL_MD.format(name=name), encoding="utf-8"
+    )
+    (workspace_path / "HEARTBEAT.md").write_text(TEMPLATE_HEARTBEAT_MD, encoding="utf-8")
+
+    # Write optional but recommended files.
+    (workspace_path / "agent.yaml").write_text(
+        _build_agent_yaml(name, channel, model), encoding="utf-8"
+    )
+    (workspace_path / ".env").write_text(TEMPLATE_ENV, encoding="utf-8")
+
+    return workspace_path
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+def _print_next_steps(workspace_path: Path, name: str) -> None:
+    """Print the post-creation summary and suggested next steps.
+
+    Args:
+        workspace_path: Absolute path to the created workspace directory.
+        name: Workspace name.
+    """
+    print(f"Created workspace: {name}")
+    print(f"  Path: {workspace_path}/")
+    print()
+    print("Next steps:")
+    print("  1. Edit agent.yaml with your model and channel settings")
+    print("  2. Add API keys to .env")
+    print("  3. Customize AGENT.md, USER.md, and SOUL.md")
+    print(f"  4. Run: openpaw -c config.yaml -w {name}")
+
+
+# ---------------------------------------------------------------------------
+# Command handlers
+# ---------------------------------------------------------------------------
+
+def _handle_init(args: list[str]) -> None:
+    """Handle the ``openpaw init <name>`` command.
+
+    Parses arguments, validates the workspace name, creates the workspace
+    directory with all required files, and prints next steps.
+
+    Args:
+        args: Remaining CLI arguments after the ``init`` subcommand token.
+    """
+    parser = argparse.ArgumentParser(
+        prog="openpaw init",
+        description="Scaffold a new OpenPaw agent workspace.",
+    )
+    parser.add_argument("name", help="Workspace name (e.g., my_agent)")
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=Path("agent_workspaces"),
+        help="Parent directory for workspaces (default: ./agent_workspaces)",
+    )
+    parser.add_argument(
+        "--channel",
+        default=None,
+        help="Pre-configure channel type (e.g., telegram)",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Pre-configure model (e.g., anthropic:claude-sonnet-4-20250514)",
+    )
+
+    parsed = parser.parse_args(args)
+
+    try:
+        _validate_workspace_name(parsed.name)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if parsed.model:
+        try:
+            _parse_model_string(parsed.model)
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+    try:
+        workspace_path = _create_workspace(
+            parsed.path, parsed.name, parsed.channel, parsed.model
+        )
+    except FileExistsError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except OSError as exc:
+        print(f"Error creating workspace: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    _print_next_steps(workspace_path, parsed.name)
+
+
+def _handle_list(args: list[str]) -> None:
+    """Handle the ``openpaw list`` command.
+
+    Discovers valid workspaces in the specified directory and prints their
+    names, or prints an appropriate message if none are found.
+
+    Args:
+        args: Remaining CLI arguments after the ``list`` subcommand token.
+    """
+    parser = argparse.ArgumentParser(
+        prog="openpaw list",
+        description="List available OpenPaw agent workspaces.",
+    )
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=Path("agent_workspaces"),
+        help="Directory to search for workspaces (default: ./agent_workspaces)",
+    )
+
+    parsed = parser.parse_args(args)
+    workspaces_path = parsed.path
+
+    if not workspaces_path.exists():
+        print(f"Directory not found: {workspaces_path}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        from openpaw.workspace.loader import WorkspaceLoader
+
+        loader = WorkspaceLoader(workspaces_path)
+        workspace_names = loader.list_workspaces()
+    except OSError as exc:
+        print(f"Error reading workspaces: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if not workspace_names:
+        print(f"No workspaces found in {workspaces_path}/")
+        return
+
+    print(f"Workspaces in {workspaces_path}/:")
+    for ws_name in workspace_names:
+        print(f"  {ws_name}")
+    print(f"{len(workspace_names)} workspace(s) found.")
+
+
+# ---------------------------------------------------------------------------
+# Dispatch entry point
+# ---------------------------------------------------------------------------
+
+def dispatch_command(command: str, args: list[str]) -> None:
+    """Route a CLI subcommand to its handler.
+
+    Args:
+        command: Subcommand name (``init`` or ``list``).
+        args: Remaining arguments to pass to the handler.
+    """
+    if command == "init":
+        _handle_init(args)
+    elif command == "list":
+        _handle_list(args)
+    else:
+        print(f"Error: Unknown command '{command}'.", file=sys.stderr)
+        sys.exit(1)

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -1,0 +1,438 @@
+"""Tests for openpaw init and openpaw list CLI commands."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from openpaw.cli_init import (
+    _build_agent_yaml,
+    _create_workspace,
+    _handle_init,
+    _handle_list,
+    _parse_model_string,
+    _validate_workspace_name,
+    dispatch_command,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_valid_workspace(base: Path, name: str) -> Path:
+    """Create a minimal valid workspace directory under base."""
+    ws = base / name
+    ws.mkdir(parents=True)
+    for fname in ["AGENT.md", "USER.md", "SOUL.md", "HEARTBEAT.md"]:
+        (ws / fname).write_text(f"# {fname}", encoding="utf-8")
+    return ws
+
+
+# ---------------------------------------------------------------------------
+# 1. Name validation
+# ---------------------------------------------------------------------------
+
+class TestValidateWorkspaceName:
+    """Unit tests for _validate_workspace_name()."""
+
+    @pytest.mark.parametrize("name", ["my_agent", "a1", "test-agent", "ab"])
+    def test_valid_names_pass(self, name: str) -> None:
+        """Valid names should not raise."""
+        _validate_workspace_name(name)
+
+    def test_rejects_uppercase(self) -> None:
+        with pytest.raises(ValueError, match="invalid"):
+            _validate_workspace_name("MyAgent")
+
+    def test_rejects_spaces(self) -> None:
+        with pytest.raises(ValueError, match="invalid"):
+            _validate_workspace_name("my agent")
+
+    def test_rejects_special_chars(self) -> None:
+        with pytest.raises(ValueError, match="invalid"):
+            _validate_workspace_name("my@agent")
+
+    def test_rejects_starts_with_digit(self) -> None:
+        with pytest.raises(ValueError, match="invalid"):
+            _validate_workspace_name("1agent")
+
+    def test_rejects_starts_with_hyphen(self) -> None:
+        with pytest.raises(ValueError, match="invalid"):
+            _validate_workspace_name("-agent")
+
+    def test_rejects_too_long(self) -> None:
+        with pytest.raises(ValueError, match="too long"):
+            _validate_workspace_name("a" * 65)
+
+    def test_rejects_single_char(self) -> None:
+        with pytest.raises(ValueError, match="too short"):
+            _validate_workspace_name("a")
+
+    def test_rejects_empty_string(self) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            _validate_workspace_name("")
+
+    def test_accepts_max_length(self) -> None:
+        """Exactly 64 chars should be accepted."""
+        _validate_workspace_name("a" * 64)
+
+    def test_accepts_min_length(self) -> None:
+        """Exactly 2 chars should be accepted."""
+        _validate_workspace_name("ab")
+
+
+# ---------------------------------------------------------------------------
+# 2. Workspace creation
+# ---------------------------------------------------------------------------
+
+class TestCreateWorkspace:
+    """Unit tests for _create_workspace()."""
+
+    def test_creates_required_files(self, tmp_path: Path) -> None:
+        """All four required markdown files and agent.yaml must be present."""
+        _create_workspace(tmp_path, "my_agent", None, None)
+
+        ws = tmp_path / "my_agent"
+        for fname in ["AGENT.md", "USER.md", "SOUL.md", "HEARTBEAT.md", "agent.yaml"]:
+            assert (ws / fname).exists(), f"Expected {fname} to exist"
+
+    def test_creates_env_file(self, tmp_path: Path) -> None:
+        _create_workspace(tmp_path, "my_agent", None, None)
+        assert (tmp_path / "my_agent" / ".env").exists()
+
+    def test_name_placeholder_replaced_in_agent_md(self, tmp_path: Path) -> None:
+        _create_workspace(tmp_path, "hal", None, None)
+        content = (tmp_path / "hal" / "AGENT.md").read_text()
+        assert "AGENT: hal" in content
+        assert "{name}" not in content
+
+    def test_name_placeholder_replaced_in_soul_md(self, tmp_path: Path) -> None:
+        _create_workspace(tmp_path, "hal", None, None)
+        content = (tmp_path / "hal" / "SOUL.md").read_text()
+        assert "SOUL: hal" in content
+        assert "{name}" not in content
+
+    def test_raises_on_existing_workspace(self, tmp_path: Path) -> None:
+        _create_workspace(tmp_path, "dup", None, None)
+        with pytest.raises(FileExistsError, match="already exists"):
+            _create_workspace(tmp_path, "dup", None, None)
+
+    def test_workspace_passes_loader_validation(self, tmp_path: Path) -> None:
+        """WorkspaceLoader._is_valid_workspace() must return True for created workspaces."""
+        from openpaw.workspace.loader import WorkspaceLoader
+
+        _create_workspace(tmp_path, "gilfoyle", None, None)
+        loader = WorkspaceLoader(tmp_path)
+        ws_path = tmp_path / "gilfoyle"
+        assert loader._is_valid_workspace(ws_path)
+
+    def test_agent_yaml_parseable_by_workspace_config(self, tmp_path: Path) -> None:
+        """agent.yaml must be parseable by WorkspaceConfig without errors."""
+        from openpaw.core.config.models import WorkspaceConfig
+
+        _create_workspace(tmp_path, "chomsky", None, None)
+        data = yaml.safe_load((tmp_path / "chomsky" / "agent.yaml").read_text())
+        # Pydantic should not raise here.
+        WorkspaceConfig(**data)
+
+    def test_returns_workspace_path(self, tmp_path: Path) -> None:
+        result = _create_workspace(tmp_path, "rex", None, None)
+        assert result == tmp_path / "rex"
+
+
+# ---------------------------------------------------------------------------
+# 3. agent.yaml generation
+# ---------------------------------------------------------------------------
+
+class TestBuildAgentYaml:
+    """Unit tests for _build_agent_yaml()."""
+
+    def test_no_flags_model_section_commented_out(self) -> None:
+        yaml_text = _build_agent_yaml("mybot", None, None)
+        assert "# model:" in yaml_text
+        # The top-level model key must NOT be present as an active YAML key
+        # (i.e., no line starting with "model:" without a leading #).
+        active_keys = {
+            line.split(":")[0]
+            for line in yaml_text.splitlines()
+            if line and not line.startswith("#") and ":" in line
+        }
+        assert "model" not in active_keys
+
+    def test_no_flags_channel_section_commented_out(self) -> None:
+        yaml_text = _build_agent_yaml("mybot", None, None)
+        assert "# channel:" in yaml_text
+        active_keys = {
+            line.split(":")[0]
+            for line in yaml_text.splitlines()
+            if line and not line.startswith("#") and ":" in line
+        }
+        assert "channel" not in active_keys
+
+    def test_model_flag_populates_model_section(self) -> None:
+        yaml_text = _build_agent_yaml("mybot", None, "anthropic:claude-sonnet-4-20250514")
+        parsed = yaml.safe_load(yaml_text)
+        assert parsed["model"]["provider"] == "anthropic"
+        assert parsed["model"]["model"] == "claude-sonnet-4-20250514"
+
+    def test_channel_flag_populates_channel_section(self) -> None:
+        yaml_text = _build_agent_yaml("mybot", "telegram", None)
+        parsed = yaml.safe_load(yaml_text)
+        assert parsed["channel"]["type"] == "telegram"
+
+    def test_both_flags_set_both_sections(self) -> None:
+        yaml_text = _build_agent_yaml("mybot", "telegram", "openai:gpt-4o")
+        parsed = yaml.safe_load(yaml_text)
+        assert parsed["model"]["provider"] == "openai"
+        assert parsed["channel"]["type"] == "telegram"
+
+    def test_queue_section_always_present(self) -> None:
+        yaml_text = _build_agent_yaml("mybot", None, None)
+        parsed = yaml.safe_load(yaml_text)
+        assert parsed["queue"]["mode"] == "collect"
+        assert parsed["queue"]["debounce_ms"] == 1000
+
+    def test_workspace_name_in_name_field(self) -> None:
+        yaml_text = _build_agent_yaml("clippy", None, None)
+        parsed = yaml.safe_load(yaml_text)
+        assert parsed["name"] == "clippy"
+
+    def test_model_without_colon_defaults_to_anthropic(self) -> None:
+        """A bare model string without a colon should still produce valid YAML."""
+        yaml_text = _build_agent_yaml("mybot", None, "gpt-4o")
+        parsed = yaml.safe_load(yaml_text)
+        assert parsed["model"]["provider"] == "anthropic"
+        assert parsed["model"]["model"] == "gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# 4. Error cases via _handle_init
+# ---------------------------------------------------------------------------
+
+class TestHandleInit:
+    """Integration-level tests for the init command handler."""
+
+    def test_invalid_name_exits_1(self, tmp_path: Path, capsys) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            _handle_init(["MyBadName", "--path", str(tmp_path)])
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Error" in captured.err
+
+    def test_duplicate_name_exits_1(self, tmp_path: Path, capsys) -> None:
+        _handle_init(["good_name", "--path", str(tmp_path)])
+        with pytest.raises(SystemExit) as exc_info:
+            _handle_init(["good_name", "--path", str(tmp_path)])
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "already exists" in captured.err
+
+    def test_success_prints_created_message(self, tmp_path: Path, capsys) -> None:
+        _handle_init(["my_agent", "--path", str(tmp_path)])
+        captured = capsys.readouterr()
+        assert "Created workspace: my_agent" in captured.out
+
+    def test_success_prints_next_steps(self, tmp_path: Path, capsys) -> None:
+        _handle_init(["my_agent", "--path", str(tmp_path)])
+        captured = capsys.readouterr()
+        assert "Next steps:" in captured.out
+        assert "openpaw -c config.yaml -w my_agent" in captured.out
+
+    def test_model_flag_passed_through(self, tmp_path: Path) -> None:
+        _handle_init(["agent_x", "--path", str(tmp_path), "--model", "anthropic:claude-sonnet-4-20250514"])
+        data = yaml.safe_load((tmp_path / "agent_x" / "agent.yaml").read_text())
+        assert data["model"]["provider"] == "anthropic"
+
+    def test_channel_flag_passed_through(self, tmp_path: Path) -> None:
+        _handle_init(["agent_y", "--path", str(tmp_path), "--channel", "telegram"])
+        data = yaml.safe_load((tmp_path / "agent_y" / "agent.yaml").read_text())
+        assert data["channel"]["type"] == "telegram"
+
+
+# ---------------------------------------------------------------------------
+# 5. List command
+# ---------------------------------------------------------------------------
+
+class TestHandleList:
+    """Tests for the list command handler."""
+
+    def test_lists_valid_workspaces(self, tmp_path: Path, capsys) -> None:
+        _make_valid_workspace(tmp_path, "alpha")
+        _make_valid_workspace(tmp_path, "beta")
+        _handle_list(["--path", str(tmp_path)])
+        captured = capsys.readouterr()
+        assert "alpha" in captured.out
+        assert "beta" in captured.out
+        assert "2 workspace(s) found." in captured.out
+
+    def test_skips_invalid_directories(self, tmp_path: Path, capsys) -> None:
+        """Directories missing required files should not appear in the list."""
+        _make_valid_workspace(tmp_path, "valid_one")
+        incomplete = tmp_path / "incomplete"
+        incomplete.mkdir()
+        (incomplete / "AGENT.md").write_text("# test")
+        # Missing USER.md, SOUL.md, HEARTBEAT.md
+
+        _handle_list(["--path", str(tmp_path)])
+        captured = capsys.readouterr()
+        assert "valid_one" in captured.out
+        assert "incomplete" not in captured.out
+
+    def test_empty_directory_prints_no_workspaces(self, tmp_path: Path, capsys) -> None:
+        _handle_list(["--path", str(tmp_path)])
+        captured = capsys.readouterr()
+        assert "No workspaces found" in captured.out
+
+    def test_nonexistent_directory_exits_1(self, tmp_path: Path, capsys) -> None:
+        missing = tmp_path / "does_not_exist"
+        with pytest.raises(SystemExit) as exc_info:
+            _handle_list(["--path", str(missing)])
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "Directory not found" in captured.err
+
+    def test_output_includes_workspace_count(self, tmp_path: Path, capsys) -> None:
+        for name in ["one", "two", "three"]:
+            _make_valid_workspace(tmp_path, name)
+        _handle_list(["--path", str(tmp_path)])
+        captured = capsys.readouterr()
+        assert "3 workspace(s) found." in captured.out
+
+
+# ---------------------------------------------------------------------------
+# 6. Dispatch routing
+# ---------------------------------------------------------------------------
+
+class TestDispatchCommand:
+    """Tests for the dispatch_command() router."""
+
+    def test_dispatch_init_calls_init_handler(self, tmp_path: Path) -> None:
+        with patch("openpaw.cli_init._handle_init") as mock_init:
+            dispatch_command("init", ["mybot", "--path", str(tmp_path)])
+            mock_init.assert_called_once_with(["mybot", "--path", str(tmp_path)])
+
+    def test_dispatch_list_calls_list_handler(self, tmp_path: Path) -> None:
+        with patch("openpaw.cli_init._handle_list") as mock_list:
+            dispatch_command("list", ["--path", str(tmp_path)])
+            mock_list.assert_called_once_with(["--path", str(tmp_path)])
+
+    def test_dispatch_unknown_command_exits_1(self, capsys) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            dispatch_command("unknown", [])
+        assert exc_info.value.code == 1
+
+    def test_early_dispatch_in_cli_run_calls_dispatch(self, tmp_path: Path) -> None:
+        """cli.run() should delegate to dispatch_command for 'init'."""
+        from openpaw.cli import run
+
+        with patch("openpaw.cli_init.dispatch_command") as mock_dispatch:
+            with patch.object(sys, "argv", ["openpaw", "init", "test_ws"]):
+                run()
+            mock_dispatch.assert_called_once_with("init", ["test_ws"])
+
+    def test_early_dispatch_in_cli_run_calls_list(self) -> None:
+        """cli.run() should delegate to dispatch_command for 'list'."""
+        from openpaw.cli import run
+
+        with patch("openpaw.cli_init.dispatch_command") as mock_dispatch:
+            with patch.object(sys, "argv", ["openpaw", "list"]):
+                run()
+            mock_dispatch.assert_called_once_with("list", [])
+
+
+# ---------------------------------------------------------------------------
+# 7. Model string parsing and validation
+# ---------------------------------------------------------------------------
+
+class TestParseModelString:
+    """Tests for _parse_model_string()."""
+
+    def test_splits_provider_and_model(self) -> None:
+        assert _parse_model_string("anthropic:claude-sonnet-4-20250514") == (
+            "anthropic",
+            "claude-sonnet-4-20250514",
+        )
+
+    def test_bare_model_defaults_to_anthropic(self) -> None:
+        assert _parse_model_string("gpt-4o") == ("anthropic", "gpt-4o")
+
+    def test_rejects_empty_model_id(self) -> None:
+        with pytest.raises(ValueError, match="model ID is empty"):
+            _parse_model_string("anthropic:")
+
+    def test_rejects_empty_provider(self) -> None:
+        with pytest.raises(ValueError, match="provider is empty"):
+            _parse_model_string(":claude-sonnet-4-20250514")
+
+    def test_bedrock_model_string(self) -> None:
+        provider, model_id = _parse_model_string("bedrock_converse:us.anthropic.claude-haiku:v1:0")
+        assert provider == "bedrock_converse"
+        assert model_id == "us.anthropic.claude-haiku:v1:0"
+
+
+# ---------------------------------------------------------------------------
+# 8. Bedrock-specific scaffold tests
+# ---------------------------------------------------------------------------
+
+class TestBedrockScaffold:
+    """Tests ensuring Bedrock providers omit api_key."""
+
+    def test_bedrock_omits_api_key_in_yaml(self) -> None:
+        yaml_text = _build_agent_yaml("mybot", None, "bedrock_converse:us.anthropic.claude-haiku:v1:0")
+        assert "api_key" not in yaml_text
+
+    def test_bedrock_model_section_valid(self) -> None:
+        yaml_text = _build_agent_yaml("mybot", None, "bedrock_converse:us.anthropic.claude-haiku:v1:0")
+        parsed = yaml.safe_load(yaml_text)
+        assert parsed["model"]["provider"] == "bedrock_converse"
+        assert parsed["model"]["model"] == "us.anthropic.claude-haiku:v1:0"
+
+    def test_anthropic_includes_api_key_in_yaml(self) -> None:
+        yaml_text = _build_agent_yaml("mybot", None, "anthropic:claude-sonnet-4-20250514")
+        assert "api_key" in yaml_text
+
+
+# ---------------------------------------------------------------------------
+# 9. Invalid model flag in init handler
+# ---------------------------------------------------------------------------
+
+class TestHandleInitModelValidation:
+    """Tests for invalid --model values in the init handler."""
+
+    def test_empty_model_id_exits_1(self, tmp_path: Path, capsys) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            _handle_init(["my_agent", "--path", str(tmp_path), "--model", "anthropic:"])
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "model ID is empty" in captured.err
+
+    def test_empty_provider_exits_1(self, tmp_path: Path, capsys) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            _handle_init(["my_agent", "--path", str(tmp_path), "--model", ":claude-sonnet"])
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "provider is empty" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# 10. List command uses WorkspaceLoader
+# ---------------------------------------------------------------------------
+
+class TestHandleListIntegration:
+    """Integration tests for list command with WorkspaceLoader."""
+
+    def test_list_output_is_alphabetically_sorted(self, tmp_path: Path, capsys) -> None:
+        for name in ["zeta", "alpha", "middle"]:
+            _make_valid_workspace(tmp_path, name)
+        _handle_list(["--path", str(tmp_path)])
+        captured = capsys.readouterr()
+        lines = [
+            line.strip()
+            for line in captured.out.strip().splitlines()
+            if line.strip()
+            and not line.startswith("Workspaces")
+            and "workspace(s)" not in line
+        ]
+        assert lines == sorted(lines)


### PR DESCRIPTION
## Summary

- Adds `openpaw init <name>` to scaffold new workspaces with all required files (AGENT.md, USER.md, SOUL.md, HEARTBEAT.md, agent.yaml, .env)
- Adds `openpaw list` to discover valid workspaces in a directory
- Supports `--model` and `--channel` flags for pre-configured scaffolds
- Early dispatch in `cli.py` routes init/list before argparse/async, preserving backward compatibility

## Test plan

- [x] 57 new tests in `tests/test_cli_init.py` (name validation, workspace creation, flag handling, error cases, list command, dispatch routing, bedrock scaffold, model string parsing)
- [x] Full suite: 1346 passed, 0 regressions
- [x] Lint clean (`ruff check`)
- [x] Manual smoke tests: `openpaw init`, `openpaw list`, `openpaw init --model --channel`

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)