### PR TITLE
docs: project scaffolding for open-source readiness

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,174 @@
+# Contributing to OpenPaw
+
+Thank you for your interest in contributing. OpenPaw is built with a strong emphasis on clean, readable, and maintainable code. Contributions that share that philosophy are welcome.
+
+Before diving in, it is worth reading through this guide and the [Architecture overview](docs/architecture.md) to understand how the system is structured and where new code belongs.
+
+---
+
+## Development Setup
+
+**Prerequisites**
+
+- Python 3.11+
+- [Poetry 2.0+](https://python-poetry.org/docs/#installation)
+
+**Install**
+
+```bash
+git clone https://github.com/johnsosoka/OpenPaw.git
+cd OpenPaw
+poetry install
+```
+
+**Optional extras**
+
+```bash
+poetry install --extras voice    # Whisper transcription + ElevenLabs TTS
+poetry install --extras web      # Brave Search via langchain-community
+poetry install --extras memory   # Semantic search over conversation archives
+poetry install --extras all-builtins  # All of the above
+```
+
+**Verify**
+
+```bash
+poetry run pytest
+```
+
+All tests should pass before you begin.
+
+---
+
+## Project Structure
+
+OpenPaw is organized into eight top-level packages:
+
+| Package | Purpose |
+|---------|---------|
+| `openpaw/model/` | Pure business models — `Message`, `Task`, `SessionState`, etc. No framework dependencies. |
+| `openpaw/core/` | Configuration, logging, timezone utilities, centralized prompts, shared utilities. |
+| `openpaw/agent/` | `AgentRunner` (LangGraph wrapper), token metrics, tool middleware, sandboxed filesystem tools. |
+| `openpaw/workspace/` | `WorkspaceRunner`, message processing loop, agent factory, lifecycle hooks, tool loader. |
+| `openpaw/runtime/` | `OpenPawOrchestrator`, lane queues, cron/heartbeat schedulers, session management, sub-agent runner. |
+| `openpaw/stores/` | Persistence layer — task, sub-agent, dynamic cron, and vector stores. |
+| `openpaw/channels/` | Channel adapters (Telegram), command router, channel factory. |
+| `openpaw/builtins/` | Optional tools and processors loaded conditionally at startup. |
+
+**Stability contract:** Dependencies point inward toward stability. `model/` has no dependencies on any other package. `core/` depends only on `model/`. Code in `agent/` or `workspace/` may depend on lower layers but not on `runtime/` or `channels/`. Violations of this contract will be flagged in review.
+
+---
+
+## Development Workflow
+
+**Branching**
+
+Branch from `main` using one of these prefixes:
+
+```
+feature/short-description
+bugfix/short-description
+docs/short-description
+chore/short-description
+```
+
+**Before submitting**
+
+Run all three checks locally before opening a pull request:
+
+```bash
+# Lint
+poetry run ruff check openpaw/
+
+# Type check
+poetry run mypy openpaw/
+
+# Tests
+poetry run pytest
+```
+
+Fix any issues before pushing. PRs with failing lint, type errors, or broken tests will not be merged.
+
+---
+
+## Code Style
+
+OpenPaw uses [Ruff](https://docs.astral.sh/ruff/) for linting and formatting, and [mypy](https://mypy-lang.org/) in strict mode for type checking. Configuration lives in `pyproject.toml`.
+
+**Key conventions:**
+
+- All functions and methods must have type annotations.
+- Keep functions small and single-purpose. If a function is doing more than one thing, extract it.
+- Avoid flag arguments and deep nesting. Prefer early returns.
+- Use descriptive names. Abbreviations are acceptable only for well-understood domain terms.
+- Thread-safe persistence follows the `threading.Lock` + atomic write (tmp + rename) pattern used throughout `openpaw/stores/`.
+- Async tools use the `StructuredTool.from_function(func=sync_fn, coroutine=async_fn)` pattern.
+- Builtins that need channel access use the shared `_channel_context.py` contextvars module — do not pass channel references directly into tool functions.
+
+---
+
+## Testing
+
+Tests live in `tests/` and mirror the `openpaw/` package structure. New code requires new tests.
+
+```bash
+# Run all tests
+poetry run pytest
+
+# Run a specific file
+poetry run pytest tests/test_builtin_loader.py -v
+
+# Run tests matching a name pattern
+poetry run pytest -k "test_approval"
+```
+
+**Test conventions:**
+
+- Use `pytest` with `pytest-asyncio` for async tests (`asyncio_mode = "auto"` is set in `pyproject.toml`).
+- Tests should be fast and isolated — no shared mutable state between test functions.
+- Use fixtures over setUp/tearDown patterns.
+- Test behavior, not implementation details.
+- When adding a new builtin, processor, or channel adapter, include unit tests for the core logic and at least one integration-style test for the happy path.
+
+---
+
+## Pull Request Process
+
+1. Fork the repository and create a branch from `main`.
+2. Implement your change with tests.
+3. Run lint, type check, and tests locally — all must pass.
+4. Open a pull request against `main`. Reference any related issue in the PR description.
+5. Keep PRs focused: one feature or fix per PR. If your change is large, consider breaking it into a series of smaller PRs.
+
+PRs that introduce unnecessary complexity, skip tests, or deviate from the architectural conventions described above will be asked to revise before merge.
+
+---
+
+## Adding Builtins
+
+Builtins are the primary extension point. They are optional capabilities (tools or processors) loaded conditionally at workspace startup.
+
+**Tools** are LangChain-compatible tools the agent can invoke. **Processors** are channel-layer message transformers that run before the agent sees a message.
+
+**Steps to add a new builtin:**
+
+1. Create a class in `openpaw/builtins/tools/` or `openpaw/builtins/processors/` that extends `BaseBuiltinTool` or `BaseBuiltinProcessor`.
+2. Define a `metadata` property returning a `BuiltinMetadata` instance. Declare any prerequisites (e.g., API keys, packages) here — the loader will skip the builtin if prerequisites are not met.
+3. Implement `get_langchain_tool()` (for tools) or `process()` (for processors). Tools must return a list, even if it contains a single tool.
+4. Register the class in `openpaw/builtins/registry.py`.
+5. If the builtin has configuration fields, add a typed field to `BuiltinsConfig` / `WorkspaceBuiltinsConfig` in `openpaw/core/config/models.py`.
+6. If the builtin warrants a mention in the framework orientation prompt, add a conditional section in `openpaw/core/prompts/framework.py`.
+
+See `openpaw/builtins/tools/brave_search.py` for a minimal tool example and `openpaw/builtins/processors/whisper.py` for a processor example.
+
+---
+
+## Adding Channels
+
+The channel system is factory-based and decoupled from `WorkspaceRunner`. See [docs/channels.md](docs/channels.md) for the full guide on implementing and registering a new channel adapter.
+
+---
+
+## License
+
+OpenPaw is released under the [PolyForm Noncommercial 1.0.0](LICENSE) license. By contributing, you agree that your contributions will be licensed under the same terms.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,20 +12,20 @@ logging:
   backup_count: 5
   per_workspace: true
 
-# Message queue defaults (can be overridden per workspace)
+# Message queue defaults (can be overridden per workspace via agent.yaml)
 queue:
   mode: collect            # collect, steer, followup, interrupt
-  debounce_ms: 1000
-  cap: 20
-  drop_policy: summarize   # old, new, summarize
+  debounce_ms: 1000        # Wait this long after last message before processing
+  cap: 20                  # Max queued messages per session before drop policy fires
+  drop_policy: summarize   # overflow policy: old (drop oldest), new (drop newest), summarize
 
-# Lane concurrency
+# Lane concurrency (controls how many agent runs happen simultaneously per lane)
 lanes:
-  main_concurrency: 4
-  subagent_concurrency: 8
-  cron_concurrency: 2
+  main_concurrency: 4      # User-facing message lanes
+  subagent_concurrency: 8  # Background sub-agent workers
+  cron_concurrency: 2      # Scheduled job runners
 
-# Default agent model
+# Default agent model — applies to all workspaces unless overridden in agent.yaml
 # Format: provider:model_id
 # Examples:
 #   anthropic:claude-sonnet-4-20250514
@@ -37,65 +37,184 @@ agent:
   max_turns: 50
   temperature: 0.7
 
-# Builtins (tools and processors)
-# Conditionally loaded based on API keys and installed packages.
-# See docs/builtins.md for full reference.
+# ──────────────────────────────────────────────────────────────────────────────
+# Builtins — tools and processors conditionally loaded based on API key
+# availability and installed packages. All sections below are commented out;
+# uncomment only what you need.
+# ──────────────────────────────────────────────────────────────────────────────
 builtins:
-  allow: []    # Empty = allow all available
-  deny: []     # Use "group:voice" to deny entire groups
+  allow: []    # Empty = allow all available builtins
+  deny: []     # Deny specific builtins or groups: e.g., ["group:voice", "browser"]
 
-  # Example: configure Brave Search
+  # Web search via Brave API (requires BRAVE_API_KEY)
   # brave_search:
   #   enabled: true
   #   config:
-  #     count: 5
+  #     count: 5              # Number of search results to return
 
-  # Example: configure browser automation
+  # Audio transcription for voice messages (requires OPENAI_API_KEY)
+  # whisper:
+  #   enabled: true
+  #   config:
+  #     model: whisper-1
+
+  # Text-to-speech for voice responses (requires ELEVENLABS_API_KEY)
+  # elevenlabs:
+  #   enabled: true
+  #   config:
+  #     voice_id: 21m00Tcm4TlvDq8ikWAM
+
+  # Async shell command execution (no API key required)
+  # shell:
+  #   enabled: true
+
+  # Agent self-scheduling — lets agents schedule their own follow-up tasks
+  # (no API key required; see "Dynamic Scheduling" in CLAUDE.md)
+  # cron:
+  #   enabled: true
+  #   config:
+  #     min_interval_seconds: 300   # Minimum recurring task interval (5 min default)
+  #     max_tasks: 50               # Maximum pending scheduled tasks per workspace
+
+  # Sub-agent spawning — agents can launch background workers for concurrent tasks
+  # (no API key required; see "Sub-Agent Spawning" in CLAUDE.md)
+  # spawn:
+  #   enabled: true
+  #   config:
+  #     max_concurrent: 8           # Maximum simultaneous sub-agents
+
+  # Browser automation via Playwright with accessibility tree navigation
+  # (requires: poetry add playwright && poetry run playwright install chromium)
   # browser:
   #   enabled: true
   #   config:
   #     headless: true
-  #     allowed_domains: []
-  #     blocked_domains: []
+  #     allowed_domains: []         # Empty = allow all; e.g., ["calendly.com", "*.google.com"]
+  #     blocked_domains: []         # Always denied, even if in allowed_domains
   #     timeout_seconds: 30
-  #     persist_cookies: false
+  #     persist_cookies: false      # Persist auth state across agent runs within a session
+  #     downloads_dir: downloads    # Relative to workspace root
+  #     screenshots_dir: screenshots
 
-# Per-workspace settings (also configurable in agent.yaml)
+  # Save all uploaded files to uploads/{YYYY-MM-DD}/ (no API key required)
+  file_persistence:
+    enabled: true
+    config:
+      max_file_size: 52428800     # 50 MB in bytes
+      clear_data_after_save: false
+
+  # PDF/DOCX/PPTX → markdown conversion (core dependency, no API key required)
+  docling:
+    enabled: true
+    config:
+      max_file_size: 52428800     # 50 MB in bytes
+      ocr_backend: auto           # auto, mac, easyocr, tesseract, rapidocr
+      ocr_languages: [en]
+      force_full_page_ocr: true   # Recommended for scanned documents
+      do_table_structure: true
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Approval gates — pause execution and require user confirmation before
+# running specified tools. Disabled by default. Per-workspace override in agent.yaml.
+# ──────────────────────────────────────────────────────────────────────────────
+# approval_gates:
+#   enabled: false
+#   timeout_seconds: 120          # Seconds to wait before applying default_action
+#   default_action: deny          # Action on timeout: "deny" or "approve"
+#   tools:
+#     overwrite_file:
+#       require_approval: true
+#       show_args: true           # Show tool arguments in the approval prompt
+#     shell_run:
+#       require_approval: true
+#       show_args: true
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tool timeouts — cap how long any individual tool call can run.
+# Defaults apply globally; per-tool overrides take precedence.
+# Per-workspace override in agent.yaml.
+# ──────────────────────────────────────────────────────────────────────────────
+# tool_timeouts:
+#   default_seconds: 120          # Applied to any tool without a specific override
+#   overrides:
+#     shell_run: 300              # Shell commands often need more time
+#     browser_navigate: 60
+#     brave_search: 30
+
+# ──────────────────────────────────────────────────────────────────────────────
+# The sections below are workspace-level settings. They can be placed here as
+# global defaults, but are typically configured per-workspace in agent.yaml.
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Auto-compact — rotate to a fresh conversation when context window fills
 # auto_compact:
-#   enabled: false          # Auto-compact when context window fills
-#   trigger: 0.8            # Fraction of context window to trigger (0.0-1.0)
-#   summary_model: null     # Model for summaries (null = use workspace model)
+#   enabled: false
+#   trigger: 0.8                  # Trigger at 80% context window utilization
+#   summary_model: null           # Model for summary generation (null = workspace model)
 
+# Lifecycle notifications — best-effort channel messages on workspace events
 # lifecycle:
-#   notify_startup: false   # Notify users when workspace starts
-#   notify_shutdown: true   # Notify users when workspace stops
-#   notify_auto_compact: true  # Notify users on auto-compact
+#   notify_startup: false         # Notify users when workspace starts
+#   notify_shutdown: true         # Notify users when workspace stops
+#   notify_auto_compact: true     # Notify users when auto-compact fires
 
-# Conversation memory (vector search)
-# Disabled by default — requires embedding API key
+# Heartbeat — periodic proactive agent check-ins (workspace-level only, in agent.yaml)
+# heartbeat:
+#   enabled: false
+#   interval_minutes: 30          # How often the agent checks in
+#   active_hours: "09:00-17:00"   # Only run during this window (workspace timezone)
+#   suppress_ok: true             # Suppress messages when agent responds HEARTBEAT_OK
+#   delivery: channel             # channel, agent, or both
+#   target_channel: telegram
+#   target_chat_id: 123456789     # Telegram chat ID to deliver heartbeat responses
+
+# Conversation memory (vector search) — requires embedding API key
 # memory:
-#   enabled: true
+#   enabled: false
 #   embedding:
 #     provider: openai
 #     model: text-embedding-3-small
 #     api_key: ${OPENAI_API_KEY}
 
-# Per-workspace model config (in agent.yaml, not here)
+# ──────────────────────────────────────────────────────────────────────────────
+# Per-workspace model config (typically in agent.yaml, not here)
 # Two equivalent formats:
-#   Combined: model: "anthropic:claude-sonnet-4-20250514"
+#   Combined:  model: "anthropic:claude-sonnet-4-20250514"
 #   Explicit:
 #     model:
 #       provider: anthropic
 #       model: claude-sonnet-4-20250514
 #       temperature: 0.5
+#       max_turns: 50
+#
+# AWS Bedrock:
+#   model:
+#     provider: bedrock_converse
+#     model: moonshot.kimi-k2-thinking
+#     region: us-east-1
+#
+# OpenAI-compatible (custom base_url):
+#   model:
+#     provider: openai
+#     model: kimi-k2.5
+#     api_key: ${MOONSHOT_API_KEY}
+#     base_url: https://api.moonshot.ai/v1
+# ──────────────────────────────────────────────────────────────────────────────
 
-# Per-workspace channel settings (in agent.yaml, not here)
+# Per-workspace channel settings (typically in agent.yaml, not here)
 # channel:
 #   type: telegram
 #   token: ${TELEGRAM_BOT_TOKEN}
 #   allowed_users:
 #     - 123456789
 #     - 987654321
-#   user_aliases:             # Map user IDs to display names
+#   allowed_groups: []
+#   allow_all: false              # Insecure — allow any user; use only for testing
+#   user_aliases:                 # Map user IDs to display names for multi-user workspaces
 #     123456789: "John"
 #     987654321: "Sarah"
+
+# Per-workspace tool allow/deny (typically in agent.yaml, not here)
+# workspace_tools:
+#   allow: []                     # Empty = allow all tools in tools/ directory
+#   deny: []                      # Tool function names to exclude

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -317,7 +317,7 @@ def get_weather(city: str) -> str:
     return fetch_weather_api(city)
 ```
 
-### Queue System (`openpaw/core/queue/`)
+### Queue System (`openpaw/runtime/queue/`)
 
 Lane-based FIFO queue with configurable concurrency per lane.
 
@@ -871,8 +871,8 @@ CLI (openpaw/cli.py)
            ├─→ ConfigLoader (openpaw/core/config/loader.py)
            ├─→ ChannelFactory (openpaw/channels/factory.py)
            │    └─→ TelegramAdapter (openpaw/channels/telegram.py)
-           ├─→ QueueManager (openpaw/core/queue/manager.py)
-           │    └─→ LaneQueue (openpaw/core/queue/lane.py)
+           ├─→ QueueManager (openpaw/runtime/queue/manager.py)
+           │    └─→ LaneQueue (openpaw/runtime/queue/lane.py)
            ├─→ BuiltinLoader (openpaw/builtins/loader.py)
            ├─→ CronScheduler (openpaw/runtime/scheduling/cron.py)
            ├─→ HeartbeatScheduler (openpaw/runtime/scheduling/heartbeat.py)
@@ -1061,7 +1061,7 @@ See [builtins.md](builtins.md) for details.
 
 ### Adding a New Queue Mode
 
-1. Add mode to `QueueMode` enum in `openpaw/core/queue/lane.py`
+1. Add mode to `QueueMode` enum in `openpaw/runtime/queue/lane.py`
 2. Implement handling logic in `QueueManager.add_message()`
 3. Update middleware behavior in `QueueAwareToolMiddleware` if needed
 4. Update configuration schema in `openpaw/core/config/models.py`
@@ -1210,7 +1210,7 @@ Middleware enables:
 
 **Unit tests:**
 - Configuration parsing and merging (`openpaw/core/config/`)
-- Queue mode behaviors (`openpaw/core/queue/`)
+- Queue mode behaviors (`openpaw/runtime/queue/`)
 - Message format conversions (`openpaw/channels/`)
 - Builtin registration and loading (`openpaw/builtins/`)
 - Timezone utilities (`openpaw/core/timezone.py`)

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -32,7 +32,7 @@ This decouples `WorkspaceRunner` from concrete channel types, enabling extensibi
 
 ## Unified Message Format
 
-All channels convert platform-specific messages to OpenPaw's unified format defined in `openpaw/domain/message.py`:
+All channels convert platform-specific messages to OpenPaw's unified format defined in `openpaw/model/message.py`:
 
 ```python
 @dataclass
@@ -436,7 +436,7 @@ Create `openpaw/channels/<platform>.py` extending `ChannelAdapter`:
 
 ```python
 from openpaw.channels.base import ChannelAdapter
-from openpaw.domain.message import Message, Attachment, MessageDirection
+from openpaw.model.message import Message, Attachment, MessageDirection
 from openpaw.channels.commands.router import CommandRouter, CommandContext, CommandResult
 from typing import Callable, Awaitable
 import discord  # Platform SDK

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ This guide walks through installing OpenPaw, creating your first agent workspace
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/jsosoka/OpenPaw.git
+git clone https://github.com/johnsosoka/OpenPaw.git
 cd OpenPaw
 ```
 
@@ -441,6 +441,6 @@ poetry run openpaw -c config.yaml -w my-agent
 
 ### Still Having Issues?
 
-- Check the [GitHub Issues](https://github.com/jsosoka/OpenPaw/issues) for similar problems
+- Check the [GitHub Issues](https://github.com/johnsosoka/OpenPaw/issues) for similar problems
 - Review the full logs in `logs/<workspace>_YYYY-MM-DD.log`
 - Ensure your Poetry environment is up to date: `poetry update`

--- a/docs/queue-system.md
+++ b/docs/queue-system.md
@@ -6,8 +6,8 @@ OpenPaw implements a sophisticated lane-based queuing system that enables respon
 
 The queue system is implemented in two core components:
 
-- **`openpaw/core/queue/lane.py`** - `LaneQueue` provides lane-based FIFO queuing with configurable concurrency
-- **`openpaw/core/queue/manager.py`** - `QueueManager` coordinates message routing, debouncing, and queue mode behavior
+- **`openpaw/runtime/queue/lane.py`** - `LaneQueue` provides lane-based FIFO queuing with configurable concurrency
+- **`openpaw/runtime/queue/manager.py`** - `QueueManager` coordinates message routing, debouncing, and queue mode behavior
 
 Each workspace maintains its own isolated queue system with three lanes:
 


### PR DESCRIPTION
## Summary

Closes #12. Addresses documentation infrastructure gaps for open-source readiness.

- **Fix stale path references** — `openpaw/domain/` → `openpaw/model/` (channels.md), `openpaw/core/queue/` → `openpaw/runtime/queue/` (queue-system.md, architecture.md)
- **Fix GitHub URL** — `jsosoka/OpenPaw` → `johnsosoka/OpenPaw` in getting-started.md
- **Add CONTRIBUTING.md** — dev setup, project structure overview, code style, testing, PR process, guides for extending builtins and channels
- **Expand config.example.yaml** — added commented-out sections for approval_gates, tool_timeouts, heartbeat, cron, spawn, browser, whisper, elevenlabs; uncommented file_persistence and docling as core builtins

## Test plan

- [x] `poetry run ruff check openpaw/` passes
- [x] `poetry run pytest` — 1346 tests passing
- [x] Verified no remaining stale `openpaw/domain/` or `openpaw/core/queue/` refs in docs/
- [x] Verified no remaining `jsosoka` refs in docs/