### PR TITLE
chore: remove unused deps, clean up extras

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,9 +42,6 @@ poetry install -E voice
 # Web search (Brave Search API)
 poetry install -E web
 
-# System tools (SSH remote execution)
-poetry install -E system
-
 # Memory search (semantic search over past conversations)
 poetry install -E memory
 
@@ -58,11 +55,10 @@ poetry install -E all-builtins
 |-------|----------|----------|
 | `voice` | Whisper audio transcription, ElevenLabs text-to-speech | `OPENAI_API_KEY`, `ELEVENLABS_API_KEY` |
 | `web` | Brave Search web search | `BRAVE_API_KEY` |
-| `system` | Shell command execution, SSH remote execution | `asyncssh` package |
 | `memory` | Semantic search over conversation archives | `sqlite-vec` package |
 | `all-builtins` | All of the above | All API keys above |
 
-**Note:** Docling (document conversion) and Playwright (browser automation) are **core dependencies** and installed automatically with `poetry install`.
+**Note:** Docling (document conversion), Playwright (browser automation), and all LLM providers (Anthropic, OpenAI, AWS Bedrock, xAI) are **core dependencies** installed automatically with `poetry install`.
 
 ### 4. Set Up Environment Variables
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,46 +8,46 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
 dependencies = [
+    # Agent runtime
     "langchain (>=1.2.8,<2.0.0)",
+    "langgraph (>=1.0.7,<2.0.0)",
+    "langgraph-checkpoint-sqlite (>=2.0.0,<4.0.0)",
+    # LLM providers
     "langchain-anthropic (>=1.3.1,<2.0.0)",
     "langchain-aws (>=1.0.0,<2.0.0)",
     "langchain-openai (>=1.1.7,<2.0.0)",
-    "langgraph (>=1.0.7,<2.0.0)",
-    "langgraph-checkpoint-sqlite (>=2.0.0,<4.0.0)",
+    "langchain-xai (>=1.2.2,<2.0.0)",
+    # Channel adapters
     "python-telegram-bot[job-queue] (>=22.6,<23.0)",
-    "pyyaml (>=6.0.3,<7.0.0)",
+    # Configuration and scheduling
     "pydantic (>=2.12.5,<3.0.0)",
+    "pyyaml (>=6.0.3,<7.0.0)",
     "apscheduler (>=3.10.0,<4.0.0)",
-    "langchain-experimental (>=0.4.1,<0.5.0)",
     "python-dotenv (>=1.2.1,<2.0.0)",
+    # Document processing and browser automation
     "docling (>=2.72.0,<3.0.0)",
-    "playwright (>=1.58.0,<2.0.0)",
     "easyocr (>=1.7.2,<2.0.0)",
     "opencv-python-headless (>=4.13.0.92,<5.0.0.0)",
-    "langchain-xai (>=1.2.2,<2.0.0)"
+    "playwright (>=1.58.0,<2.0.0)",
 ]
 
 [project.optional-dependencies]
-# Builtins - install specific extras for the builtins you need
+# Optional builtins — install extras for specific capabilities
 voice = [
     "openai (>=1.0.0)",      # Whisper transcription
-    "elevenlabs (>=1.0.0)"   # Text-to-speech
+    "elevenlabs (>=1.0.0)",  # Text-to-speech
 ]
 web = [
-    "langchain-community (>=0.4.0)"  # Brave Search
-]
-system = [
-    "langchain-experimental (>=0.4.0)"  # Shell tool
+    "langchain-community (>=0.4.0)",  # Brave Search
 ]
 memory = [
-    "sqlite-vec (>=0.1.6)"
+    "sqlite-vec (>=0.1.6)",  # Semantic search over conversation archives
 ]
 all-builtins = [
     "openai (>=1.0.0)",
     "elevenlabs (>=1.0.0)",
     "langchain-community (>=0.4.0)",
-    "langchain-experimental (>=0.4.0)",
-    "sqlite-vec (>=0.1.6)"
+    "sqlite-vec (>=0.1.6)",
 ]
 
 


### PR DESCRIPTION
## Summary

- Remove `langchain-experimental` from core dependencies (zero imports across entire codebase)
- Remove `system` extra entirely — shell tool is a custom async implementation, SSH tool was documented but never implemented
- Remove stale SSH tool documentation from `docs/builtins.md`
- Organize core deps with section comments (runtime, providers, channels, config, document processing)
- Update `docs/getting-started.md` extras table to match

## Test plan

- [x] Full suite: 1346 passed, 0 regressions
- [x] Lint clean
- [x] `poetry show langchain-experimental` confirms package removed
- [x] `poetry install` succeeds with updated lock file
- [x] Verified zero imports of `langchain-experimental` in `openpaw/` and `tests/`

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)