### PR TITLE
fix: use in-project virtualenvs for reliable CI caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,17 +27,15 @@ jobs:
           python-version: "3.12"
 
       - name: Install Poetry
-        run: pipx install poetry
+        run: |
+          pipx install poetry
+          poetry config virtualenvs.in-project true
 
-      - name: Cache Poetry downloads
+      - name: Cache virtualenv
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.cache/pypoetry/artifacts
-            ~/.cache/pypoetry/cache
-          key: poetry-v2-${{ runner.os }}-3.12-${{ hashFiles('poetry.lock') }}
-          restore-keys: |
-            poetry-v2-${{ runner.os }}-3.12-
+          path: .venv
+          key: venv-${{ runner.os }}-3.12-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
         run: poetry install --only main,dev
@@ -69,17 +67,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
-        run: pipx install poetry
+        run: |
+          pipx install poetry
+          poetry config virtualenvs.in-project true
 
-      - name: Cache Poetry downloads
+      - name: Cache virtualenv
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.cache/pypoetry/artifacts
-            ~/.cache/pypoetry/cache
-          key: poetry-v2-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
-          restore-keys: |
-            poetry-v2-${{ runner.os }}-${{ matrix.python-version }}-
+          path: .venv
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
         run: poetry install


### PR DESCRIPTION
## Summary
- Switches Poetry to in-project virtualenvs (`.venv/`) instead of `~/.cache/pypoetry/virtualenvs/`
- Caches `.venv` directly with exact-match keys (no `restore-keys` fallback)
- Fixes Python 3.12 CI failures caused by nvidia/torch packages corrupting the cached virtualenv

## Context
After merging #25, the push-to-develop CI run failed on Python 3.12 with exit code 127 (`poetry run pytest` — command not found). The root cause: multiple nvidia CUDA packages share `nvidia/__init__.py`, and when torch is upgraded/downgraded in a cached virtualenv, pip overwrites cause corruption.

## Test plan
- [ ] All 3 CI jobs pass (Lint, Test 3.11, Test 3.12)
- [ ] Cache miss on first run → fresh install
- [ ] Subsequent runs restore `.venv` from cache → fast install