### PR TITLE
refactor: workspace directory restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Agents can ingest documents, browse the web, search the internet, and manage the
 
 **First Class Document processing** -- Docling OCR/ICR turns scanned PDFs, DOCX, and PPTX into markdown automatically. Whisper transcribes voice messages on arrival.
 
-**Drop-in custom tools** -- Write a `@tool` function, put it in `tools/`, restart. Your agent picks it up with zero wiring.
+**Drop-in custom tools** -- Write a `@tool` function, put it in `agent/tools/`, restart. Your agent picks it up with zero wiring.
 
 **Multi-agent spawning** -- Agents spin up background workers for parallel tasks with full lifecycle tracking and result collection.
 
@@ -63,7 +63,7 @@ poetry run openpaw init my_agent \
 cp config.example.yaml config.yaml
 ```
 
-Add your API keys to `agent_workspaces/my_agent/.env`:
+Add your API keys to `agent_workspaces/my_agent/config/.env`:
 
 ```bash
 ANTHROPIC_API_KEY=your-key-here
@@ -93,21 +93,36 @@ All commands should be prefixed with `poetry run` when running from the project 
 
 ## Agent Workspace Structure
 
-Each workspace lives under `agent_workspaces/<name>/` and requires four markdown files that define the agent's identity:
+Each workspace lives under `agent_workspaces/<name>/` and is organized into five directories:
 
 ```
 agent_workspaces/my_agent/
-├── AGENT.md          # Capabilities and behavior guidelines
-├── USER.md           # User context and preferences
-├── SOUL.md           # Core personality and values
-├── HEARTBEAT.md      # Session state scratchpad (can start empty)
-├── agent.yaml        # Per-workspace configuration (optional)
-├── .env              # API keys and secrets (optional)
-├── tools/            # Custom LangChain @tool functions (optional)
-└── crons/            # Scheduled task definitions (optional)
+├── agent/              # Identity and extensions
+│   ├── AGENT.md        # Capabilities and behavior guidelines
+│   ├── USER.md         # User context and preferences
+│   ├── SOUL.md         # Core personality and values
+│   ├── HEARTBEAT.md    # Session state scratchpad (agent-writable)
+│   ├── tools/          # Custom LangChain @tool functions
+│   └── skills/         # Skill directories
+├── config/             # Configuration (write-protected)
+│   ├── agent.yaml      # Per-workspace settings (model, channel, queue)
+│   ├── .env            # API keys and secrets
+│   └── crons/          # Scheduled task definitions
+├── data/               # Framework-managed state (write-protected)
+│   ├── TASKS.yaml      # Persistent task tracking
+│   ├── uploads/        # User-uploaded files
+│   └── ...             # Conversations DB, session state, token logs
+├── memory/             # Archived conversations and session logs
+│   ├── conversations/  # Conversation exports (markdown + JSON)
+│   └── logs/           # Heartbeat, cron, and sub-agent session logs
+└── workspace/          # Agent work area (default write target)
+    ├── downloads/      # Browser-downloaded files
+    └── screenshots/    # Browser screenshots
 ```
 
-The `openpaw init` command generates all required files with starter templates. Customize the markdown files to shape your agent's personality and purpose. Configure model, channel, and queue behavior in `agent.yaml`.
+The `openpaw init` command scaffolds this structure with starter templates. Customize the identity files in `agent/` to shape your agent's personality and purpose. Configure model, channel, and queue behavior in `config/agent.yaml`.
+
+Existing workspaces using the older flat layout are automatically migrated on first startup. The `data/` and `config/` directories are write-protected from agent filesystem tools. Write operations default to the `workspace/` directory unless an explicit path is provided.
 
 ## In-Chat Commands
 

--- a/openpaw/agent/metrics.py
+++ b/openpaw/agent/metrics.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
 
+from openpaw.core.paths import TOKEN_USAGE_JSONL
+
 logger = logging.getLogger(__name__)
 
 
@@ -94,7 +96,7 @@ def extract_metrics_from_callback(
 class TokenUsageLogger:
     """Append-only JSONL logger for token usage metrics.
 
-    Logs each agent invocation to {workspace}/.openpaw/token_usage.jsonl
+    Logs each agent invocation to {workspace}/data/token_usage.jsonl
     for session-level and workspace-level token tracking.
     """
 
@@ -105,7 +107,7 @@ class TokenUsageLogger:
             workspace_path: Path to the workspace directory.
         """
         self._workspace_path = Path(workspace_path)
-        self._log_path = self._workspace_path / ".openpaw" / "token_usage.jsonl"
+        self._log_path = self._workspace_path / str(TOKEN_USAGE_JSONL)
         self._lock = threading.Lock()
 
     def log(
@@ -158,7 +160,7 @@ class TokenUsageReader:
             workspace_path: Path to the workspace directory.
         """
         self._workspace_path = Path(workspace_path)
-        self._log_path = self._workspace_path / ".openpaw" / "token_usage.jsonl"
+        self._log_path = self._workspace_path / str(TOKEN_USAGE_JSONL)
 
     def tokens_today(self, timezone_str: str = "UTC") -> InvocationMetrics:
         """Aggregate all entries from today in the specified timezone.

--- a/openpaw/agent/session_logger.py
+++ b/openpaw/agent/session_logger.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from openpaw.agent.metrics import InvocationMetrics
+from openpaw.core.paths import MEMORY_LOGS_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +29,7 @@ class SessionLogger:
     """Writes agent session data to JSONL files.
 
     Session files are stored at:
-        {workspace_path}/memory/sessions/{session_type}/{name}_{timestamp}.jsonl
+        {workspace_path}/memory/logs/{session_type}/{name}_{timestamp}.jsonl
 
     These are readable by the main agent via read_file().
     """
@@ -42,7 +43,7 @@ class SessionLogger:
         """
         self._workspace_path = Path(workspace_path)
         self._session_type = session_type
-        self._sessions_dir = self._workspace_path / "memory" / "sessions" / session_type
+        self._sessions_dir = self._workspace_path / str(MEMORY_LOGS_DIR) / session_type
         self._current_path: Path | None = None
 
     def _ensure_dir(self) -> None:

--- a/openpaw/agent/tools/sandbox.py
+++ b/openpaw/agent/tools/sandbox.py
@@ -1,56 +1,107 @@
 """Sandbox path resolution for workspace-confined file operations."""
 
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+
+from openpaw.core.paths import AGENT_WRITABLE_FILES, WRITE_PROTECTED_DIRS
 
 
-def resolve_sandboxed_path(workspace_root: Path, path: str) -> Path:
+def _is_write_protected(relative_path: str) -> bool:
+    """Return True if the given workspace-relative path falls inside a write-protected directory.
+
+    Protection is based on path parts rather than string prefix matching, so
+    ``data/file.txt`` is protected (starts with ``data``) while a hypothetical
+    ``database/file.txt`` is not.
+
+    An explicit exception is made for paths listed in ``AGENT_WRITABLE_FILES``
+    (e.g. ``agent/HEARTBEAT.md``), which are always allowed regardless of
+    which directory they live under.
+
+    Args:
+        relative_path: Workspace-relative path string (no ``..``, no ``/`` prefix).
+
+    Returns:
+        True if the path is inside a write-protected directory, False otherwise.
+    """
+    # Normalise to a PurePosixPath so we work with parts consistently.
+    pure = PurePosixPath(relative_path)
+
+    # Explicit writable-file exception takes priority.
+    if str(pure) in AGENT_WRITABLE_FILES:
+        return False
+
+    # Walk from the full path upward, checking each ancestor against
+    # WRITE_PROTECTED_DIRS.  This catches both exact matches (``data``) and
+    # deeper paths (``data/uploads/file.txt``).
+    parts = pure.parts
+    for depth in range(1, len(parts) + 1):
+        ancestor = str(PurePosixPath(*parts[:depth]))
+        if ancestor in WRITE_PROTECTED_DIRS:
+            return True
+
+    return False
+
+
+def resolve_sandboxed_path(
+    workspace_root: Path,
+    path: str,
+    write_mode: bool = False,
+) -> Path:
     """Resolve and validate that a path is within the workspace sandbox.
 
-    Rejects:
-    - Absolute paths (starting with /)
-    - Home directory expansion (~)
-    - Path traversal (..)
-    - Access to .openpaw/ framework directory
+    Read mode (``write_mode=False``, the default):
+        Rejects absolute paths, home-directory expansion (``~``), and path
+        traversal (``..``).  No directory restrictions — the agent can read
+        any file within the workspace root, including ``data/``.
+
+    Write mode (``write_mode=True``):
+        All read-mode checks apply, plus writes to directories listed in
+        ``WRITE_PROTECTED_DIRS`` (``data/``, ``config/``, ``memory/logs``,
+        ``memory/conversations``) are blocked.  The sole exception is
+        ``agent/HEARTBEAT.md``, which is listed in ``AGENT_WRITABLE_FILES``
+        and is always permitted.
 
     Args:
         workspace_root: The workspace root directory (must be resolved/absolute).
         path: Relative path string to resolve.
+        write_mode: When True, enforce write-protection rules.
 
     Returns:
         Resolved absolute Path within the workspace.
 
     Raises:
-        ValueError: If the path attempts to escape the sandbox or access protected dirs.
+        ValueError: If the path attempts to escape the sandbox or violates
+            a write-protection rule.
     """
-    # Reject absolute paths
+    # Reject absolute paths.
     if Path(path).is_absolute():
         raise ValueError(
             f"Absolute paths not allowed in sandbox. Use relative paths from workspace root. Got: {path}"
         )
 
-    # Reject path traversal attempts
+    # Reject path traversal attempts.
     if ".." in Path(path).parts:
         raise ValueError(
             f"Path traversal (..) not allowed in sandbox. Got: {path}"
         )
 
-    # Reject home directory expansion
+    # Reject home directory expansion.
     if path.startswith("~"):
         raise ValueError(
             f"Home directory expansion (~) not allowed in sandbox. Got: {path}"
         )
 
-    # Reject framework internal directory
-    if any(part == ".openpaw" for part in Path(path).parts):
+    # Enforce write protection when in write mode.
+    if write_mode and _is_write_protected(path):
         raise ValueError(
-            "Access to .openpaw/ directory is not allowed. "
-            "This directory contains framework internals."
+            f"Write access to '{path}' is not allowed. "
+            "This path is inside a framework-managed directory. "
+            "Write files to the 'workspace/' directory instead."
         )
 
-    # Resolve path relative to workspace root
+    # Resolve the path relative to workspace root.
     full_path = (workspace_root / path).resolve()
 
-    # Verify resolved path stays within workspace
+    # Verify the resolved path stays within the workspace.
     try:
         full_path.relative_to(workspace_root)
     except ValueError:

--- a/openpaw/builtins/processors/file_persistence.py
+++ b/openpaw/builtins/processors/file_persistence.py
@@ -12,6 +12,7 @@ from openpaw.builtins.base import (
     BuiltinType,
     ProcessorResult,
 )
+from openpaw.core.paths import UPLOADS_DIR
 from openpaw.core.prompts.processors import FILE_RECEIVED_TEMPLATE
 from openpaw.core.timezone import workspace_now
 from openpaw.core.utils import deduplicate_path, sanitize_filename
@@ -205,7 +206,7 @@ class FilePersistenceProcessor(BaseBuiltinProcessor):
 
         # Build target directory (use workspace timezone for date partition)
         today = workspace_now(self._timezone).strftime("%Y-%m-%d")
-        target_dir = Path(self.workspace_path) / "uploads" / today
+        target_dir = Path(self.workspace_path) / str(UPLOADS_DIR) / today
         target_dir.mkdir(parents=True, exist_ok=True)
 
         # Build target path and deduplicate

--- a/openpaw/builtins/tools/browser/session.py
+++ b/openpaw/builtins/tools/browser/session.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from openpaw.builtins.tools.browser.security import DomainPolicy
 from openpaw.builtins.tools.browser.snapshot import SnapshotTransformer
+from openpaw.core.paths import BROWSER_COOKIES_JSON
 
 logger = logging.getLogger(__name__)
 
@@ -55,11 +56,11 @@ class BrowserSession:
         # Paths (workspace-relative)
         workspace_path = Path(config["workspace_path"])
         self.workspace_path = workspace_path
-        self.downloads_dir = workspace_path / config.get("downloads_dir", "downloads")
+        self.downloads_dir = workspace_path / config.get("downloads_dir", "workspace/downloads")
         self.screenshots_dir = workspace_path / config.get(
-            "screenshots_dir", "screenshots"
+            "screenshots_dir", "workspace/screenshots"
         )
-        self.cookie_file = workspace_path / ".openpaw" / "browser_cookies.json"
+        self.cookie_file = workspace_path / str(BROWSER_COOKIES_JSON)
 
         # Create directories if needed
         self.downloads_dir.mkdir(parents=True, exist_ok=True)
@@ -716,7 +717,7 @@ class BrowserSession:
             return
 
         try:
-            # Ensure .openpaw directory exists
+            # Ensure the data/ directory exists
             self.cookie_file.parent.mkdir(parents=True, exist_ok=True)
 
             # Save storage state

--- a/openpaw/cli_init.py
+++ b/openpaw/cli_init.py
@@ -5,6 +5,25 @@ import re
 import sys
 from pathlib import Path
 
+from openpaw.core.paths import (
+    AGENT_DIR,
+    AGENT_MD,
+    AGENT_YAML,
+    CONFIG_DIR,
+    CRONS_DIR,
+    DATA_DIR,
+    DOT_ENV,
+    HEARTBEAT_MD,
+    MEMORY_CONVERSATIONS_DIR,
+    MEMORY_DIR,
+    MEMORY_LOGS_DIR,
+    SKILLS_DIR,
+    SOUL_MD,
+    TOOLS_DIR,
+    USER_MD,
+    WORKSPACE_DIR,
+)
+
 # ---------------------------------------------------------------------------
 # Template constants
 # ---------------------------------------------------------------------------
@@ -282,21 +301,36 @@ def _create_workspace(
 
     workspace_path.mkdir(parents=True, exist_ok=False)
 
-    # Write the four required markdown files, substituting {name} where used.
-    (workspace_path / "AGENT.md").write_text(
+    # Create all required subdirectories.
+    for subdir in [
+        AGENT_DIR,
+        TOOLS_DIR,
+        SKILLS_DIR,
+        CONFIG_DIR,
+        CRONS_DIR,
+        DATA_DIR,
+        MEMORY_DIR,
+        MEMORY_CONVERSATIONS_DIR,
+        MEMORY_LOGS_DIR,
+        WORKSPACE_DIR,
+    ]:
+        (workspace_path / str(subdir)).mkdir(parents=True, exist_ok=True)
+
+    # Write the four required identity files under agent/.
+    (workspace_path / str(AGENT_MD)).write_text(
         TEMPLATE_AGENT_MD.format(name=name), encoding="utf-8"
     )
-    (workspace_path / "USER.md").write_text(TEMPLATE_USER_MD, encoding="utf-8")
-    (workspace_path / "SOUL.md").write_text(
+    (workspace_path / str(USER_MD)).write_text(TEMPLATE_USER_MD, encoding="utf-8")
+    (workspace_path / str(SOUL_MD)).write_text(
         TEMPLATE_SOUL_MD.format(name=name), encoding="utf-8"
     )
-    (workspace_path / "HEARTBEAT.md").write_text(TEMPLATE_HEARTBEAT_MD, encoding="utf-8")
+    (workspace_path / str(HEARTBEAT_MD)).write_text(TEMPLATE_HEARTBEAT_MD, encoding="utf-8")
 
-    # Write optional but recommended files.
-    (workspace_path / "agent.yaml").write_text(
+    # Write config files under config/.
+    (workspace_path / str(AGENT_YAML)).write_text(
         _build_agent_yaml(name, channel, model), encoding="utf-8"
     )
-    (workspace_path / ".env").write_text(TEMPLATE_ENV, encoding="utf-8")
+    (workspace_path / str(DOT_ENV)).write_text(TEMPLATE_ENV, encoding="utf-8")
 
     return workspace_path
 
@@ -316,9 +350,9 @@ def _print_next_steps(workspace_path: Path, name: str) -> None:
     print(f"  Path: {workspace_path}/")
     print()
     print("Next steps:")
-    print("  1. Edit agent.yaml with your model and channel settings")
-    print("  2. Add API keys to .env")
-    print("  3. Customize AGENT.md, USER.md, and SOUL.md")
+    print("  1. Edit config/agent.yaml with your model and channel settings")
+    print("  2. Add API keys to config/.env")
+    print("  3. Customize agent/AGENT.md, agent/USER.md, and agent/SOUL.md")
     print(f"  4. Run: openpaw -c config.yaml -w {name}")
 
 

--- a/openpaw/core/config/models.py
+++ b/openpaw/core/config/models.py
@@ -10,6 +10,8 @@ from typing import Any, Literal
 from apscheduler.triggers.cron import CronTrigger
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from openpaw.core.paths import DOWNLOADS_DIR, SCREENSHOTS_DIR
+
 
 class QueueConfig(BaseModel):
     """Configuration for the command queue system."""
@@ -160,8 +162,8 @@ class BrowserBuiltinConfig(BuiltinItemConfig):
     blocked_domains: list[str] = Field(default_factory=list, description="Domain blocklist (takes precedence)")
     timeout_seconds: int = Field(default=30, description="Default timeout for browser operations")
     persist_cookies: bool = Field(default=False, description="Persist cookies across agent runs")
-    downloads_dir: str = Field(default="downloads", description="Directory for downloaded files")
-    screenshots_dir: str = Field(default="screenshots", description="Directory for screenshots")
+    downloads_dir: str = Field(default=str(DOWNLOADS_DIR), description="Directory for downloaded files")
+    screenshots_dir: str = Field(default=str(SCREENSHOTS_DIR), description="Directory for screenshots")
 
 
 class SpawnBuiltinConfig(BuiltinItemConfig):

--- a/openpaw/core/paths.py
+++ b/openpaw/core/paths.py
@@ -1,0 +1,103 @@
+"""Central workspace path constants.
+
+Single source of truth for all workspace-relative directory and file paths.
+Every module that constructs workspace paths should import from here.
+All paths are relative to the workspace root.
+"""
+
+from pathlib import PurePosixPath
+
+# ---------------------------------------------------------------------------
+# Top-level directories
+# ---------------------------------------------------------------------------
+
+AGENT_DIR = PurePosixPath("agent")
+CONFIG_DIR = PurePosixPath("config")
+DATA_DIR = PurePosixPath("data")
+MEMORY_DIR = PurePosixPath("memory")
+WORKSPACE_DIR = PurePosixPath("workspace")
+
+# ---------------------------------------------------------------------------
+# Agent identity files
+# ---------------------------------------------------------------------------
+
+AGENT_MD = AGENT_DIR / "AGENT.md"
+USER_MD = AGENT_DIR / "USER.md"
+SOUL_MD = AGENT_DIR / "SOUL.md"
+HEARTBEAT_MD = AGENT_DIR / "HEARTBEAT.md"
+IDENTITY_FILES = [AGENT_MD, USER_MD, SOUL_MD, HEARTBEAT_MD]
+
+# ---------------------------------------------------------------------------
+# Agent extension directories
+# ---------------------------------------------------------------------------
+
+TOOLS_DIR = AGENT_DIR / "tools"
+SKILLS_DIR = AGENT_DIR / "skills"
+TEAM_DIR = AGENT_DIR / "team"
+
+# ---------------------------------------------------------------------------
+# Config files
+# ---------------------------------------------------------------------------
+
+AGENT_YAML = CONFIG_DIR / "agent.yaml"
+DOT_ENV = CONFIG_DIR / ".env"
+CRONS_DIR = CONFIG_DIR / "crons"
+
+# ---------------------------------------------------------------------------
+# Data files (framework-managed, agent read-only via dedicated tools)
+# ---------------------------------------------------------------------------
+
+CONVERSATIONS_DB = DATA_DIR / "conversations.db"
+SESSIONS_JSON = DATA_DIR / "sessions.json"
+SUBAGENTS_YAML = DATA_DIR / "subagents.yaml"
+TOKEN_USAGE_JSONL = DATA_DIR / "token_usage.jsonl"
+VECTORS_DB = DATA_DIR / "vectors.db"
+BROWSER_COOKIES_JSON = DATA_DIR / "browser_cookies.json"
+DYNAMIC_CRONS_JSON = DATA_DIR / "dynamic_crons.json"
+HEARTBEAT_LOG_JSONL = DATA_DIR / "heartbeat_log.jsonl"
+TASKS_YAML = DATA_DIR / "TASKS.yaml"
+UPLOADS_DIR = DATA_DIR / "uploads"
+
+# ---------------------------------------------------------------------------
+# Memory directories
+# ---------------------------------------------------------------------------
+
+MEMORY_CONVERSATIONS_DIR = MEMORY_DIR / "conversations"
+MEMORY_LOGS_DIR = MEMORY_DIR / "logs"
+
+# ---------------------------------------------------------------------------
+# Workspace (agent work area — default write root)
+# ---------------------------------------------------------------------------
+
+DOWNLOADS_DIR = WORKSPACE_DIR / "downloads"
+SCREENSHOTS_DIR = WORKSPACE_DIR / "screenshots"
+
+# ---------------------------------------------------------------------------
+# Access control
+# ---------------------------------------------------------------------------
+
+# Known top-level directory names (used to detect explicit paths in write ops).
+# Paths whose first component matches one of these are NOT auto-prefixed with workspace/.
+TOP_LEVEL_DIRS: frozenset[str] = frozenset({
+    str(AGENT_DIR),
+    str(CONFIG_DIR),
+    str(DATA_DIR),
+    str(MEMORY_DIR),
+    str(WORKSPACE_DIR),
+})
+
+# Write-protected directories: agent filesystem tools may NOT write to these.
+# Paths are compared by parts, not string prefix, to avoid false matches.
+WRITE_PROTECTED_DIRS: frozenset[str] = frozenset({
+    str(DATA_DIR),
+    str(MEMORY_DIR / "logs"),
+    str(MEMORY_DIR / "conversations"),
+    str(CONFIG_DIR),
+})
+
+# Specific files within write-protected directories that the agent IS allowed
+# to write (via overwrite_file / edit_file).  These are absolute exceptions
+# to WRITE_PROTECTED_DIRS.
+AGENT_WRITABLE_FILES: frozenset[str] = frozenset({
+    str(HEARTBEAT_MD),
+})

--- a/openpaw/core/prompts/framework.py
+++ b/openpaw/core/prompts/framework.py
@@ -7,8 +7,9 @@ FRAMEWORK_ORIENTATION = (
     "You are a persistent autonomous agent running in the OpenPaw framework. "
     "Your workspace directory is your long-term memory—files you write today will "
     "be there tomorrow. You are encouraged to organize your workspace: create "
-    "subdirectories, maintain notes, keep state files. You can freely read, write, "
-    "and edit files in your workspace. This is YOUR space—use it to stay organized "
+    "subdirectories, maintain notes, keep state files. You can freely read files "
+    "throughout your workspace and write files in your workspace/ directory. "
+    "This is YOUR space—use workspace/ as your default write area to stay organized "
     "and maintain continuity across conversations."
 )
 
@@ -20,18 +21,23 @@ FRAMEWORK_ORIENTATION_TEMPLATE = (
     "All filesystem tools operate relative to your workspace root directory. "
     "Your workspace directory is your long-term memory—files you write today will "
     "be there tomorrow. You are encouraged to organize your workspace: create "
-    "subdirectories, maintain notes, keep state files. You can freely read, write, "
-    "and edit files in your workspace. This is YOUR space—use it to stay organized "
+    "subdirectories, maintain notes, keep state files. You can freely read files "
+    "throughout your workspace and write files in your workspace/ directory. "
+    "This is YOUR space—use workspace/ as your default write area to stay organized "
     "and maintain continuity across conversations."
 )
 
 # Workspace filesystem orientation - always included (filesystem tools always available)
 SECTION_WORKSPACE_FILESYSTEM = (
     "\n\n## Workspace Filesystem\n\n"
-    "Your workspace is NOT a code repository—it is your personal workspace directory. "
-    "All filesystem tool paths are relative to your workspace root. "
-    "Use relative paths like 'notes.md' or 'research/report.txt'. "
-    "Use ls('.') to see your workspace contents."
+    "Your workspace has five top-level directories:\n"
+    "- agent/ — Your identity files (AGENT.md, USER.md, SOUL.md, HEARTBEAT.md) and custom tools\n"
+    "- config/ — Configuration (agent.yaml, .env, crons/)\n"
+    "- data/ — Framework-managed state (tasks, sessions, uploads) — read via dedicated tools\n"
+    "- memory/ — Archived conversations and operational logs — read-only\n"
+    "- workspace/ — Your work area (default write root) — create files and directories here\n\n"
+    "Write operations default to workspace/. To write elsewhere, use explicit paths "
+    "(e.g., agent/HEARTBEAT.md). Use ls('.') to see your workspace contents."
 )
 
 
@@ -52,7 +58,7 @@ SECTION_HEARTBEAT = (
     "\n\n## Heartbeat System\n\n"
     "You receive periodic wake-up calls to check on ongoing work. Use these "
     "heartbeats to review tasks, monitor long-running operations, and send "
-    "proactive updates. HEARTBEAT.md is your scratchpad for things to check "
+    "proactive updates. agent/HEARTBEAT.md is your scratchpad for things to check "
     "on next time you wake up. If there's nothing requiring attention, respond "
     "with exactly 'HEARTBEAT_OK' to avoid sending unnecessary messages."
 )
@@ -60,8 +66,8 @@ SECTION_HEARTBEAT = (
 # Task management - conditional on task_tracker builtin
 SECTION_TASK_MANAGEMENT = (
     "\n\n## Task Management\n\n"
-    "You have a task tracking system (TASKS.yaml) for managing work across "
-    "sessions. Tasks persist—use them to remember what you're working on. "
+    "You have a task tracking system for managing work across sessions. "
+    "Tasks persist—use them to remember what you're working on. "
     "Future heartbeats will see your tasks and can continue where you left off.\n\n"
     "When starting work that may not complete in a single conversation turn, "
     "create a task to maintain continuity across heartbeats and conversations. "
@@ -166,8 +172,8 @@ SECTION_FILE_SHARING = (
 SECTION_FILE_UPLOADS = (
     "\n\n## File Uploads\n\n"
     "When users send you files (documents, images, audio, etc.), they are "
-    "automatically saved to your uploads/ directory, organized by date. "
-    "You'll see a notification in the message like [Saved to: uploads/...]. "
+    "automatically saved to your data/uploads/ directory, organized by date. "
+    "You'll see a notification in the message like [Saved to: data/uploads/...]. "
     "You can read, reference, and process these files using your filesystem tools. "
     "Supported document types (PDF, DOCX, etc.) are also automatically converted "
     "to markdown for easier reading."
@@ -293,7 +299,7 @@ def build_capability_summary(enabled_builtins: list[str] | None) -> str:
     ]
 
     if _is_enabled("task_tracker"):
-        capabilities.append("- **Task Tracking**: Persistent TASKS.yaml for cross-session work management")
+        capabilities.append("- **Task Tracking**: Persistent task tracking for cross-session work management")
     if _is_enabled("spawn"):
         capabilities.append("- **Sub-Agent Spawning**: Spawn background workers for concurrent tasks")
     if _is_enabled("browser"):

--- a/openpaw/core/prompts/heartbeat.py
+++ b/openpaw/core/prompts/heartbeat.py
@@ -17,7 +17,7 @@ Use your task management tools to review active work:
 4. Update task status and notes as you work through each item
 
 ## Step 2: Review HEARTBEAT.md
-Check your HEARTBEAT.md file for any non-task items requiring attention:
+Check your agent/HEARTBEAT.md file for any non-task items requiring attention:
 - Time-sensitive reminders or monitors
 - Pending status checks (PRs, builds, deployments)
 - User notifications that need to be sent
@@ -25,7 +25,7 @@ Check your HEARTBEAT.md file for any non-task items requiring attention:
 ## Step 3: Take Action or Stand Down
 If you found items needing attention:
 - Take appropriate action (check APIs, read files, notify user)
-- Update HEARTBEAT.md with completed items
+- Update agent/HEARTBEAT.md with completed items
 - Update task statuses with progress notes
 
 If nothing requires immediate attention, respond exactly: HEARTBEAT_OK

--- a/openpaw/core/workspace.py
+++ b/openpaw/core/workspace.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from openpaw.core.paths import AGENT_MD, HEARTBEAT_MD, SOUL_MD, USER_MD
 from openpaw.core.prompts.framework import (
     SECTION_AUTONOMOUS_PLANNING,
     SECTION_CONVERSATION_MEMORY,
@@ -60,10 +61,10 @@ class AgentWorkspace:
         its own AGENT.md or HEARTBEAT.md) to ensure the next prompt build
         uses current content.
         """
-        self.agent_md = self._read_file(self.path / "AGENT.md")
-        self.user_md = self._read_file(self.path / "USER.md")
-        self.soul_md = self._read_file(self.path / "SOUL.md")
-        self.heartbeat_md = self._read_file(self.path / "HEARTBEAT.md")
+        self.agent_md = self._read_file(self.path / str(AGENT_MD))
+        self.user_md = self._read_file(self.path / str(USER_MD))
+        self.soul_md = self._read_file(self.path / str(SOUL_MD))
+        self.heartbeat_md = self._read_file(self.path / str(HEARTBEAT_MD))
         logger.debug(f"Reloaded workspace files for: {self.name}")
 
     @staticmethod
@@ -140,8 +141,10 @@ class AgentWorkspace:
             entries = sorted(self.path.iterdir(), key=lambda p: p.name)
             for entry in entries:
                 name = entry.name
-                # Skip hidden files/dirs except .env
-                # (.openpaw/ is excluded by this rule — must remain invisible to agents)
+                # Skip hidden files/dirs.  In the new layout, .env lives at
+                # config/.env so there is no hidden file the agent needs to see
+                # at the workspace root.  Keep the `.env` exception for
+                # backward compatibility with workspaces not yet migrated.
                 if name.startswith(".") and name != ".env":
                     continue
                 if entry.is_dir():

--- a/openpaw/runtime/scheduling/heartbeat.py
+++ b/openpaw/runtime/scheduling/heartbeat.py
@@ -14,6 +14,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from openpaw.agent.session_logger import SessionLogger
 from openpaw.channels.base import ChannelAdapter
 from openpaw.core.config import HeartbeatConfig
+from openpaw.core.paths import HEARTBEAT_LOG_JSONL, HEARTBEAT_MD, TASKS_YAML
 from openpaw.core.prompts.heartbeat import (
     ACTIVE_TASKS_TEMPLATE,
     HEARTBEAT_PROMPT,
@@ -30,8 +31,6 @@ if TYPE_CHECKING:
     pass
 
 logger = logging.getLogger(__name__)
-
-HEARTBEAT_LOG_FILENAME = "heartbeat_log.jsonl"
 
 
 class HeartbeatScheduler:
@@ -181,7 +180,7 @@ class HeartbeatScheduler:
             task_summary is None if skipping or no active tasks, otherwise a formatted string.
             task_count is the number of active tasks found (0 if none or on error).
         """
-        heartbeat_md = self.workspace_path / "HEARTBEAT.md"
+        heartbeat_md = self.workspace_path / str(HEARTBEAT_MD)
         heartbeat_empty = True
         if heartbeat_md.exists():
             try:
@@ -190,7 +189,7 @@ class HeartbeatScheduler:
             except OSError:
                 heartbeat_empty = False  # Can't read = don't skip
 
-        tasks_file = self.workspace_path / "TASKS.yaml"
+        tasks_file = self.workspace_path / str(TASKS_YAML)
         active_tasks = []
         if tasks_file.exists():
             try:
@@ -240,7 +239,7 @@ class HeartbeatScheduler:
             response: Full agent response text.
             tools_used: List of tool names invoked during the heartbeat.
         """
-        log_path = self.workspace_path / HEARTBEAT_LOG_FILENAME
+        log_path = self.workspace_path / str(HEARTBEAT_LOG_JSONL)
         event: dict[str, Any] = {
             "timestamp": datetime.now(UTC).isoformat(),
             "workspace": self.workspace_name,

--- a/openpaw/runtime/scheduling/loader.py
+++ b/openpaw/runtime/scheduling/loader.py
@@ -7,12 +7,11 @@ import yaml
 
 from openpaw.core.config import check_unexpanded_vars, expand_env_vars_recursive
 from openpaw.core.config.models import CronDefinition
+from openpaw.core.paths import CRONS_DIR
 
 
 class CronLoader:
-    """Loads cron definitions from a workspace's crons/ directory."""
-
-    CRONS_DIR = "crons"
+    """Loads cron definitions from a workspace's config/crons/ directory."""
 
     def __init__(self, workspace_path: Path):
         """Initialize the cron loader.
@@ -21,7 +20,7 @@ class CronLoader:
             workspace_path: Path to the agent workspace root.
         """
         self.workspace_path = Path(workspace_path)
-        self.crons_path = self.workspace_path / self.CRONS_DIR
+        self.crons_path = self.workspace_path / str(CRONS_DIR)
 
     def load_all(self) -> list[CronDefinition]:
         """Load all cron definitions from the workspace.
@@ -42,7 +41,10 @@ class CronLoader:
                     raw_data: dict[str, Any] = yaml.safe_load(f) or {}
 
                 expanded_data = expand_env_vars_recursive(raw_data)
-                check_unexpanded_vars(expanded_data, source=f"crons/{cron_file.name}")
+                check_unexpanded_vars(
+                    expanded_data,
+                    source=f"config/crons/{cron_file.name}",
+                )
 
                 cron_def = CronDefinition(**expanded_data)
                 cron_definitions.append(cron_def)
@@ -73,6 +75,6 @@ class CronLoader:
             raw_data: dict[str, Any] = yaml.safe_load(f) or {}
 
         expanded_data = expand_env_vars_recursive(raw_data)
-        check_unexpanded_vars(expanded_data, source=f"crons/{name}")
+        check_unexpanded_vars(expanded_data, source=f"config/crons/{name}")
 
         return CronDefinition(**expanded_data)

--- a/openpaw/runtime/session/archiver.py
+++ b/openpaw/runtime/session/archiver.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
 
+from openpaw.core.paths import MEMORY_CONVERSATIONS_DIR
 from openpaw.core.timezone import format_for_display
 
 logger = logging.getLogger(__name__)
@@ -75,7 +76,7 @@ class ConversationArchive:
             ConversationArchive instance.
         """
         conversation_id = data["conversation_id"]
-        archive_dir = workspace_path / "memory" / "conversations"
+        archive_dir = workspace_path / str(MEMORY_CONVERSATIONS_DIR)
 
         return cls(
             conversation_id=conversation_id,
@@ -113,7 +114,7 @@ class ConversationArchiver:
         self._workspace_name = workspace_name
         self._timezone = timezone
         self._indexer = indexer
-        self._archive_dir = self._workspace_path / "memory" / "conversations"
+        self._archive_dir = self._workspace_path / str(MEMORY_CONVERSATIONS_DIR)
         self._archive_dir.mkdir(parents=True, exist_ok=True)
 
         logger.info(f"ConversationArchiver initialized: {self._archive_dir}")

--- a/openpaw/runtime/session/manager.py
+++ b/openpaw/runtime/session/manager.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from threading import Lock
 
+from openpaw.core.paths import SESSIONS_JSON
 from openpaw.model.session import SessionState
 
 logger = logging.getLogger(__name__)
@@ -32,9 +33,6 @@ class SessionManager:
         # Rotates to new conversation, returns old conversation ID for archiving
     """
 
-    OPENPAW_DIR = ".openpaw"
-    STATE_FILE = "sessions.json"
-
     def __init__(self, workspace_path: Path):
         """Initialize the session manager.
 
@@ -42,13 +40,12 @@ class SessionManager:
             workspace_path: Path to the agent workspace root.
         """
         self.workspace_path = Path(workspace_path)
-        self._openpaw_dir = self.workspace_path / self.OPENPAW_DIR
-        self._state_file = self._openpaw_dir / self.STATE_FILE
+        self._state_file = self.workspace_path / str(SESSIONS_JSON)
         self._lock = Lock()
         self._sessions: dict[str, SessionState] = {}
 
-        # Ensure .openpaw directory exists
-        self._openpaw_dir.mkdir(parents=True, exist_ok=True)
+        # Ensure the data/ directory exists
+        self._state_file.parent.mkdir(parents=True, exist_ok=True)
 
         # Load existing state
         self._load()

--- a/openpaw/stores/cron.py
+++ b/openpaw/stores/cron.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from threading import Lock
 
+from openpaw.core.paths import DYNAMIC_CRONS_JSON
 from openpaw.model.cron import DynamicCronTask
 
 logger = logging.getLogger(__name__)
@@ -19,11 +20,9 @@ logger = logging.getLogger(__name__)
 class DynamicCronStore:
     """Manages persistent storage of dynamically scheduled agent tasks.
 
-    Stores tasks in JSON format at {workspace_path}/dynamic_crons.json.
+    Stores tasks in JSON format at {workspace_path}/data/dynamic_crons.json.
     Thread-safe with file locking for concurrent access.
     """
-
-    STORAGE_FILENAME = "dynamic_crons.json"
 
     def __init__(self, workspace_path: Path):
         """Initialize the dynamic cron store.
@@ -32,11 +31,11 @@ class DynamicCronStore:
             workspace_path: Path to the agent workspace root.
         """
         self.workspace_path = Path(workspace_path)
-        self.storage_file = self.workspace_path / self.STORAGE_FILENAME
+        self.storage_file = self.workspace_path / str(DYNAMIC_CRONS_JSON)
         self._lock = Lock()
 
-        # Ensure workspace directory exists
-        self.workspace_path.mkdir(parents=True, exist_ok=True)
+        # Ensure the data/ directory exists
+        self.storage_file.parent.mkdir(parents=True, exist_ok=True)
 
         logger.info(f"DynamicCronStore initialized: {self.storage_file}")
 

--- a/openpaw/stores/subagent.py
+++ b/openpaw/stores/subagent.py
@@ -13,16 +13,17 @@ from typing import Any
 
 import yaml
 
+from openpaw.core.paths import SUBAGENTS_YAML
 from openpaw.model.subagent import SubAgentRequest, SubAgentResult, SubAgentStatus
 
 logger = logging.getLogger(__name__)
 
 
 class SubAgentStore:
-    """Manages persistent storage of sub-agent state in .openpaw/subagents.yaml.
+    """Manages persistent storage of sub-agent state in data/subagents.yaml.
 
     Provides CRUD operations for sub-agent requests and results with thread-safe
-    file access. State is stored in YAML format at {workspace}/.openpaw/subagents.yaml.
+    file access. State is stored in YAML format at {workspace}/data/subagents.yaml.
 
     Example:
         >>> store = SubAgentStore(Path("agent_workspaces/gilfoyle"))
@@ -39,7 +40,6 @@ class SubAgentStore:
         >>> store.save_result(result)
     """
 
-    STORAGE_FILENAME = ".openpaw/subagents.yaml"
     MAX_RESULT_SIZE = 50_000  # 50K char truncation (consistent with read_file 100K valve)
     VERSION = 1
 
@@ -52,12 +52,11 @@ class SubAgentStore:
         """
         self.workspace_path = Path(workspace_path)
         self.max_age_hours = max_age_hours
-        self.storage_file = self.workspace_path / self.STORAGE_FILENAME
+        self.storage_file = self.workspace_path / str(SUBAGENTS_YAML)
         self._lock = Lock()
 
-        # Ensure .openpaw directory exists
-        storage_dir = self.storage_file.parent
-        storage_dir.mkdir(parents=True, exist_ok=True)
+        # Ensure the data/ directory exists
+        self.storage_file.parent.mkdir(parents=True, exist_ok=True)
 
         # Clean up stale records on initialization
         self.cleanup_stale()

--- a/openpaw/stores/task.py
+++ b/openpaw/stores/task.py
@@ -13,16 +13,17 @@ from typing import Any
 
 import yaml
 
+from openpaw.core.paths import TASKS_YAML
 from openpaw.model.task import Task, TaskPriority, TaskStatus
 
 logger = logging.getLogger(__name__)
 
 
 class TaskStore:
-    """Manages persistent storage of task state in TASKS.yaml.
+    """Manages persistent storage of task state in data/TASKS.yaml.
 
     Provides CRUD operations for task management with thread-safe file access.
-    Tasks are stored in YAML format at {workspace_path}/TASKS.yaml.
+    Tasks are stored in YAML format at {workspace_path}/data/TASKS.yaml.
 
     Example:
         >>> store = TaskStore(Path("agent_workspaces/gilfoyle"))
@@ -37,7 +38,6 @@ class TaskStore:
         >>> store.update(task.id, status=TaskStatus.COMPLETED)
     """
 
-    STORAGE_FILENAME = "TASKS.yaml"
     VERSION = 1
 
     def __init__(self, workspace_path: Path):
@@ -47,11 +47,11 @@ class TaskStore:
             workspace_path: Path to the agent workspace root.
         """
         self.workspace_path = Path(workspace_path)
-        self.storage_file = self.workspace_path / self.STORAGE_FILENAME
+        self.storage_file = self.workspace_path / str(TASKS_YAML)
         self._lock = Lock()
 
-        # Ensure workspace directory exists
-        self.workspace_path.mkdir(parents=True, exist_ok=True)
+        # Ensure the data/ directory exists
+        self.storage_file.parent.mkdir(parents=True, exist_ok=True)
 
         logger.info(f"TaskStore initialized: {self.storage_file}")
 

--- a/openpaw/stores/vector/factory.py
+++ b/openpaw/stores/vector/factory.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from openpaw.core.paths import VECTORS_DB
 from openpaw.stores.vector.base import BaseVectorStore
 from openpaw.stores.vector.embeddings import BaseEmbeddingProvider
 
@@ -27,7 +28,7 @@ def create_vector_store(provider: str, config: dict[str, Any], workspace_path: P
     if provider == "sqlite_vec":
         from openpaw.stores.vector.sqlite_vec import SqliteVecStore
 
-        db_path = workspace_path / ".openpaw" / "vectors.db"
+        db_path = workspace_path / str(VECTORS_DB)
         db_path.parent.mkdir(parents=True, exist_ok=True)
 
         return SqliteVecStore(

--- a/openpaw/stores/vector/sqlite_vec.py
+++ b/openpaw/stores/vector/sqlite_vec.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 class SqliteVecStore(BaseVectorStore):
     """sqlite-vec backed vector store.
 
-    Storage: {workspace}/.openpaw/vectors.db
+    Storage: {workspace}/data/vectors.db
     Uses aiosqlite + sqlite-vec extension for vector similarity search.
 
     Tables:

--- a/openpaw/workspace/migration.py
+++ b/openpaw/workspace/migration.py
@@ -1,0 +1,292 @@
+"""Workspace layout migration from flat to structured directory layout.
+
+Runs automatically on workspace startup. Moves files from legacy locations
+to the new directory structure. Idempotent — safe to run multiple times.
+
+Legacy layout (flat):
+    {workspace}/
+        AGENT.md, USER.md, SOUL.md, HEARTBEAT.md
+        agent.yaml, .env
+        TASKS.yaml, dynamic_crons.json, heartbeat_log.jsonl
+        tools/, skills/, crons/, uploads/, downloads/, screenshots/
+        .openpaw/conversations.db, .openpaw/sessions.json, ...
+        memory/sessions/{type}/
+
+New structured layout:
+    {workspace}/
+        agent/        — identity files and extensions
+        config/       — agent.yaml, .env, crons/
+        data/         — framework-managed state (conversations.db, etc.)
+        memory/       — conversations/ and logs/
+        workspace/    — agent work area (downloads/, screenshots/)
+"""
+
+import logging
+import shutil
+from pathlib import Path
+
+from openpaw.core.paths import (
+    AGENT_DIR,
+    AGENT_MD,
+    AGENT_YAML,
+    BROWSER_COOKIES_JSON,
+    CONFIG_DIR,
+    CONVERSATIONS_DB,
+    CRONS_DIR,
+    DATA_DIR,
+    DOT_ENV,
+    DOWNLOADS_DIR,
+    DYNAMIC_CRONS_JSON,
+    HEARTBEAT_LOG_JSONL,
+    HEARTBEAT_MD,
+    MEMORY_CONVERSATIONS_DIR,
+    MEMORY_DIR,
+    MEMORY_LOGS_DIR,
+    SCREENSHOTS_DIR,
+    SESSIONS_JSON,
+    SKILLS_DIR,
+    SOUL_MD,
+    SUBAGENTS_YAML,
+    TASKS_YAML,
+    TOKEN_USAGE_JSONL,
+    TOOLS_DIR,
+    UPLOADS_DIR,
+    USER_MD,
+    VECTORS_DB,
+    WORKSPACE_DIR,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Top-level directories created during migration
+# ---------------------------------------------------------------------------
+
+_TARGET_DIRS = [
+    AGENT_DIR,
+    CONFIG_DIR,
+    DATA_DIR,
+    MEMORY_DIR,
+    WORKSPACE_DIR,
+    MEMORY_CONVERSATIONS_DIR,
+    MEMORY_LOGS_DIR,
+]
+
+# ---------------------------------------------------------------------------
+# File migration table: (old_relative, new_relative)
+# ---------------------------------------------------------------------------
+
+_FILE_MIGRATIONS = [
+    # Identity files → agent/
+    ("AGENT.md",      AGENT_MD),
+    ("USER.md",       USER_MD),
+    ("SOUL.md",       SOUL_MD),
+    ("HEARTBEAT.md",  HEARTBEAT_MD),
+    # Config → config/
+    ("agent.yaml",    AGENT_YAML),
+    (".env",          DOT_ENV),
+    # Root-level state → data/
+    ("TASKS.yaml",           TASKS_YAML),
+    ("dynamic_crons.json",   DYNAMIC_CRONS_JSON),
+    ("heartbeat_log.jsonl",  HEARTBEAT_LOG_JSONL),
+    # .openpaw/ contents → data/
+    (".openpaw/conversations.db",    CONVERSATIONS_DB),
+    (".openpaw/sessions.json",       SESSIONS_JSON),
+    (".openpaw/subagents.yaml",      SUBAGENTS_YAML),
+    (".openpaw/token_usage.jsonl",   TOKEN_USAGE_JSONL),
+    (".openpaw/vectors.db",          VECTORS_DB),
+    (".openpaw/browser_cookies.json", BROWSER_COOKIES_JSON),
+    # SQLite WAL/SHM companion files (handled separately for clarity)
+    (".openpaw/conversations.db-wal", DATA_DIR / "conversations.db-wal"),
+    (".openpaw/conversations.db-shm", DATA_DIR / "conversations.db-shm"),
+]
+
+# ---------------------------------------------------------------------------
+# Directory migration table: (old_relative, new_relative)
+# ---------------------------------------------------------------------------
+
+_DIR_MIGRATIONS = [
+    # Extension directories → agent/
+    ("tools",    TOOLS_DIR),
+    ("skills",   SKILLS_DIR),
+    # Config → config/
+    ("crons",    CRONS_DIR),
+    # Data → data/
+    ("uploads",  UPLOADS_DIR),
+    # Agent work area → workspace/
+    ("downloads",   DOWNLOADS_DIR),
+    ("screenshots", SCREENSHOTS_DIR),
+    # memory/sessions → memory/logs (rename)
+    ("memory/sessions", MEMORY_LOGS_DIR),
+]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def migrate_workspace(workspace_path: Path) -> list[str]:
+    """Migrate a workspace from the legacy flat layout to the structured layout.
+
+    Creates target directories, moves files and directories from their old
+    locations to new locations, then cleans up the (now-empty) .openpaw/
+    directory.
+
+    This function is idempotent. If a file or directory already exists at the
+    target location, the migration for that item is skipped and a warning is
+    logged. Existing data is never overwritten or deleted.
+
+    Args:
+        workspace_path: Absolute path to the workspace root directory.
+
+    Returns:
+        A list of human-readable action strings describing what was moved.
+        Returns an empty list when no migration was needed.
+    """
+    actions: list[str] = []
+
+    _ensure_target_dirs(workspace_path, actions)
+
+    for old_rel, new_rel in _FILE_MIGRATIONS:
+        _migrate_file(workspace_path, old_rel, str(new_rel), actions)
+
+    for old_rel, new_rel in _DIR_MIGRATIONS:
+        _migrate_dir(workspace_path, old_rel, str(new_rel), actions)
+
+    _cleanup_empty_dir(workspace_path / ".openpaw", actions)
+
+    return actions
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_target_dirs(workspace: Path, actions: list[str]) -> None:
+    """Create all target directories that do not yet exist.
+
+    ``memory/logs/`` is skipped when ``memory/sessions/`` is still present: the
+    directory migration that renames sessions → logs will create it.  Creating
+    the empty target first would block the rename and leave the content stranded
+    in ``memory/sessions/``.
+    """
+    legacy_sessions = workspace / "memory" / "sessions"
+
+    for rel_dir in _TARGET_DIRS:
+        target = workspace / str(rel_dir)
+
+        # Defer memory/logs creation when the rename migration will handle it.
+        if rel_dir == MEMORY_LOGS_DIR and legacy_sessions.exists():
+            continue
+
+        if not target.exists():
+            target.mkdir(parents=True, exist_ok=True)
+            msg = f"Created {rel_dir}/"
+            actions.append(msg)
+            logger.info("Migration: %s", msg)
+
+
+def _migrate_file(
+    workspace: Path,
+    old: str,
+    new: str,
+    actions: list[str],
+) -> None:
+    """Move a single file from *old* to *new* if the old path exists.
+
+    Skips the move if the target path already exists (logs a warning so the
+    operator knows there is a conflict). The source file is left in place when
+    skipped — data is never deleted.
+
+    Args:
+        workspace: Workspace root directory.
+        old: Relative path of the source file.
+        new: Relative path of the destination file.
+        actions: Accumulator list for human-readable action strings.
+    """
+    src = workspace / old
+    dst = workspace / new
+
+    if not src.exists():
+        return
+
+    if dst.exists():
+        logger.warning(
+            "Migration conflict: cannot move %s → %s (destination already exists). "
+            "Leaving source in place.",
+            old,
+            new,
+        )
+        return
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    src.rename(dst)
+    msg = f"Moved {old} → {new}"
+    actions.append(msg)
+    logger.info("Migration: %s", msg)
+
+
+def _migrate_dir(
+    workspace: Path,
+    old: str,
+    new: str,
+    actions: list[str],
+) -> None:
+    """Move a directory from *old* to *new* if the old path exists.
+
+    Uses :func:`shutil.move` to handle cross-filesystem moves. Skips the move
+    if the target path already exists (logs a warning). The source directory is
+    left in place when skipped — data is never deleted.
+
+    Args:
+        workspace: Workspace root directory.
+        old: Relative path of the source directory.
+        new: Relative path of the destination directory.
+        actions: Accumulator list for human-readable action strings.
+    """
+    src = workspace / old
+    dst = workspace / new
+
+    if not src.exists():
+        return
+
+    if dst.exists():
+        logger.warning(
+            "Migration conflict: cannot move %s → %s (destination already exists). "
+            "Leaving source in place.",
+            old,
+            new,
+        )
+        return
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(src), str(dst))
+    msg = f"Moved {old}/ → {new}/"
+    actions.append(msg)
+    logger.info("Migration: %s", msg)
+
+
+def _cleanup_empty_dir(dir_path: Path, actions: list[str]) -> None:
+    """Remove *dir_path* if it exists and is empty.
+
+    Performs no action when the directory does not exist or still contains
+    files (which would indicate un-migrated items).
+
+    Args:
+        dir_path: Absolute path to the directory to (possibly) remove.
+        actions: Accumulator list for human-readable action strings.
+    """
+    if not dir_path.exists():
+        return
+
+    try:
+        dir_path.rmdir()  # Only succeeds when directory is empty
+        rel = dir_path.name
+        msg = f"Removed empty {rel}/"
+        actions.append(msg)
+        logger.info("Migration: %s", msg)
+    except OSError:
+        # Directory still has contents — leave it alone.
+        pass

--- a/tests/test_agent_metrics_integration.py
+++ b/tests/test_agent_metrics_integration.py
@@ -16,10 +16,12 @@ def mock_workspace(tmp_path: Path) -> AgentWorkspace:
     workspace_dir.mkdir()
 
     # Create required markdown files
-    (workspace_dir / "AGENT.md").write_text("# Agent\nTest agent")
-    (workspace_dir / "USER.md").write_text("# User\nTest user")
-    (workspace_dir / "SOUL.md").write_text("# Soul\nTest soul")
-    (workspace_dir / "HEARTBEAT.md").write_text("")
+    agent_dir = workspace_dir / "agent"
+    agent_dir.mkdir()
+    (agent_dir / "AGENT.md").write_text("# Agent\nTest agent")
+    (agent_dir / "USER.md").write_text("# User\nTest user")
+    (agent_dir / "SOUL.md").write_text("# Soul\nTest soul")
+    (agent_dir / "HEARTBEAT.md").write_text("")
 
     workspace = Mock(spec=AgentWorkspace)
     workspace.name = "test_workspace"

--- a/tests/test_browser_session.py
+++ b/tests/test_browser_session.py
@@ -24,8 +24,8 @@ def config(tmp_path: Path) -> dict:
         "viewport_width": 1280,
         "viewport_height": 720,
         "timeout_seconds": 30,
-        "downloads_dir": "downloads",
-        "screenshots_dir": "screenshots",
+        "downloads_dir": "workspace/downloads",
+        "screenshots_dir": "workspace/screenshots",
         "persist_cookies": False,
         "allowed_domains": [],
         "blocked_domains": [],
@@ -385,7 +385,7 @@ async def test_cookie_persistence_saves_on_close(config: dict, tmp_path: Path, m
         await session.close()
 
     # Check cookie file was created
-    cookie_file = tmp_path / ".openpaw" / "browser_cookies.json"
+    cookie_file = tmp_path / "data" / "browser_cookies.json"
     assert cookie_file.exists()
 
     with open(cookie_file) as f:
@@ -399,7 +399,7 @@ async def test_cookie_persistence_loads_on_launch(config: dict, tmp_path: Path, 
     config["persist_cookies"] = True
 
     # Create cookie file
-    cookie_file = tmp_path / ".openpaw" / "browser_cookies.json"
+    cookie_file = tmp_path / "data" / "browser_cookies.json"
     cookie_file.parent.mkdir(parents=True, exist_ok=True)
     storage_state = {"cookies": [{"name": "test", "value": "456"}], "origins": []}
     with open(cookie_file, "w") as f:
@@ -461,7 +461,7 @@ async def test_screenshot_saves_to_workspace(config: dict, tmp_path: Path, mock_
         result = await session.screenshot()
 
     assert "screenshot" in result.lower()
-    assert "screenshots/" in result
+    assert "workspace/screenshots/" in result
     mock_playwright["page"].screenshot.assert_called_once()
 
 

--- a/tests/test_cron_dynamic.py
+++ b/tests/test_cron_dynamic.py
@@ -136,7 +136,7 @@ class TestDynamicCronStore:
 
         assert workspace.exists()
         assert workspace.is_dir()
-        assert store.storage_file == workspace / "dynamic_crons.json"
+        assert store.storage_file == workspace / "data" / "dynamic_crons.json"
 
     def test_load_empty_returns_empty_list(self, tmp_path: Any) -> None:
         """Test loading from non-existent file returns empty list."""

--- a/tests/test_cron_yml_support.py
+++ b/tests/test_cron_yml_support.py
@@ -19,13 +19,13 @@ class TestCronLoaderYmlSupport:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir) / "test_workspace"
             workspace.mkdir()
-            crons_dir = workspace / "crons"
-            crons_dir.mkdir()
+            crons_dir = workspace / "config" / "crons"
+            crons_dir.mkdir(parents=True, exist_ok=True)
             yield workspace
 
     def test_load_all_includes_yml_files(self, workspace_path):
         """Test that load_all() includes both .yaml and .yml files."""
-        crons_dir = workspace_path / "crons"
+        crons_dir = workspace_path / "config" / "crons"
 
         # Create .yaml file
         yaml_cron = {
@@ -59,7 +59,7 @@ class TestCronLoaderYmlSupport:
 
     def test_load_all_sorted_order(self, workspace_path):
         """Test that .yaml and .yml files are loaded in sorted order."""
-        crons_dir = workspace_path / "crons"
+        crons_dir = workspace_path / "config" / "crons"
 
         # Create files in non-alphabetical order
         for name in ["c.yml", "a.yaml", "b.yml"]:
@@ -83,7 +83,7 @@ class TestCronLoaderYmlSupport:
 
     def test_load_one_prefers_yaml_then_yml(self, workspace_path):
         """Test that load_one() checks .yaml first, then .yml."""
-        crons_dir = workspace_path / "crons"
+        crons_dir = workspace_path / "config" / "crons"
 
         yml_cron = {
             "name": "test-cron",
@@ -103,7 +103,7 @@ class TestCronLoaderYmlSupport:
 
     def test_load_one_yaml_takes_precedence(self, workspace_path):
         """Test that .yaml takes precedence over .yml when both exist."""
-        crons_dir = workspace_path / "crons"
+        crons_dir = workspace_path / "config" / "crons"
 
         # Create both .yaml and .yml
         yaml_cron = {
@@ -156,20 +156,22 @@ class TestWorkspaceLoaderYmlSupport:
             workspace = root / "test_workspace"
             workspace.mkdir()
 
-            # Create required workspace files
+            # Create required workspace files in agent/ subdirectory
+            agent_dir = workspace / "agent"
+            agent_dir.mkdir(parents=True, exist_ok=True)
             for filename in ["AGENT.md", "USER.md", "SOUL.md", "HEARTBEAT.md"]:
-                (workspace / filename).write_text(f"# {filename}\n")
+                (agent_dir / filename).write_text(f"# {filename}\n")
 
-            # Create crons directory
-            crons_dir = workspace / "crons"
-            crons_dir.mkdir()
+            # Create crons directory under config/
+            crons_dir = workspace / "config" / "crons"
+            crons_dir.mkdir(parents=True, exist_ok=True)
 
             yield root
 
     def test_workspace_loader_includes_yml_crons(self, workspaces_root):
         """Test that WorkspaceLoader._load_crons() includes .yml files."""
         workspace_path = workspaces_root / "test_workspace"
-        crons_dir = workspace_path / "crons"
+        crons_dir = workspace_path / "config" / "crons"
 
         # Create .yaml file
         yaml_cron = {
@@ -204,7 +206,7 @@ class TestWorkspaceLoaderYmlSupport:
     def test_workspace_loader_crons_sorted(self, workspaces_root):
         """Test that crons are loaded in sorted order."""
         workspace_path = workspaces_root / "test_workspace"
-        crons_dir = workspace_path / "crons"
+        crons_dir = workspace_path / "config" / "crons"
 
         # Create files in non-alphabetical order
         for name in ["z.yml", "a.yaml", "m.yml"]:
@@ -229,7 +231,7 @@ class TestWorkspaceLoaderYmlSupport:
     def test_workspace_loader_handles_invalid_yml_gracefully(self, workspaces_root):
         """Test that invalid .yml files are logged as warnings, not errors."""
         workspace_path = workspaces_root / "test_workspace"
-        crons_dir = workspace_path / "crons"
+        crons_dir = workspace_path / "config" / "crons"
 
         # Create invalid .yml file
         with (crons_dir / "invalid.yml").open("w") as f:

--- a/tests/test_docling_processor.py
+++ b/tests/test_docling_processor.py
@@ -465,7 +465,7 @@ async def test_saved_path_reads_from_disk(
 ):
     """Verify that processor reads from saved_path when available."""
     # Create a saved file on disk
-    uploads_dir = workspace_path / "uploads" / "2026-02-07"
+    uploads_dir = workspace_path / "data" / "uploads" / "2026-02-07"
     uploads_dir.mkdir(parents=True, exist_ok=True)
     source_file = uploads_dir / "report.pdf"
     source_file.write_bytes(b"%PDF-1.4 fake pdf content")
@@ -476,7 +476,7 @@ async def test_saved_path_reads_from_disk(
             data=None,  # No data - should read from saved_path
             mime_type="application/pdf",
             filename="report.pdf",
-            saved_path="uploads/2026-02-07/report.pdf",
+            saved_path="data/uploads/2026-02-07/report.pdf",
         )
     ]
 
@@ -509,7 +509,7 @@ async def test_saved_path_reads_from_disk(
     assert "# Report" in md_file.read_text()
 
     # Verify attachment metadata was set
-    assert sample_message.attachments[0].metadata.get("processed_path") == "uploads/2026-02-07/report.md"
+    assert sample_message.attachments[0].metadata.get("processed_path") == "data/uploads/2026-02-07/report.md"
 
 
 @pytest.mark.asyncio
@@ -563,7 +563,7 @@ async def test_sibling_md_written(
 ):
     """Verify that .md file is written as sibling to source file."""
     # Create a saved file on disk
-    uploads_dir = workspace_path / "uploads" / "2026-02-07"
+    uploads_dir = workspace_path / "data" / "uploads" / "2026-02-07"
     uploads_dir.mkdir(parents=True, exist_ok=True)
     source_file = uploads_dir / "document.pdf"
     source_file.write_bytes(b"%PDF-1.4 content")
@@ -574,7 +574,7 @@ async def test_sibling_md_written(
             data=None,
             mime_type="application/pdf",
             filename="document.pdf",
-            saved_path="uploads/2026-02-07/document.pdf",
+            saved_path="data/uploads/2026-02-07/document.pdf",
         )
     ]
 
@@ -616,7 +616,7 @@ async def test_processed_path_metadata_set(
 ):
     """Verify that attachment.metadata['processed_path'] is set correctly."""
     # Create a saved file on disk
-    uploads_dir = workspace_path / "uploads" / "2026-02-07"
+    uploads_dir = workspace_path / "data" / "uploads" / "2026-02-07"
     uploads_dir.mkdir(parents=True, exist_ok=True)
     source_file = uploads_dir / "test.pdf"
     source_file.write_bytes(b"%PDF content")
@@ -626,7 +626,7 @@ async def test_processed_path_metadata_set(
         data=None,
         mime_type="application/pdf",
         filename="test.pdf",
-        saved_path="uploads/2026-02-07/test.pdf",
+        saved_path="data/uploads/2026-02-07/test.pdf",
     )
     sample_message.attachments = [attachment]
 
@@ -652,7 +652,7 @@ async def test_processed_path_metadata_set(
     # Verify processed_path metadata is set
     assert attachment.metadata is not None
     assert "processed_path" in attachment.metadata
-    assert attachment.metadata["processed_path"] == "uploads/2026-02-07/test.md"
+    assert attachment.metadata["processed_path"] == "data/uploads/2026-02-07/test.md"
 
 
 # ============================================================================

--- a/tests/test_extra_model_kwargs.py
+++ b/tests/test_extra_model_kwargs.py
@@ -24,10 +24,12 @@ def mock_workspace(tmp_path: Path) -> AgentWorkspace:
     workspace_path = tmp_path / "test_workspace"
     workspace_path.mkdir()
 
-    (workspace_path / "AGENT.md").write_text("Test agent")
-    (workspace_path / "USER.md").write_text("Test user")
-    (workspace_path / "SOUL.md").write_text("Test soul")
-    (workspace_path / "HEARTBEAT.md").write_text("Test heartbeat")
+    agent_dir = workspace_path / "agent"
+    agent_dir.mkdir()
+    (agent_dir / "AGENT.md").write_text("Test agent")
+    (agent_dir / "USER.md").write_text("Test user")
+    (agent_dir / "SOUL.md").write_text("Test soul")
+    (agent_dir / "HEARTBEAT.md").write_text("Test heartbeat")
 
     workspace = Mock(spec=AgentWorkspace)
     workspace.path = workspace_path

--- a/tests/test_file_persistence.py
+++ b/tests/test_file_persistence.py
@@ -56,7 +56,7 @@ async def test_single_document_saved(processor, sample_message, temp_workspace):
     result = await processor.process_inbound(sample_message)
 
     # Verify file was saved
-    uploads_dir = Path(temp_workspace) / "uploads"
+    uploads_dir = Path(temp_workspace) / "data" / "uploads"
     assert uploads_dir.exists()
 
     # Find the saved file (date-based subdirectory)
@@ -68,7 +68,7 @@ async def test_single_document_saved(processor, sample_message, temp_workspace):
 
     # Verify saved_path is set
     assert attachment.saved_path is not None
-    assert attachment.saved_path.startswith("uploads/")
+    assert attachment.saved_path.startswith("data/uploads/")
     assert attachment.saved_path.endswith("report.pdf")
 
     # Verify content enrichment
@@ -115,7 +115,7 @@ async def test_multiple_attachments(processor, sample_message, temp_workspace):
     result = await processor.process_inbound(sample_message)
 
     # Verify all files saved
-    uploads_dir = Path(temp_workspace) / "uploads"
+    uploads_dir = Path(temp_workspace) / "data" / "uploads"
     saved_files = list(uploads_dir.rglob("*"))
     saved_files = [f for f in saved_files if f.is_file()]
     assert len(saved_files) == 3
@@ -123,7 +123,7 @@ async def test_multiple_attachments(processor, sample_message, temp_workspace):
     # Verify all saved_paths set
     for attachment in attachments:
         assert attachment.saved_path is not None
-        assert attachment.saved_path.startswith("uploads/")
+        assert attachment.saved_path.startswith("data/uploads/")
 
     # Verify all listed in content
     assert "report.pdf" in result.message.content
@@ -149,7 +149,7 @@ async def test_audio_no_filename(processor, sample_message, temp_workspace):
     await processor.process_inbound(sample_message)
 
     # Verify filename generated
-    uploads_dir = Path(temp_workspace) / "uploads"
+    uploads_dir = Path(temp_workspace) / "data" / "uploads"
     saved_files = list(uploads_dir.rglob("*.ogg"))
     assert len(saved_files) == 1
     assert saved_files[0].name.startswith("voice_msg123")
@@ -171,7 +171,7 @@ async def test_photo_no_filename(processor, sample_message, temp_workspace):
     await processor.process_inbound(sample_message)
 
     # Verify filename generated
-    uploads_dir = Path(temp_workspace) / "uploads"
+    uploads_dir = Path(temp_workspace) / "data" / "uploads"
     saved_files = list(uploads_dir.rglob("*.jpg"))
     assert len(saved_files) == 1
     assert saved_files[0].name.startswith("photo_msg123")
@@ -197,7 +197,7 @@ async def test_file_too_large(processor, sample_message, temp_workspace):
     result = await processor.process_inbound(sample_message)
 
     # Verify file NOT saved
-    uploads_dir = Path(temp_workspace) / "uploads"
+    uploads_dir = Path(temp_workspace) / "data" / "uploads"
     if uploads_dir.exists():
         saved_files = list(uploads_dir.rglob("*.pdf"))
         assert len(saved_files) == 0
@@ -249,7 +249,7 @@ async def test_attachment_no_data(processor, sample_message, temp_workspace):
     result = await processor.process_inbound(sample_message)
 
     # No files should be saved
-    uploads_dir = Path(temp_workspace) / "uploads"
+    uploads_dir = Path(temp_workspace) / "data" / "uploads"
     if uploads_dir.exists():
         saved_files = list(uploads_dir.rglob("*"))
         saved_files = [f for f in saved_files if f.is_file()]
@@ -283,7 +283,7 @@ async def test_filename_collision(processor, sample_message, temp_workspace):
     await processor.process_inbound(sample_message)
 
     # Verify both files exist
-    uploads_dir = Path(temp_workspace) / "uploads"
+    uploads_dir = Path(temp_workspace) / "data" / "uploads"
     saved_files = list(uploads_dir.rglob("*.pdf"))
     assert len(saved_files) == 2
 
@@ -318,7 +318,7 @@ async def test_content_enrichment_format(processor, sample_message, temp_workspa
 
     # Second line: [Saved to: ...]
     assert content_lines[1].startswith("[Saved to:")
-    assert "uploads/" in content_lines[1]
+    assert "data/uploads/" in content_lines[1]
     assert "report.pdf" in content_lines[1]
 
     # User caption preserved
@@ -349,7 +349,7 @@ async def test_metadata_populated(processor, sample_message, temp_workspace):
     assert file_meta["mime_type"] == "application/pdf"
     assert file_meta["size_bytes"] == len(b"PDF data")
     assert "original_path" in file_meta
-    assert file_meta["original_path"].startswith("uploads/")
+    assert file_meta["original_path"].startswith("data/uploads/")
 
 
 @pytest.mark.asyncio
@@ -455,7 +455,7 @@ async def test_mime_type_fallback(processor, sample_message, temp_workspace):
     await processor.process_inbound(sample_message)
 
     # File should still be saved
-    uploads_dir = Path(temp_workspace) / "uploads"
+    uploads_dir = Path(temp_workspace) / "data" / "uploads"
     saved_files = list(uploads_dir.rglob("*.json"))
     assert len(saved_files) == 1
 
@@ -474,7 +474,7 @@ async def test_binary_file_no_extension(processor, sample_message, temp_workspac
     await processor.process_inbound(sample_message)
 
     # Should generate upload_{id}.bin
-    uploads_dir = Path(temp_workspace) / "uploads"
+    uploads_dir = Path(temp_workspace) / "data" / "uploads"
     saved_files = list(uploads_dir.rglob("*.bin"))
     assert len(saved_files) == 1
     assert saved_files[0].name.startswith("upload_msg123")
@@ -497,7 +497,7 @@ async def test_date_partitioning(processor, sample_message, temp_workspace):
 
     # Verify date-based directory (processor defaults to UTC timezone)
     today = workspace_now("UTC").strftime("%Y-%m-%d")
-    expected_dir = Path(temp_workspace) / "uploads" / today
+    expected_dir = Path(temp_workspace) / "data" / "uploads" / today
     assert expected_dir.exists()
     assert expected_dir.is_dir()
 
@@ -520,7 +520,7 @@ async def test_special_characters_sanitized(processor, sample_message, temp_work
     await processor.process_inbound(sample_message)
 
     # Filename should be sanitized
-    uploads_dir = Path(temp_workspace) / "uploads"
+    uploads_dir = Path(temp_workspace) / "data" / "uploads"
     saved_files = list(uploads_dir.rglob("*.pdf"))
     assert len(saved_files) == 1
 
@@ -571,7 +571,7 @@ async def test_timezone_aware_date_partition(temp_workspace, sample_message):
         await processor.process_inbound(sample_message)
 
     # Verify file landed in 2026-02-07 (Mountain Time date), NOT 2026-02-08
-    expected_dir = Path(temp_workspace) / "uploads" / "2026-02-07"
+    expected_dir = Path(temp_workspace) / "data" / "uploads" / "2026-02-07"
     assert expected_dir.exists(), "Expected Mountain Time date directory to exist"
 
     saved_files = list(expected_dir.glob("*.pdf"))
@@ -579,5 +579,5 @@ async def test_timezone_aware_date_partition(temp_workspace, sample_message):
     assert saved_files[0].name == "report.pdf"
 
     # Verify no file in the UTC date directory
-    utc_dir = Path(temp_workspace) / "uploads" / "2026-02-08"
+    utc_dir = Path(temp_workspace) / "data" / "uploads" / "2026-02-08"
     assert not utc_dir.exists(), "UTC date directory should not exist"

--- a/tests/test_filesystem_write_protection.py
+++ b/tests/test_filesystem_write_protection.py
@@ -1,0 +1,346 @@
+"""Tests for FilesystemTools write protection and workspace/ default root.
+
+Phase 1 additions:
+- Write operations (write_file, overwrite_file, edit_file) go through
+  _resolve_write_path(), which enforces write protection and transparently
+  redirects bare filenames to workspace/.
+- Read operations remain unrestricted.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from openpaw.agent.tools.filesystem import FilesystemTools
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_fs(tmp_path: Path, workspace_name: str = "") -> FilesystemTools:
+    return FilesystemTools(tmp_path, workspace_name=workspace_name)
+
+
+def get_tools(fs: FilesystemTools) -> dict:
+    return {t.name: t for t in fs.get_tools()}
+
+
+# ---------------------------------------------------------------------------
+# _resolve_write_path: unit tests via the private method
+# ---------------------------------------------------------------------------
+
+
+class TestResolveWritePath:
+    """Verify _resolve_write_path routing logic directly."""
+
+    def test_bare_filename_redirects_to_workspace(self, tmp_path: Path):
+        fs = make_fs(tmp_path)
+        result = fs._resolve_write_path("report.md")
+        assert result == (tmp_path / "workspace" / "report.md").resolve()
+
+    def test_relative_path_redirects_to_workspace(self, tmp_path: Path):
+        fs = make_fs(tmp_path)
+        result = fs._resolve_write_path("research/notes.txt")
+        assert result == (tmp_path / "workspace" / "research" / "notes.txt").resolve()
+
+    def test_explicit_workspace_path_kept(self, tmp_path: Path):
+        fs = make_fs(tmp_path)
+        result = fs._resolve_write_path("workspace/report.md")
+        assert result == (tmp_path / "workspace" / "report.md").resolve()
+
+    def test_heartbeat_md_path_kept(self, tmp_path: Path):
+        fs = make_fs(tmp_path)
+        result = fs._resolve_write_path("agent/HEARTBEAT.md")
+        assert result == (tmp_path / "agent" / "HEARTBEAT.md").resolve()
+
+    def test_data_path_raises(self, tmp_path: Path):
+        fs = make_fs(tmp_path)
+        with pytest.raises(ValueError, match="Write access"):
+            fs._resolve_write_path("data/TASKS.yaml")
+
+    def test_config_path_raises(self, tmp_path: Path):
+        fs = make_fs(tmp_path)
+        with pytest.raises(ValueError, match="Write access"):
+            fs._resolve_write_path("config/agent.yaml")
+
+    def test_memory_logs_path_raises(self, tmp_path: Path):
+        fs = make_fs(tmp_path)
+        with pytest.raises(ValueError, match="Write access"):
+            fs._resolve_write_path("memory/logs/heartbeat/session.jsonl")
+
+    def test_memory_conversations_path_raises(self, tmp_path: Path):
+        fs = make_fs(tmp_path)
+        with pytest.raises(ValueError, match="Write access"):
+            fs._resolve_write_path("memory/conversations/conv_abc.md")
+
+
+# ---------------------------------------------------------------------------
+# write_file: bare filename goes to workspace/
+# ---------------------------------------------------------------------------
+
+
+class TestWriteFileDefaultRoot:
+    """write_file transparently places bare filenames under workspace/."""
+
+    def test_bare_filename_written_to_workspace(self, tmp_path: Path):
+        (tmp_path / "workspace").mkdir()
+        fs = make_fs(tmp_path)
+        tools = get_tools(fs)
+
+        result = tools["write_file"].invoke({"file_path": "report.md", "content": "hello"})
+
+        assert "Error:" not in result
+        assert (tmp_path / "workspace" / "report.md").exists()
+        assert (tmp_path / "workspace" / "report.md").read_text() == "hello"
+
+    def test_explicit_workspace_path_written(self, tmp_path: Path):
+        (tmp_path / "workspace").mkdir()
+        fs = make_fs(tmp_path)
+        tools = get_tools(fs)
+
+        result = tools["write_file"].invoke({"file_path": "workspace/notes.md", "content": "hi"})
+
+        assert "Error:" not in result
+        assert (tmp_path / "workspace" / "notes.md").exists()
+
+    def test_write_to_data_blocked(self, tmp_path: Path):
+        (tmp_path / "data").mkdir()
+        fs = make_fs(tmp_path)
+        tools = get_tools(fs)
+
+        result = tools["write_file"].invoke({"file_path": "data/TASKS.yaml", "content": "bad"})
+
+        assert "Error:" in result
+        assert not (tmp_path / "data" / "TASKS.yaml").exists()
+
+    def test_write_to_config_blocked(self, tmp_path: Path):
+        (tmp_path / "config").mkdir()
+        fs = make_fs(tmp_path)
+        tools = get_tools(fs)
+
+        result = tools["write_file"].invoke({"file_path": "config/agent.yaml", "content": "bad"})
+
+        assert "Error:" in result
+        assert not (tmp_path / "config" / "agent.yaml").exists()
+
+    def test_write_creates_workspace_subdir_if_needed(self, tmp_path: Path):
+        """Parent directories under workspace/ are created automatically."""
+        fs = make_fs(tmp_path)
+        tools = get_tools(fs)
+
+        result = tools["write_file"].invoke({
+            "file_path": "research/deep/notes.txt",
+            "content": "deep content",
+        })
+
+        assert "Error:" not in result
+        assert (tmp_path / "workspace" / "research" / "deep" / "notes.txt").exists()
+
+
+# ---------------------------------------------------------------------------
+# overwrite_file: bare filename goes to workspace/
+# ---------------------------------------------------------------------------
+
+
+class TestOverwriteFileDefaultRoot:
+    """overwrite_file transparently places bare filenames under workspace/."""
+
+    def test_bare_filename_overwritten_in_workspace(self, tmp_path: Path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        (ws / "notes.md").write_text("old")
+
+        fs = make_fs(tmp_path)
+        tools = get_tools(fs)
+
+        result = tools["overwrite_file"].invoke({"file_path": "notes.md", "content": "new"})
+
+        assert "Error:" not in result
+        assert (ws / "notes.md").read_text() == "new"
+
+    def test_overwrite_heartbeat_md_allowed(self, tmp_path: Path):
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        (agent_dir / "HEARTBEAT.md").write_text("old heartbeat")
+
+        fs = make_fs(tmp_path)
+        tools = get_tools(fs)
+
+        result = tools["overwrite_file"].invoke({
+            "file_path": "agent/HEARTBEAT.md",
+            "content": "updated heartbeat",
+        })
+
+        assert "Error:" not in result
+        assert (agent_dir / "HEARTBEAT.md").read_text() == "updated heartbeat"
+
+    def test_overwrite_to_data_blocked(self, tmp_path: Path):
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "TASKS.yaml").write_text("original")
+
+        fs = make_fs(tmp_path)
+        tools = get_tools(fs)
+
+        result = tools["overwrite_file"].invoke({"file_path": "data/TASKS.yaml", "content": "evil"})
+
+        assert "Error:" in result
+        # Original file must be intact
+        assert (data_dir / "TASKS.yaml").read_text() == "original"
+
+    def test_overwrite_to_memory_logs_blocked(self, tmp_path: Path):
+        logs_dir = tmp_path / "memory" / "logs" / "heartbeat"
+        logs_dir.mkdir(parents=True)
+        target = logs_dir / "session.jsonl"
+        target.write_text("real logs")
+
+        fs = make_fs(tmp_path)
+        tools = get_tools(fs)
+
+        result = tools["overwrite_file"].invoke({
+            "file_path": "memory/logs/heartbeat/session.jsonl",
+            "content": "tampered",
+        })
+
+        assert "Error:" in result
+        assert target.read_text() == "real logs"
+
+
+# ---------------------------------------------------------------------------
+# edit_file: bare filename resolved under workspace/
+# ---------------------------------------------------------------------------
+
+
+class TestEditFileDefaultRoot:
+    """edit_file transparently resolves bare filenames under workspace/."""
+
+    def test_edit_bare_filename_in_workspace(self, tmp_path: Path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        (ws / "draft.md").write_text("hello world")
+
+        fs = make_fs(tmp_path)
+        tools = get_tools(fs)
+
+        result = tools["edit_file"].invoke({
+            "file_path": "draft.md",
+            "old_text": "world",
+            "new_text": "there",
+        })
+
+        assert "Error:" not in result
+        assert (ws / "draft.md").read_text() == "hello there"
+
+    def test_edit_heartbeat_md_allowed(self, tmp_path: Path):
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        (agent_dir / "HEARTBEAT.md").write_text("check: pending")
+
+        fs = make_fs(tmp_path)
+        tools = get_tools(fs)
+
+        result = tools["edit_file"].invoke({
+            "file_path": "agent/HEARTBEAT.md",
+            "old_text": "pending",
+            "new_text": "done",
+        })
+
+        assert "Error:" not in result
+        assert (agent_dir / "HEARTBEAT.md").read_text() == "check: done"
+
+    def test_edit_data_file_blocked(self, tmp_path: Path):
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "TASKS.yaml").write_text("tasks: []")
+
+        fs = make_fs(tmp_path)
+        tools = get_tools(fs)
+
+        result = tools["edit_file"].invoke({
+            "file_path": "data/TASKS.yaml",
+            "old_text": "tasks",
+            "new_text": "evil",
+        })
+
+        assert "Error:" in result
+        assert (data_dir / "TASKS.yaml").read_text() == "tasks: []"
+
+    def test_edit_config_file_blocked(self, tmp_path: Path):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "agent.yaml").write_text("name: test")
+
+        fs = make_fs(tmp_path)
+        tools = get_tools(fs)
+
+        result = tools["edit_file"].invoke({
+            "file_path": "config/agent.yaml",
+            "old_text": "test",
+            "new_text": "hacked",
+        })
+
+        assert "Error:" in result
+        assert (config_dir / "agent.yaml").read_text() == "name: test"
+
+
+# ---------------------------------------------------------------------------
+# Read operations: protected directories are still readable
+# ---------------------------------------------------------------------------
+
+
+class TestReadFromProtectedDirs:
+    """Agent reads from data/, config/, memory/logs/ should succeed."""
+
+    def test_read_from_data(self, tmp_path: Path):
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "TASKS.yaml").write_text("tasks: []")
+
+        fs = make_fs(tmp_path)
+        tools = get_tools(fs)
+
+        result = tools["read_file"].invoke({"file_path": "data/TASKS.yaml"})
+
+        assert "Error:" not in result
+        assert "tasks: []" in result
+
+    def test_read_from_config(self, tmp_path: Path):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "agent.yaml").write_text("name: gilfoyle")
+
+        fs = make_fs(tmp_path)
+        tools = get_tools(fs)
+
+        result = tools["read_file"].invoke({"file_path": "config/agent.yaml"})
+
+        assert "Error:" not in result
+        assert "gilfoyle" in result
+
+    def test_read_from_memory_logs(self, tmp_path: Path):
+        logs_dir = tmp_path / "memory" / "logs" / "heartbeat"
+        logs_dir.mkdir(parents=True)
+        (logs_dir / "session.jsonl").write_text('{"type": "prompt"}')
+
+        fs = make_fs(tmp_path)
+        tools = get_tools(fs)
+
+        result = tools["read_file"].invoke({"file_path": "memory/logs/heartbeat/session.jsonl"})
+
+        assert "Error:" not in result
+        assert "prompt" in result
+
+    def test_ls_data_directory(self, tmp_path: Path):
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "TASKS.yaml").write_text("tasks: []")
+
+        fs = make_fs(tmp_path)
+        tools = get_tools(fs)
+
+        result = tools["ls"].invoke({"path": "data"})
+
+        assert "Error:" not in result
+        assert "TASKS.yaml" in result

--- a/tests/test_framework_prompt_metacognitive.py
+++ b/tests/test_framework_prompt_metacognitive.py
@@ -14,11 +14,13 @@ def mock_workspace(tmp_path: Path) -> AgentWorkspace:
     workspace_path = tmp_path / "test_workspace"
     workspace_path.mkdir()
 
-    # Create required markdown files
-    (workspace_path / "AGENT.md").write_text("# Agent")
-    (workspace_path / "USER.md").write_text("# User")
-    (workspace_path / "SOUL.md").write_text("# Soul")
-    (workspace_path / "HEARTBEAT.md").write_text("# Heartbeat with content for testing")
+    # Create required markdown files in the agent/ subdirectory.
+    agent_path = workspace_path / "agent"
+    agent_path.mkdir(parents=True, exist_ok=True)
+    (agent_path / "AGENT.md").write_text("# Agent")
+    (agent_path / "USER.md").write_text("# User")
+    (agent_path / "SOUL.md").write_text("# Soul")
+    (agent_path / "HEARTBEAT.md").write_text("# Heartbeat with content for testing")
 
     loader = WorkspaceLoader(tmp_path)
     return loader.load("test_workspace")
@@ -105,7 +107,6 @@ class TestTaskManagementProactiveGuidance:
         prompt = mock_workspace.build_system_prompt(enabled_builtins=["task_tracker"])
 
         # Original content should still be present
-        assert "TASKS.yaml" in prompt
         assert "Tasks persist" in prompt
         assert "Future heartbeats will see your tasks" in prompt
 

--- a/tests/test_heartbeat_enrichment.py
+++ b/tests/test_heartbeat_enrichment.py
@@ -80,6 +80,7 @@ def scheduler(
 ) -> HeartbeatScheduler:
     """Create a heartbeat scheduler instance."""
     workspace_path.mkdir(parents=True, exist_ok=True)
+    (workspace_path / "data").mkdir(parents=True, exist_ok=True)
     return HeartbeatScheduler(
         workspace_name="test_workspace",
         workspace_path=workspace_path,
@@ -92,14 +93,15 @@ def scheduler(
 
 def create_tasks_yaml(workspace_path: Path, tasks: list[dict]) -> None:
     """Create a TASKS.yaml file with given tasks."""
-    tasks_file = workspace_path / "TASKS.yaml"
+    (workspace_path / "data").mkdir(parents=True, exist_ok=True)
+    tasks_file = workspace_path / "data" / "TASKS.yaml"
     with tasks_file.open("w") as f:
         yaml.dump({"tasks": tasks}, f)
 
 
 def read_heartbeat_log(workspace_path: Path) -> list[dict]:
     """Read and parse heartbeat_log.jsonl."""
-    log_file = workspace_path / "heartbeat_log.jsonl"
+    log_file = workspace_path / "data" / "heartbeat_log.jsonl"
     if not log_file.exists():
         return []
 
@@ -200,7 +202,8 @@ class TestHeartbeatJSONLEnrichment:
         mock_token_logger: Mock,
     ):
         """Test that skipped heartbeats don't include token counts."""
-        # Create empty HEARTBEAT.md and no tasks (triggers skip)
+        # Create empty HEARTBEAT.md and no tasks (triggers skip).
+        # NOTE: path will move to agent/HEARTBEAT.md after workspace restructure.
         heartbeat_md = workspace_path / "HEARTBEAT.md"
         heartbeat_md.write_text("")
 
@@ -260,7 +263,8 @@ class TestHeartbeatJSONLEnrichment:
         workspace_path: Path,
     ):
         """Test task_count is None when no TASKS.yaml exists."""
-        # Create HEARTBEAT.md with content to prevent skip
+        # Create HEARTBEAT.md with content to prevent skip.
+        # NOTE: path will move to agent/HEARTBEAT.md after workspace restructure.
         heartbeat_md = workspace_path / "HEARTBEAT.md"
         heartbeat_md.write_text("# Heartbeat\n\nSome pending work here")
 
@@ -398,6 +402,7 @@ class TestHeartbeatJSONLEnrichment:
         )
 
         workspace_path.mkdir(parents=True, exist_ok=True)
+        (workspace_path / "data").mkdir(parents=True, exist_ok=True)
 
         # Mock active hours check to guarantee outside-hours behavior
         scheduler._is_within_active_hours = Mock(return_value=False)  # type: ignore[method-assign]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -292,7 +292,7 @@ def test_tokens_today_mountain_time(workspace_with_tokens: Path):
     ) - timedelta(days=1)
 
     # Manually log an entry with yesterday's timestamp
-    log_path = workspace_with_tokens / ".openpaw" / "token_usage.jsonl"
+    log_path = workspace_with_tokens / "data" / "token_usage.jsonl"
     log_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(log_path, "a") as f:
@@ -378,7 +378,7 @@ def test_tokens_today_multiple_timezones(workspace_with_tokens: Path):
     reader = TokenUsageReader(workspace_with_tokens)
 
     # Create entries near midnight boundary
-    log_path = workspace_with_tokens / ".openpaw" / "token_usage.jsonl"
+    log_path = workspace_with_tokens / "data" / "token_usage.jsonl"
     log_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Entry at 11:30 PM Pacific Time

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,253 @@
+"""Tests for openpaw/core/paths.py — workspace path constants."""
+
+from pathlib import PurePosixPath
+
+import openpaw.core.paths as paths
+from openpaw.core.paths import (
+    AGENT_DIR,
+    AGENT_MD,
+    AGENT_WRITABLE_FILES,
+    AGENT_YAML,
+    BROWSER_COOKIES_JSON,
+    CONFIG_DIR,
+    CONVERSATIONS_DB,
+    CRONS_DIR,
+    DATA_DIR,
+    DOT_ENV,
+    DOWNLOADS_DIR,
+    DYNAMIC_CRONS_JSON,
+    HEARTBEAT_LOG_JSONL,
+    HEARTBEAT_MD,
+    IDENTITY_FILES,
+    MEMORY_CONVERSATIONS_DIR,
+    MEMORY_DIR,
+    MEMORY_LOGS_DIR,
+    SCREENSHOTS_DIR,
+    SESSIONS_JSON,
+    SKILLS_DIR,
+    SOUL_MD,
+    SUBAGENTS_YAML,
+    TASKS_YAML,
+    TEAM_DIR,
+    TOKEN_USAGE_JSONL,
+    TOOLS_DIR,
+    UPLOADS_DIR,
+    USER_MD,
+    VECTORS_DB,
+    WORKSPACE_DIR,
+    WRITE_PROTECTED_DIRS,
+)
+
+
+def _all_path_constants() -> list[PurePosixPath]:
+    """Collect every PurePosixPath constant exported from paths module."""
+    return [
+        v for v in vars(paths).values()
+        if isinstance(v, PurePosixPath)
+    ]
+
+
+class TestConstantTypes:
+    """Every path constant must be a PurePosixPath instance."""
+
+    def test_top_level_dirs_are_pure_posix_paths(self) -> None:
+        for constant in [AGENT_DIR, CONFIG_DIR, DATA_DIR, MEMORY_DIR, WORKSPACE_DIR]:
+            assert isinstance(constant, PurePosixPath), f"{constant!r} is not a PurePosixPath"
+
+    def test_identity_files_are_pure_posix_paths(self) -> None:
+        for constant in [AGENT_MD, USER_MD, SOUL_MD, HEARTBEAT_MD]:
+            assert isinstance(constant, PurePosixPath), f"{constant!r} is not a PurePosixPath"
+
+    def test_extension_dirs_are_pure_posix_paths(self) -> None:
+        for constant in [TOOLS_DIR, SKILLS_DIR, TEAM_DIR]:
+            assert isinstance(constant, PurePosixPath), f"{constant!r} is not a PurePosixPath"
+
+    def test_config_paths_are_pure_posix_paths(self) -> None:
+        for constant in [AGENT_YAML, DOT_ENV, CRONS_DIR]:
+            assert isinstance(constant, PurePosixPath), f"{constant!r} is not a PurePosixPath"
+
+    def test_data_paths_are_pure_posix_paths(self) -> None:
+        for constant in [
+            CONVERSATIONS_DB,
+            SESSIONS_JSON,
+            SUBAGENTS_YAML,
+            TOKEN_USAGE_JSONL,
+            VECTORS_DB,
+            BROWSER_COOKIES_JSON,
+            DYNAMIC_CRONS_JSON,
+            HEARTBEAT_LOG_JSONL,
+            TASKS_YAML,
+            UPLOADS_DIR,
+        ]:
+            assert isinstance(constant, PurePosixPath), f"{constant!r} is not a PurePosixPath"
+
+    def test_memory_paths_are_pure_posix_paths(self) -> None:
+        for constant in [MEMORY_CONVERSATIONS_DIR, MEMORY_LOGS_DIR]:
+            assert isinstance(constant, PurePosixPath), f"{constant!r} is not a PurePosixPath"
+
+    def test_workspace_paths_are_pure_posix_paths(self) -> None:
+        for constant in [DOWNLOADS_DIR, SCREENSHOTS_DIR]:
+            assert isinstance(constant, PurePosixPath), f"{constant!r} is not a PurePosixPath"
+
+
+class TestNoDuplicatePaths:
+    """No two constants should resolve to the same path string."""
+
+    def test_all_path_constants_are_unique(self) -> None:
+        all_paths = _all_path_constants()
+        path_strings = [str(p) for p in all_paths]
+        assert len(path_strings) == len(set(path_strings)), (
+            f"Duplicate paths found: "
+            f"{[p for p in path_strings if path_strings.count(p) > 1]}"
+        )
+
+
+class TestIdentityFiles:
+    """IDENTITY_FILES must contain exactly the four required markdown files."""
+
+    def test_identity_files_has_four_entries(self) -> None:
+        assert len(IDENTITY_FILES) == 4
+
+    def test_identity_files_contains_agent_md(self) -> None:
+        assert AGENT_MD in IDENTITY_FILES
+
+    def test_identity_files_contains_user_md(self) -> None:
+        assert USER_MD in IDENTITY_FILES
+
+    def test_identity_files_contains_soul_md(self) -> None:
+        assert SOUL_MD in IDENTITY_FILES
+
+    def test_identity_files_contains_heartbeat_md(self) -> None:
+        assert HEARTBEAT_MD in IDENTITY_FILES
+
+    def test_identity_files_are_all_pure_posix_paths(self) -> None:
+        for p in IDENTITY_FILES:
+            assert isinstance(p, PurePosixPath)
+
+
+class TestParentDirectoryConsistency:
+    """Paths must live under their expected parent directories."""
+
+    def test_agent_md_under_agent_dir(self) -> None:
+        assert AGENT_MD.parent == AGENT_DIR
+
+    def test_user_md_under_agent_dir(self) -> None:
+        assert USER_MD.parent == AGENT_DIR
+
+    def test_soul_md_under_agent_dir(self) -> None:
+        assert SOUL_MD.parent == AGENT_DIR
+
+    def test_heartbeat_md_under_agent_dir(self) -> None:
+        assert HEARTBEAT_MD.parent == AGENT_DIR
+
+    def test_tools_dir_under_agent_dir(self) -> None:
+        assert TOOLS_DIR.parent == AGENT_DIR
+
+    def test_skills_dir_under_agent_dir(self) -> None:
+        assert SKILLS_DIR.parent == AGENT_DIR
+
+    def test_team_dir_under_agent_dir(self) -> None:
+        assert TEAM_DIR.parent == AGENT_DIR
+
+    def test_agent_yaml_under_config_dir(self) -> None:
+        assert AGENT_YAML.parent == CONFIG_DIR
+
+    def test_dot_env_under_config_dir(self) -> None:
+        assert DOT_ENV.parent == CONFIG_DIR
+
+    def test_crons_dir_under_config_dir(self) -> None:
+        assert CRONS_DIR.parent == CONFIG_DIR
+
+    def test_conversations_db_under_data_dir(self) -> None:
+        assert CONVERSATIONS_DB.parent == DATA_DIR
+
+    def test_sessions_json_under_data_dir(self) -> None:
+        assert SESSIONS_JSON.parent == DATA_DIR
+
+    def test_subagents_yaml_under_data_dir(self) -> None:
+        assert SUBAGENTS_YAML.parent == DATA_DIR
+
+    def test_token_usage_jsonl_under_data_dir(self) -> None:
+        assert TOKEN_USAGE_JSONL.parent == DATA_DIR
+
+    def test_vectors_db_under_data_dir(self) -> None:
+        assert VECTORS_DB.parent == DATA_DIR
+
+    def test_browser_cookies_json_under_data_dir(self) -> None:
+        assert BROWSER_COOKIES_JSON.parent == DATA_DIR
+
+    def test_dynamic_crons_json_under_data_dir(self) -> None:
+        assert DYNAMIC_CRONS_JSON.parent == DATA_DIR
+
+    def test_heartbeat_log_jsonl_under_data_dir(self) -> None:
+        assert HEARTBEAT_LOG_JSONL.parent == DATA_DIR
+
+    def test_tasks_yaml_under_data_dir(self) -> None:
+        assert TASKS_YAML.parent == DATA_DIR
+
+    def test_uploads_dir_under_data_dir(self) -> None:
+        assert UPLOADS_DIR.parent == DATA_DIR
+
+    def test_memory_conversations_dir_under_memory_dir(self) -> None:
+        assert MEMORY_CONVERSATIONS_DIR.parent == MEMORY_DIR
+
+    def test_memory_logs_dir_under_memory_dir(self) -> None:
+        assert MEMORY_LOGS_DIR.parent == MEMORY_DIR
+
+    def test_downloads_dir_under_workspace_dir(self) -> None:
+        assert DOWNLOADS_DIR.parent == WORKSPACE_DIR
+
+    def test_screenshots_dir_under_workspace_dir(self) -> None:
+        assert SCREENSHOTS_DIR.parent == WORKSPACE_DIR
+
+
+class TestWriteProtectedDirs:
+    """WRITE_PROTECTED_DIRS must be a frozenset of directory path strings."""
+
+    def test_write_protected_dirs_is_frozenset(self) -> None:
+        assert isinstance(WRITE_PROTECTED_DIRS, frozenset)
+
+    def test_write_protected_dirs_contains_data_dir(self) -> None:
+        assert str(DATA_DIR) in WRITE_PROTECTED_DIRS
+
+    def test_write_protected_dirs_contains_config_dir(self) -> None:
+        assert str(CONFIG_DIR) in WRITE_PROTECTED_DIRS
+
+    def test_write_protected_dirs_contains_memory_logs(self) -> None:
+        assert str(MEMORY_LOGS_DIR) in WRITE_PROTECTED_DIRS
+
+    def test_write_protected_dirs_contains_memory_conversations(self) -> None:
+        assert str(MEMORY_CONVERSATIONS_DIR) in WRITE_PROTECTED_DIRS
+
+    def test_write_protected_dirs_entries_are_strings(self) -> None:
+        for entry in WRITE_PROTECTED_DIRS:
+            assert isinstance(entry, str), f"{entry!r} is not a string"
+
+    def test_write_protected_dirs_entries_have_no_leading_slash(self) -> None:
+        for entry in WRITE_PROTECTED_DIRS:
+            assert not entry.startswith("/"), f"{entry!r} must be a relative path"
+
+
+class TestAgentWritableFiles:
+    """AGENT_WRITABLE_FILES must be a frozenset containing the allowed exceptions."""
+
+    def test_agent_writable_files_is_frozenset(self) -> None:
+        assert isinstance(AGENT_WRITABLE_FILES, frozenset)
+
+    def test_agent_writable_files_contains_heartbeat_md(self) -> None:
+        assert str(HEARTBEAT_MD) in AGENT_WRITABLE_FILES
+
+    def test_agent_writable_files_entries_are_strings(self) -> None:
+        for entry in AGENT_WRITABLE_FILES:
+            assert isinstance(entry, str), f"{entry!r} is not a string"
+
+    def test_agent_writable_files_entries_reference_valid_paths(self) -> None:
+        all_path_strings = {str(p) for p in _all_path_constants()}
+        for entry in AGENT_WRITABLE_FILES:
+            assert entry in all_path_strings, (
+                f"{entry!r} in AGENT_WRITABLE_FILES does not match any known path constant"
+            )
+
+    def test_agent_writable_files_entries_have_no_leading_slash(self) -> None:
+        for entry in AGENT_WRITABLE_FILES:
+            assert not entry.startswith("/"), f"{entry!r} must be a relative path"

--- a/tests/test_processor_pipeline_integration.py
+++ b/tests/test_processor_pipeline_integration.py
@@ -184,13 +184,13 @@ async def test_pdf_pipeline_full(tmp_path, base_message, mock_docling):
     # Should have file receipt info (after timestamp)
     assert "[File received: report.pdf" in content
     assert "application/pdf)]" in content
-    assert "[Saved to: uploads/" in content
+    assert "[Saved to: data/uploads/" in content
 
     # Should have user caption preserved
     assert "Can you summarize this document?" in content
 
     # Should have conversion info at the end
-    assert "[Converted to markdown: uploads/" in content
+    assert "[Converted to markdown: data/uploads/" in content
     assert ".md]" in content
     assert "Contents: full text" in content
     assert "1 tables" in content
@@ -208,7 +208,7 @@ async def test_pdf_pipeline_full(tmp_path, base_message, mock_docling):
 
     # Verify attachment.saved_path is set
     assert attachment.saved_path is not None
-    assert attachment.saved_path.startswith("uploads/")
+    assert attachment.saved_path.startswith("data/uploads/")
     assert attachment.saved_path.endswith(".pdf")
 
     # Verify sibling .md file exists
@@ -279,7 +279,7 @@ async def test_audio_pipeline_full(tmp_path, base_message, mock_openai_client):
         # Should have file receipt info
         assert "[File received: voice_123.ogg" in content
         assert "audio/ogg)]" in content
-        assert "[Saved to: uploads/" in content
+        assert "[Saved to: data/uploads/" in content
 
         # Should have transcription
         assert "[Voice message]: Hello, please check the document I sent." in content
@@ -362,7 +362,7 @@ async def test_image_pipeline_no_conversion(tmp_path, base_message):
     # Should have file receipt info
     assert "[File received: photo_123.jpg" in content
     assert "image/jpeg)]" in content
-    assert "[Saved to: uploads/" in content
+    assert "[Saved to: data/uploads/" in content
 
     # Should NOT have transcription (not audio)
     assert "[Voice message]:" not in content
@@ -442,7 +442,7 @@ async def test_unknown_file_still_saved(tmp_path, base_message):
     # Should have file receipt info
     assert "[File received: archive.zip" in content
     assert "application/zip)]" in content
-    assert "[Saved to: uploads/" in content
+    assert "[Saved to: data/uploads/" in content
 
     # Should NOT have any conversion notes
     assert "[Converted to markdown:" not in content

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -214,9 +214,11 @@ class TestFrameworkSections:
     def test_section_workspace_filesystem_content(self) -> None:
         """SECTION_WORKSPACE_FILESYSTEM has expected content."""
         assert "## Workspace Filesystem" in SECTION_WORKSPACE_FILESYSTEM
-        assert "relative to your workspace root" in SECTION_WORKSPACE_FILESYSTEM
+        assert "five top-level directories" in SECTION_WORKSPACE_FILESYSTEM
+        assert "agent/" in SECTION_WORKSPACE_FILESYSTEM
+        assert "data/" in SECTION_WORKSPACE_FILESYSTEM
+        assert "workspace/" in SECTION_WORKSPACE_FILESYSTEM
         assert "ls('.')" in SECTION_WORKSPACE_FILESYSTEM
-        assert "NOT a code repository" in SECTION_WORKSPACE_FILESYSTEM
 
     def test_shell_hygiene_section_exists(self) -> None:
         """SECTION_SHELL_HYGIENE is defined with expected content."""
@@ -316,11 +318,13 @@ class TestSystemPromptIdentity:
         workspace_path = tmp_path / "test_workspace"
         workspace_path.mkdir()
 
-        # Create required markdown files
-        (workspace_path / "AGENT.md").write_text("# Agent")
-        (workspace_path / "USER.md").write_text("# User")
-        (workspace_path / "SOUL.md").write_text("# Soul")
-        (workspace_path / "HEARTBEAT.md").write_text("# Heartbeat with content")
+        # Create required markdown files in the agent/ subdirectory.
+        agent_path = workspace_path / "agent"
+        agent_path.mkdir(parents=True, exist_ok=True)
+        (agent_path / "AGENT.md").write_text("# Agent")
+        (agent_path / "USER.md").write_text("# User")
+        (agent_path / "SOUL.md").write_text("# Soul")
+        (agent_path / "HEARTBEAT.md").write_text("# Heartbeat with content")
 
         loader = WorkspaceLoader(tmp_path)
         return loader.load("test_workspace")

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -38,22 +38,28 @@ class TestResolveSandboxedPath:
         with pytest.raises(ValueError, match="Path traversal"):
             resolve_sandboxed_path(tmp_path, "subdir/../../etc/passwd")
 
-    def test_openpaw_directory_rejected(self, tmp_path: Path):
-        with pytest.raises(ValueError, match=r"\.openpaw"):
-            resolve_sandboxed_path(tmp_path, ".openpaw/conversations.db")
+    def test_data_directory_readable(self, tmp_path: Path):
+        """data/ directory is readable (no longer protected like .openpaw was)."""
+        result = resolve_sandboxed_path(tmp_path, "data/sessions.json")
+        assert result == (tmp_path / "data" / "sessions.json").resolve()
 
-    def test_nested_openpaw_directory_rejected(self, tmp_path: Path):
-        with pytest.raises(ValueError, match=r"\.openpaw"):
-            resolve_sandboxed_path(tmp_path, "subdir/.openpaw/file")
-
-    def test_openpaw_like_filename_allowed(self, tmp_path: Path):
-        result = resolve_sandboxed_path(tmp_path, "openpaw_notes.txt")
-        assert result == (tmp_path / "openpaw_notes.txt").resolve()
+    def test_nested_data_directory_readable(self, tmp_path: Path):
+        """Nested data/ access is also allowed for reads."""
+        result = resolve_sandboxed_path(tmp_path, "subdir/data/file")
+        assert result == (tmp_path / "subdir" / "data" / "file").resolve()
 
     def test_dotfile_allowed(self, tmp_path: Path):
         result = resolve_sandboxed_path(tmp_path, ".env")
         assert result == (tmp_path / ".env").resolve()
 
-    def test_tasks_yaml_allowed(self, tmp_path: Path):
-        result = resolve_sandboxed_path(tmp_path, "TASKS.yaml")
-        assert result == (tmp_path / "TASKS.yaml").resolve()
+    def test_tasks_yaml_in_data_allowed(self, tmp_path: Path):
+        result = resolve_sandboxed_path(tmp_path, "data/TASKS.yaml")
+        assert result == (tmp_path / "data" / "TASKS.yaml").resolve()
+
+    def test_agent_subdir_allowed(self, tmp_path: Path):
+        result = resolve_sandboxed_path(tmp_path, "agent/AGENT.md")
+        assert result == (tmp_path / "agent" / "AGENT.md").resolve()
+
+    def test_config_subdir_allowed(self, tmp_path: Path):
+        result = resolve_sandboxed_path(tmp_path, "config/agent.yaml")
+        assert result == (tmp_path / "config" / "agent.yaml").resolve()

--- a/tests/test_sandbox_write_protection.py
+++ b/tests/test_sandbox_write_protection.py
@@ -1,0 +1,216 @@
+"""Tests for write-mode sandbox protection introduced in Phase 1.
+
+These tests verify:
+- WRITE_PROTECTED_DIRS blocks writes to data/, config/, memory/logs,
+  memory/conversations
+- AGENT_WRITABLE_FILES exception: agent/HEARTBEAT.md is always writable
+- Reads from protected directories are still permitted (write_mode=False default)
+- Backward compatibility: callers that do not pass write_mode still work
+"""
+
+from pathlib import Path
+
+import pytest
+
+from openpaw.agent.tools.sandbox import _is_write_protected, resolve_sandboxed_path
+from openpaw.core.paths import (
+    AGENT_WRITABLE_FILES,
+    HEARTBEAT_MD,
+    WRITE_PROTECTED_DIRS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _is_write_protected helper
+# ---------------------------------------------------------------------------
+
+
+class TestIsWriteProtected:
+    """Unit tests for the _is_write_protected helper."""
+
+    # --- data/ directory ---
+
+    def test_data_root_is_protected(self):
+        assert _is_write_protected("data") is True
+
+    def test_data_file_is_protected(self):
+        assert _is_write_protected("data/TASKS.yaml") is True
+
+    def test_data_nested_file_is_protected(self):
+        assert _is_write_protected("data/uploads/2026-01-01/report.pdf") is True
+
+    # --- config/ directory ---
+
+    def test_config_root_is_protected(self):
+        assert _is_write_protected("config") is True
+
+    def test_config_agent_yaml_is_protected(self):
+        assert _is_write_protected("config/agent.yaml") is True
+
+    def test_config_dotenv_is_protected(self):
+        assert _is_write_protected("config/.env") is True
+
+    # --- memory/logs and memory/conversations ---
+
+    def test_memory_logs_is_protected(self):
+        assert _is_write_protected("memory/logs") is True
+
+    def test_memory_logs_file_is_protected(self):
+        assert _is_write_protected("memory/logs/heartbeat/session.jsonl") is True
+
+    def test_memory_conversations_is_protected(self):
+        assert _is_write_protected("memory/conversations") is True
+
+    def test_memory_conversations_file_is_protected(self):
+        assert _is_write_protected("memory/conversations/conv_abc.md") is True
+
+    # --- agent/HEARTBEAT.md exception ---
+
+    def test_heartbeat_md_is_not_protected(self):
+        """agent/HEARTBEAT.md must bypass protection (explicit writable exception)."""
+        assert _is_write_protected("agent/HEARTBEAT.md") is False
+
+    def test_agent_writable_files_set_contains_heartbeat(self):
+        """Sanity-check the constant set used by the helper."""
+        assert str(HEARTBEAT_MD) in AGENT_WRITABLE_FILES
+
+    # --- Allowed directories / files ---
+
+    def test_workspace_dir_is_not_protected(self):
+        assert _is_write_protected("workspace/report.md") is False
+
+    def test_workspace_root_is_not_protected(self):
+        assert _is_write_protected("workspace") is False
+
+    def test_agent_dir_general_not_protected(self):
+        """agent/ subdirectory other than HEARTBEAT.md is writable (no agent/ protection)."""
+        assert _is_write_protected("agent/tools/custom_tool.py") is False
+
+    def test_memory_root_is_not_fully_protected(self):
+        """memory/ itself is not listed; only sub-paths logs/ and conversations/ are."""
+        assert _is_write_protected("memory") is False
+
+    def test_memory_other_subdir_is_not_protected(self):
+        assert _is_write_protected("memory/notes.md") is False
+
+    def test_bare_filename_is_not_protected(self):
+        assert _is_write_protected("report.md") is False
+
+    # --- No false positives from similar names ---
+
+    def test_similar_name_data_prefix_not_protected(self):
+        """'database/' must not be confused with 'data/'."""
+        assert _is_write_protected("database/file.txt") is False
+
+    def test_similar_name_configs_not_protected(self):
+        """'configs/' must not be confused with 'config/'."""
+        assert _is_write_protected("configs/agent.yaml") is False
+
+
+# ---------------------------------------------------------------------------
+# Integration tests via resolve_sandboxed_path
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSandboxedPathWriteMode:
+    """Integration tests for resolve_sandboxed_path with write_mode=True."""
+
+    # --- Protected directories raise ValueError ---
+
+    def test_write_to_data_blocked(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="Write access"):
+            resolve_sandboxed_path(tmp_path, "data/TASKS.yaml", write_mode=True)
+
+    def test_write_to_data_nested_blocked(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="Write access"):
+            resolve_sandboxed_path(tmp_path, "data/uploads/report.pdf", write_mode=True)
+
+    def test_write_to_config_blocked(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="Write access"):
+            resolve_sandboxed_path(tmp_path, "config/agent.yaml", write_mode=True)
+
+    def test_write_to_config_dotenv_blocked(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="Write access"):
+            resolve_sandboxed_path(tmp_path, "config/.env", write_mode=True)
+
+    def test_write_to_memory_logs_blocked(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="Write access"):
+            resolve_sandboxed_path(tmp_path, "memory/logs/heartbeat/run.jsonl", write_mode=True)
+
+    def test_write_to_memory_conversations_blocked(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="Write access"):
+            resolve_sandboxed_path(tmp_path, "memory/conversations/conv_abc.md", write_mode=True)
+
+    # --- HEARTBEAT.md exception ---
+
+    def test_write_to_heartbeat_md_allowed(self, tmp_path: Path):
+        """agent/HEARTBEAT.md must not raise even in write mode."""
+        result = resolve_sandboxed_path(tmp_path, "agent/HEARTBEAT.md", write_mode=True)
+        assert result == (tmp_path / "agent" / "HEARTBEAT.md").resolve()
+
+    # --- Allowed write targets ---
+
+    def test_write_to_workspace_allowed(self, tmp_path: Path):
+        result = resolve_sandboxed_path(tmp_path, "workspace/report.md", write_mode=True)
+        assert result == (tmp_path / "workspace" / "report.md").resolve()
+
+    def test_write_to_workspace_nested_allowed(self, tmp_path: Path):
+        result = resolve_sandboxed_path(tmp_path, "workspace/research/notes.txt", write_mode=True)
+        assert result == (tmp_path / "workspace" / "research" / "notes.txt").resolve()
+
+    def test_write_to_agent_tools_allowed(self, tmp_path: Path):
+        """Other files in agent/ (not HEARTBEAT.md) are writable."""
+        result = resolve_sandboxed_path(tmp_path, "agent/tools/my_tool.py", write_mode=True)
+        assert result == (tmp_path / "agent" / "tools" / "my_tool.py").resolve()
+
+    def test_write_to_memory_other_allowed(self, tmp_path: Path):
+        """memory/ subdirs outside logs/ and conversations/ are writable."""
+        result = resolve_sandboxed_path(tmp_path, "memory/notes.md", write_mode=True)
+        assert result == (tmp_path / "memory" / "notes.md").resolve()
+
+    # --- Reads from protected directories are allowed (write_mode=False default) ---
+
+    def test_read_from_data_allowed(self, tmp_path: Path):
+        result = resolve_sandboxed_path(tmp_path, "data/TASKS.yaml")
+        assert result == (tmp_path / "data" / "TASKS.yaml").resolve()
+
+    def test_read_from_config_allowed(self, tmp_path: Path):
+        result = resolve_sandboxed_path(tmp_path, "config/agent.yaml")
+        assert result == (tmp_path / "config" / "agent.yaml").resolve()
+
+    def test_read_from_memory_logs_allowed(self, tmp_path: Path):
+        result = resolve_sandboxed_path(tmp_path, "memory/logs/heartbeat/run.jsonl")
+        assert result == (tmp_path / "memory" / "logs" / "heartbeat" / "run.jsonl").resolve()
+
+    # --- Backward compatibility: existing callers without write_mode ---
+
+    def test_backward_compat_no_write_mode(self, tmp_path: Path):
+        """Calling without write_mode parameter still works for all paths."""
+        result = resolve_sandboxed_path(tmp_path, "data/TASKS.yaml")
+        assert result == (tmp_path / "data" / "TASKS.yaml").resolve()
+
+    # --- Existing security checks are unaffected ---
+
+    def test_absolute_path_still_rejected_in_write_mode(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="Absolute paths"):
+            resolve_sandboxed_path(tmp_path, "/etc/passwd", write_mode=True)
+
+    def test_path_traversal_still_rejected_in_write_mode(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="Path traversal"):
+            resolve_sandboxed_path(tmp_path, "../etc/passwd", write_mode=True)
+
+    def test_home_expansion_still_rejected_in_write_mode(self, tmp_path: Path):
+        with pytest.raises(ValueError, match="Home directory"):
+            resolve_sandboxed_path(tmp_path, "~/secrets.txt", write_mode=True)
+
+    # --- WRITE_PROTECTED_DIRS constant sanity ---
+
+    def test_write_protected_dirs_constant_content(self):
+        """Verify the constant contains exactly the directories we expect."""
+        assert "data" in WRITE_PROTECTED_DIRS
+        assert "config" in WRITE_PROTECTED_DIRS
+        assert "memory/logs" in WRITE_PROTECTED_DIRS
+        assert "memory/conversations" in WRITE_PROTECTED_DIRS
+        # workspace/ and agent/ must NOT be in the set
+        assert "workspace" not in WRITE_PROTECTED_DIRS
+        assert "agent" not in WRITE_PROTECTED_DIRS

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -214,12 +214,12 @@ def test_conversation_id_format(tmp_path: Path):
 
 
 def test_openpaw_directory_created(tmp_path: Path):
-    """Test SessionManager creates .openpaw directory."""
+    """Test SessionManager creates data directory."""
     manager = SessionManager(tmp_path)
 
-    openpaw_dir = tmp_path / ".openpaw"
-    assert openpaw_dir.exists()
-    assert openpaw_dir.is_dir()
+    data_dir = tmp_path / "data"
+    assert data_dir.exists()
+    assert data_dir.is_dir()
 
 
 def test_sessions_json_created_on_first_save(tmp_path: Path):
@@ -227,7 +227,7 @@ def test_sessions_json_created_on_first_save(tmp_path: Path):
     manager = SessionManager(tmp_path)
 
     # Initially no file
-    state_file = tmp_path / ".openpaw" / "sessions.json"
+    state_file = tmp_path / "data" / "sessions.json"
     # File may or may not exist yet (depends on whether constructor saves empty state)
 
     # Create a session (definitely triggers save)
@@ -241,9 +241,9 @@ def test_sessions_json_created_on_first_save(tmp_path: Path):
 def test_corrupted_json_handled_gracefully(tmp_path: Path):
     """Test manager handles corrupted JSON file gracefully."""
     # Create corrupted JSON file
-    openpaw_dir = tmp_path / ".openpaw"
-    openpaw_dir.mkdir(parents=True, exist_ok=True)
-    state_file = openpaw_dir / "sessions.json"
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    state_file = data_dir / "sessions.json"
     state_file.write_text("{corrupted json content")
 
     # Should not crash

--- a/tests/test_session_persistence.py
+++ b/tests/test_session_persistence.py
@@ -38,7 +38,7 @@ class TestSessionLogger:
         logger = SessionLogger(workspace, session_type="heartbeat")
         logger._ensure_dir()
 
-        sessions_dir = workspace / "memory" / "sessions" / "heartbeat"
+        sessions_dir = workspace / "memory" / "logs" / "heartbeat"
         assert sessions_dir.exists()
         assert sessions_dir.is_dir()
 
@@ -63,7 +63,7 @@ class TestSessionLogger:
 
         # Verify path is relative
         assert not relative_path.startswith("/")
-        assert relative_path.startswith("memory/sessions/heartbeat/")
+        assert relative_path.startswith("memory/logs/heartbeat/")
 
         # Read back and verify 3 records
         full_path = workspace / relative_path
@@ -114,7 +114,7 @@ class TestSessionLogger:
 
         # Should be relative path
         assert not relative_path.startswith("/")
-        assert relative_path.startswith("memory/sessions/cron/")
+        assert relative_path.startswith("memory/logs/cron/")
 
         # Should be readable from workspace root
         full_path = workspace / relative_path

--- a/tests/test_status_tokens.py
+++ b/tests/test_status_tokens.py
@@ -163,7 +163,7 @@ async def test_status_handles_corrupted_log(
 ):
     """Test /status handles corrupted JSONL gracefully."""
     # Create a corrupted token log
-    log_path = workspace_path / ".openpaw" / "token_usage.jsonl"
+    log_path = workspace_path / "data" / "token_usage.jsonl"
     log_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(log_path, "w") as f:

--- a/tests/test_steer_interrupt.py
+++ b/tests/test_steer_interrupt.py
@@ -19,11 +19,13 @@ def mock_workspace(tmp_path: Path) -> AgentWorkspace:
     workspace_path = tmp_path / "test_workspace"
     workspace_path.mkdir()
 
-    # Create required markdown files
-    (workspace_path / "AGENT.md").write_text("# Agent")
-    (workspace_path / "USER.md").write_text("# User")
-    (workspace_path / "SOUL.md").write_text("# Soul")
-    (workspace_path / "HEARTBEAT.md").write_text("# Heartbeat")
+    # Create required markdown files in the agent/ subdirectory.
+    agent_path = workspace_path / "agent"
+    agent_path.mkdir(parents=True, exist_ok=True)
+    (agent_path / "AGENT.md").write_text("# Agent")
+    (agent_path / "USER.md").write_text("# User")
+    (agent_path / "SOUL.md").write_text("# Soul")
+    (agent_path / "HEARTBEAT.md").write_text("# Heartbeat")
 
     from openpaw.workspace.loader import WorkspaceLoader
 

--- a/tests/test_subagent_store.py
+++ b/tests/test_subagent_store.py
@@ -517,12 +517,12 @@ def test_storage_file_does_not_exist_yet(tmp_path: Path):
 
 
 def test_openpaw_directory_created(tmp_path: Path):
-    """Test SubAgentStore creates .openpaw directory."""
+    """Test SubAgentStore creates data directory."""
     store = SubAgentStore(tmp_path)
 
-    openpaw_dir = tmp_path / ".openpaw"
-    assert openpaw_dir.exists()
-    assert openpaw_dir.is_dir()
+    data_dir = tmp_path / "data"
+    assert data_dir.exists()
+    assert data_dir.is_dir()
 
 
 def test_persistence_survives_reload(tmp_path: Path):

--- a/tests/test_token_logger.py
+++ b/tests/test_token_logger.py
@@ -41,20 +41,20 @@ def sample_metrics() -> InvocationMetrics:
 
 
 def test_logger_creates_directory(logger: TokenUsageLogger, temp_workspace: Path) -> None:
-    """Test that logger creates .openpaw directory on first log."""
-    openpaw_dir = temp_workspace / ".openpaw"
-    assert not openpaw_dir.exists()
+    """Test that logger creates data directory on first log."""
+    data_dir = temp_workspace / "data"
+    assert not data_dir.exists()
 
     metrics = InvocationMetrics(input_tokens=100, output_tokens=50, total_tokens=150)
     logger.log(metrics, workspace="test", invocation_type="user", session_key="test:123")
 
-    assert openpaw_dir.exists()
-    assert openpaw_dir.is_dir()
+    assert data_dir.exists()
+    assert data_dir.is_dir()
 
 
 def test_logger_creates_jsonl_file(logger: TokenUsageLogger, temp_workspace: Path) -> None:
     """Test that logger creates JSONL file on first log."""
-    log_file = temp_workspace / ".openpaw" / "token_usage.jsonl"
+    log_file = temp_workspace / "data" / "token_usage.jsonl"
     assert not log_file.exists()
 
     metrics = InvocationMetrics(input_tokens=100, output_tokens=50, total_tokens=150)
@@ -70,7 +70,7 @@ def test_logger_writes_valid_json(
     """Test that logger writes valid JSON entries."""
     logger.log(sample_metrics, workspace="gilfoyle", invocation_type="user", session_key="telegram:123")
 
-    log_file = temp_workspace / ".openpaw" / "token_usage.jsonl"
+    log_file = temp_workspace / "data" / "token_usage.jsonl"
     with open(log_file) as f:
         line = f.readline()
         entry = json.loads(line)
@@ -97,7 +97,7 @@ def test_logger_appends_multiple_entries(
     logger.log(metrics1, workspace="test", invocation_type="user", session_key="test:123")
     logger.log(metrics2, workspace="test", invocation_type="cron", session_key=None)
 
-    log_file = temp_workspace / ".openpaw" / "token_usage.jsonl"
+    log_file = temp_workspace / "data" / "token_usage.jsonl"
     with open(log_file) as f:
         lines = f.readlines()
 
@@ -173,7 +173,7 @@ def test_reader_filters_old_entries(
 ) -> None:
     """Test that reader filters out entries from previous days."""
     # Manually write an entry from yesterday
-    log_file = temp_workspace / ".openpaw" / "token_usage.jsonl"
+    log_file = temp_workspace / "data" / "token_usage.jsonl"
     log_file.parent.mkdir(parents=True, exist_ok=True)
 
     yesterday = datetime.now(UTC) - timedelta(days=1)
@@ -244,7 +244,7 @@ def test_reader_handles_malformed_entries(
     logger: TokenUsageLogger, reader: TokenUsageReader, temp_workspace: Path, caplog
 ) -> None:
     """Test that reader handles malformed JSON entries gracefully."""
-    log_file = temp_workspace / ".openpaw" / "token_usage.jsonl"
+    log_file = temp_workspace / "data" / "token_usage.jsonl"
     log_file.parent.mkdir(parents=True, exist_ok=True)
 
     # Write valid entry
@@ -277,7 +277,7 @@ def test_reader_handles_missing_fields(
     logger: TokenUsageLogger, reader: TokenUsageReader, temp_workspace: Path
 ) -> None:
     """Test that reader handles entries with missing fields."""
-    log_file = temp_workspace / ".openpaw" / "token_usage.jsonl"
+    log_file = temp_workspace / "data" / "token_usage.jsonl"
     log_file.parent.mkdir(parents=True, exist_ok=True)
 
     # Write entry with missing fields
@@ -305,7 +305,7 @@ def test_logger_cron_invocation(logger: TokenUsageLogger, temp_workspace: Path) 
     metrics = InvocationMetrics(input_tokens=100, output_tokens=50, total_tokens=150)
     logger.log(metrics, workspace="test", invocation_type="cron", session_key=None)
 
-    log_file = temp_workspace / ".openpaw" / "token_usage.jsonl"
+    log_file = temp_workspace / "data" / "token_usage.jsonl"
     with open(log_file) as f:
         entry = json.loads(f.readline())
 
@@ -318,7 +318,7 @@ def test_logger_heartbeat_invocation(logger: TokenUsageLogger, temp_workspace: P
     metrics = InvocationMetrics(input_tokens=200, output_tokens=100, total_tokens=300)
     logger.log(metrics, workspace="test", invocation_type="heartbeat", session_key=None)
 
-    log_file = temp_workspace / ".openpaw" / "token_usage.jsonl"
+    log_file = temp_workspace / "data" / "token_usage.jsonl"
     with open(log_file) as f:
         entry = json.loads(f.readline())
 

--- a/tests/test_vector_factory.py
+++ b/tests/test_vector_factory.py
@@ -29,8 +29,8 @@ class TestCreateVectorStore:
         # Verify the returned instance
         assert store is mock_store
 
-    def test_sqlite_vec_creates_openpaw_directory(self, tmp_path):
-        """Test create_vector_store creates .openpaw directory."""
+    def test_sqlite_vec_creates_data_directory(self, tmp_path):
+        """Test create_vector_store creates data directory."""
         with patch("openpaw.stores.vector.sqlite_vec.SqliteVecStore") as mock_sqlite_vec_class:
             mock_store = MagicMock()
             mock_sqlite_vec_class.return_value = mock_store
@@ -38,10 +38,10 @@ class TestCreateVectorStore:
             config = {"dimensions": 1536}
             create_vector_store("sqlite_vec", config, tmp_path)
 
-            # Verify .openpaw directory was created
-            openpaw_dir = tmp_path / ".openpaw"
-            assert openpaw_dir.exists()
-            assert openpaw_dir.is_dir()
+            # Verify data directory was created
+            data_dir = tmp_path / "data"
+            assert data_dir.exists()
+            assert data_dir.is_dir()
 
     @patch("openpaw.stores.vector.sqlite_vec.SqliteVecStore")
     def test_sqlite_vec_db_path_location(self, mock_sqlite_vec_class, tmp_path):
@@ -54,7 +54,7 @@ class TestCreateVectorStore:
 
         call_kwargs = mock_sqlite_vec_class.call_args[1]
         db_path = call_kwargs["db_path"]
-        expected_path = tmp_path / ".openpaw" / "vectors.db"
+        expected_path = tmp_path / "data" / "vectors.db"
         assert db_path == expected_path
 
     def test_unknown_provider_raises_value_error(self, tmp_path):

--- a/tests/test_whisper_processor.py
+++ b/tests/test_whisper_processor.py
@@ -278,7 +278,7 @@ async def test_transcript_saved_to_disk(
 ):
     """Verify transcript is saved as sibling .txt file."""
     # Create the saved audio file on disk
-    uploads_dir = workspace_path / "uploads" / "2026-02-07"
+    uploads_dir = workspace_path / "data" / "uploads" / "2026-02-07"
     uploads_dir.mkdir(parents=True)
     audio_path = uploads_dir / "voice_123.ogg"
     audio_path.write_bytes(b"fake audio data")
@@ -289,7 +289,7 @@ async def test_transcript_saved_to_disk(
             data=b"fake audio data",
             mime_type="audio/ogg",
             filename="voice_123.ogg",
-            saved_path="uploads/2026-02-07/voice_123.ogg",
+            saved_path="data/uploads/2026-02-07/voice_123.ogg",
         )
     ]
 
@@ -304,7 +304,7 @@ async def test_transcript_saved_to_disk(
 
     # Verify processed_path in metadata
     attachment = result.message.attachments[0]
-    assert attachment.metadata.get("processed_path") == "uploads/2026-02-07/voice_123.txt"
+    assert attachment.metadata.get("processed_path") == "data/uploads/2026-02-07/voice_123.txt"
 
 
 @pytest.mark.asyncio
@@ -340,7 +340,7 @@ async def test_transcript_no_workspace_path(
 ):
     """Verify no disk write when workspace_path is not configured."""
     # Create audio file (won't be used for saving)
-    uploads_dir = tmp_path / "uploads" / "2026-02-07"
+    uploads_dir = tmp_path / "data" / "uploads" / "2026-02-07"
     uploads_dir.mkdir(parents=True)
     audio_path = uploads_dir / "voice_123.ogg"
     audio_path.write_bytes(b"fake audio data")
@@ -351,7 +351,7 @@ async def test_transcript_no_workspace_path(
             data=b"fake audio data",
             mime_type="audio/ogg",
             filename="voice_123.ogg",
-            saved_path="uploads/2026-02-07/voice_123.ogg",
+            saved_path="data/uploads/2026-02-07/voice_123.ogg",
         )
     ]
 

--- a/tests/test_workspace_command_integration.py
+++ b/tests/test_workspace_command_integration.py
@@ -16,10 +16,12 @@ def mock_workspace(tmp_path: Path):
     workspace_path.mkdir()
 
     # Create required workspace files
-    (workspace_path / "AGENT.md").write_text("# Agent\nTest agent")
-    (workspace_path / "USER.md").write_text("# User\nTest user")
-    (workspace_path / "SOUL.md").write_text("# Soul\nTest soul")
-    (workspace_path / "HEARTBEAT.md").write_text("# Heartbeat\nTest heartbeat")
+    agent_dir = workspace_path / "agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "AGENT.md").write_text("# Agent\nTest agent")
+    (agent_dir / "USER.md").write_text("# User\nTest user")
+    (agent_dir / "SOUL.md").write_text("# Soul\nTest soul")
+    (agent_dir / "HEARTBEAT.md").write_text("# Heartbeat\nTest heartbeat")
 
     return workspace_path
 
@@ -62,6 +64,7 @@ async def test_workspace_runner_initializes_command_router(mock_config, mock_wor
 
     # Mock workspace loader
     with (
+        patch("openpaw.workspace.runner.migrate_workspace", return_value=[]),
         patch("openpaw.workspace.runner.WorkspaceLoader") as mock_loader_cls,
         patch("openpaw.workspace.runner.load_workspace_tools", return_value=[]),
         patch("openpaw.workspace.runner.BuiltinLoader") as mock_builtin_loader_cls,
@@ -105,6 +108,7 @@ async def test_workspace_runner_registers_framework_commands(mock_config, mock_w
     from openpaw.workspace.runner import WorkspaceRunner
 
     with (
+        patch("openpaw.workspace.runner.migrate_workspace", return_value=[]),
         patch("openpaw.workspace.runner.WorkspaceLoader") as mock_loader_cls,
         patch("openpaw.workspace.runner.load_workspace_tools", return_value=[]),
         patch("openpaw.workspace.runner.BuiltinLoader") as mock_builtin_loader_cls,
@@ -153,6 +157,7 @@ async def test_workspace_runner_build_command_context(mock_config, mock_workspac
     from openpaw.workspace.runner import WorkspaceRunner
 
     with (
+        patch("openpaw.workspace.runner.migrate_workspace", return_value=[]),
         patch("openpaw.workspace.runner.WorkspaceLoader") as mock_loader_cls,
         patch("openpaw.workspace.runner.load_workspace_tools", return_value=[]),
         patch("openpaw.workspace.runner.BuiltinLoader") as mock_builtin_loader_cls,
@@ -225,6 +230,7 @@ async def test_workspace_runner_build_command_context_missing_channel_raises(
     from openpaw.workspace.runner import WorkspaceRunner
 
     with (
+        patch("openpaw.workspace.runner.migrate_workspace", return_value=[]),
         patch("openpaw.workspace.runner.WorkspaceLoader") as mock_loader_cls,
         patch("openpaw.workspace.runner.load_workspace_tools", return_value=[]),
         patch("openpaw.workspace.runner.BuiltinLoader") as mock_builtin_loader_cls,

--- a/tests/test_workspace_migration.py
+++ b/tests/test_workspace_migration.py
@@ -1,0 +1,676 @@
+"""Tests for workspace layout migration (flat → structured).
+
+Covers:
+- Fresh workspace with new layout (no migration needed)
+- Full legacy workspace (all files migrate)
+- Partial migration (only remaining files migrate)
+- Idempotent re-runs (second call is a no-op)
+- SQLite WAL/SHM companion files
+- Empty .openpaw/ cleanup after migration
+- File conflict handling (both old and new exist → skip)
+- Directory migrations (tools/, crons/, uploads/, etc.)
+- memory/sessions → memory/logs rename
+- Already-migrated workspace (all files at new locations → no-op)
+"""
+
+from pathlib import Path
+
+from openpaw.workspace.migration import (
+    _cleanup_empty_dir,
+    _migrate_dir,
+    _migrate_file,
+    migrate_workspace,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write(path: Path, content: str = "data") -> None:
+    """Create parent dirs and write content to path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _make_legacy_workspace(root: Path) -> None:
+    """Populate a workspace with the old flat layout."""
+    # Identity files at workspace root
+    _write(root / "AGENT.md", "# Agent")
+    _write(root / "USER.md", "# User")
+    _write(root / "SOUL.md", "# Soul")
+    _write(root / "HEARTBEAT.md", "# Heartbeat")
+
+    # Config at root
+    _write(root / "agent.yaml", "name: test")
+    _write(root / ".env", "KEY=value")
+
+    # State at root
+    _write(root / "TASKS.yaml", "tasks: []")
+    _write(root / "dynamic_crons.json", "[]")
+    _write(root / "heartbeat_log.jsonl", '{"event":"start"}')
+
+    # .openpaw/ directory contents
+    _write(root / ".openpaw" / "conversations.db", "sqlite")
+    _write(root / ".openpaw" / "sessions.json", "{}")
+    _write(root / ".openpaw" / "subagents.yaml", "subagents: []")
+    _write(root / ".openpaw" / "token_usage.jsonl", '{"tokens":0}')
+    _write(root / ".openpaw" / "vectors.db", "vectors")
+    _write(root / ".openpaw" / "browser_cookies.json", "{}")
+
+    # Directories at root
+    _write(root / "tools" / "my_tool.py", "# tool")
+    _write(root / "skills" / "skill_a" / "SKILL.md", "# Skill")
+    _write(root / "crons" / "daily.yaml", "schedule: 0 9 * * *")
+    _write(root / "uploads" / "2026-01-01" / "photo.jpg", "imgdata")
+    _write(root / "downloads" / "report.pdf", "pdf")
+    _write(root / "screenshots" / "page.png", "png")
+
+    # memory/sessions
+    _write(root / "memory" / "sessions" / "heartbeat" / "run.jsonl", '{"ok":true}')
+    _write(root / "memory" / "conversations" / "conv_1.md", "# Conv")
+
+
+def _make_new_workspace(root: Path) -> None:
+    """Populate a workspace that already uses the new structured layout."""
+    _write(root / "agent" / "AGENT.md", "# Agent")
+    _write(root / "agent" / "USER.md", "# User")
+    _write(root / "agent" / "SOUL.md", "# Soul")
+    _write(root / "agent" / "HEARTBEAT.md", "# Heartbeat")
+
+    _write(root / "config" / "agent.yaml", "name: test")
+    _write(root / "config" / ".env", "KEY=value")
+    _write(root / "config" / "crons" / "daily.yaml", "schedule: 0 9 * * *")
+
+    _write(root / "data" / "conversations.db", "sqlite")
+    _write(root / "data" / "sessions.json", "{}")
+    _write(root / "data" / "TASKS.yaml", "tasks: []")
+    _write(root / "data" / "uploads" / "2026-01-01" / "photo.jpg", "imgdata")
+
+    _write(root / "memory" / "conversations" / "conv_1.md", "# Conv")
+    _write(root / "memory" / "logs" / "heartbeat" / "run.jsonl", '{"ok":true}')
+
+    _write(root / "workspace" / "downloads" / "report.pdf", "pdf")
+    _write(root / "workspace" / "screenshots" / "page.png", "png")
+
+
+# ---------------------------------------------------------------------------
+# 1. Fresh workspace — new layout, nothing to migrate
+# ---------------------------------------------------------------------------
+
+
+class TestFreshNewLayoutWorkspace:
+    """A workspace already using the new structure has no migration actions."""
+
+    def test_returns_empty_action_list(self, tmp_path: Path) -> None:
+        _make_new_workspace(tmp_path)
+        actions = migrate_workspace(tmp_path)
+        # Only directory-creation entries are allowed (target dirs that may not
+        # have existed yet).  No "Moved" entries should appear.
+        moved = [a for a in actions if a.startswith("Moved")]
+        assert moved == []
+
+    def test_existing_files_are_untouched(self, tmp_path: Path) -> None:
+        _make_new_workspace(tmp_path)
+        migrate_workspace(tmp_path)
+        assert (tmp_path / "agent" / "AGENT.md").read_text() == "# Agent"
+        assert (tmp_path / "data" / "sessions.json").read_text() == "{}"
+
+    def test_idempotent_on_new_layout(self, tmp_path: Path) -> None:
+        _make_new_workspace(tmp_path)
+        first = migrate_workspace(tmp_path)
+        second = migrate_workspace(tmp_path)
+        moved_first = [a for a in first if a.startswith("Moved")]
+        moved_second = [a for a in second if a.startswith("Moved")]
+        assert moved_first == []
+        assert moved_second == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Full legacy workspace — everything migrates
+# ---------------------------------------------------------------------------
+
+
+class TestFullLegacyMigration:
+    """All files in old locations should be moved to new locations."""
+
+    def test_identity_files_move_to_agent_dir(self, tmp_path: Path) -> None:
+        _make_legacy_workspace(tmp_path)
+        migrate_workspace(tmp_path)
+
+        for fname in ("AGENT.md", "USER.md", "SOUL.md", "HEARTBEAT.md"):
+            assert (tmp_path / "agent" / fname).exists(), f"Missing agent/{fname}"
+            assert not (tmp_path / fname).exists(), f"Old {fname} still present"
+
+    def test_config_files_move_to_config_dir(self, tmp_path: Path) -> None:
+        _make_legacy_workspace(tmp_path)
+        migrate_workspace(tmp_path)
+
+        assert (tmp_path / "config" / "agent.yaml").exists()
+        assert not (tmp_path / "agent.yaml").exists()
+
+        assert (tmp_path / "config" / ".env").exists()
+        assert not (tmp_path / ".env").exists()
+
+    def test_state_files_move_to_data_dir(self, tmp_path: Path) -> None:
+        _make_legacy_workspace(tmp_path)
+        migrate_workspace(tmp_path)
+
+        for fname in ("TASKS.yaml", "dynamic_crons.json", "heartbeat_log.jsonl"):
+            assert (tmp_path / "data" / fname).exists(), f"Missing data/{fname}"
+            assert not (tmp_path / fname).exists(), f"Old {fname} still present"
+
+    def test_openpaw_contents_move_to_data_dir(self, tmp_path: Path) -> None:
+        _make_legacy_workspace(tmp_path)
+        migrate_workspace(tmp_path)
+
+        for fname in (
+            "conversations.db",
+            "sessions.json",
+            "subagents.yaml",
+            "token_usage.jsonl",
+            "vectors.db",
+            "browser_cookies.json",
+        ):
+            assert (tmp_path / "data" / fname).exists(), f"Missing data/{fname}"
+            assert not (tmp_path / ".openpaw" / fname).exists(), (
+                f".openpaw/{fname} still present"
+            )
+
+    def test_tool_and_skills_dirs_move_to_agent(self, tmp_path: Path) -> None:
+        _make_legacy_workspace(tmp_path)
+        migrate_workspace(tmp_path)
+
+        assert (tmp_path / "agent" / "tools" / "my_tool.py").exists()
+        assert not (tmp_path / "tools").exists()
+
+        assert (tmp_path / "agent" / "skills" / "skill_a" / "SKILL.md").exists()
+        assert not (tmp_path / "skills").exists()
+
+    def test_crons_dir_moves_to_config(self, tmp_path: Path) -> None:
+        _make_legacy_workspace(tmp_path)
+        migrate_workspace(tmp_path)
+
+        assert (tmp_path / "config" / "crons" / "daily.yaml").exists()
+        assert not (tmp_path / "crons").exists()
+
+    def test_uploads_dir_moves_to_data(self, tmp_path: Path) -> None:
+        _make_legacy_workspace(tmp_path)
+        migrate_workspace(tmp_path)
+
+        assert (tmp_path / "data" / "uploads" / "2026-01-01" / "photo.jpg").exists()
+        assert not (tmp_path / "uploads").exists()
+
+    def test_downloads_and_screenshots_move_to_workspace(self, tmp_path: Path) -> None:
+        _make_legacy_workspace(tmp_path)
+        migrate_workspace(tmp_path)
+
+        assert (tmp_path / "workspace" / "downloads" / "report.pdf").exists()
+        assert not (tmp_path / "downloads").exists()
+
+        assert (tmp_path / "workspace" / "screenshots" / "page.png").exists()
+        assert not (tmp_path / "screenshots").exists()
+
+    def test_memory_sessions_renamed_to_memory_logs(self, tmp_path: Path) -> None:
+        _make_legacy_workspace(tmp_path)
+        migrate_workspace(tmp_path)
+
+        assert (tmp_path / "memory" / "logs" / "heartbeat" / "run.jsonl").exists()
+        assert not (tmp_path / "memory" / "sessions").exists()
+
+    def test_memory_conversations_dir_is_unchanged(self, tmp_path: Path) -> None:
+        """memory/conversations/ path does not change."""
+        _make_legacy_workspace(tmp_path)
+        migrate_workspace(tmp_path)
+
+        assert (tmp_path / "memory" / "conversations" / "conv_1.md").exists()
+
+    def test_file_content_preserved_after_move(self, tmp_path: Path) -> None:
+        _make_legacy_workspace(tmp_path)
+        migrate_workspace(tmp_path)
+
+        assert (tmp_path / "agent" / "AGENT.md").read_text() == "# Agent"
+        assert (tmp_path / "data" / "sessions.json").read_text() == "{}"
+        assert (tmp_path / "config" / "agent.yaml").read_text() == "name: test"
+
+    def test_actions_list_is_non_empty(self, tmp_path: Path) -> None:
+        _make_legacy_workspace(tmp_path)
+        actions = migrate_workspace(tmp_path)
+        moved = [a for a in actions if a.startswith("Moved")]
+        assert len(moved) > 0
+
+    def test_actions_contain_moved_entries(self, tmp_path: Path) -> None:
+        _make_legacy_workspace(tmp_path)
+        actions = migrate_workspace(tmp_path)
+        # Check a representative sample
+        assert any("AGENT.md" in a for a in actions)
+        assert any("sessions.json" in a for a in actions)
+        assert any("tools/" in a for a in actions)
+
+
+# ---------------------------------------------------------------------------
+# 3. Partial migration — some files already moved
+# ---------------------------------------------------------------------------
+
+
+class TestPartialMigration:
+    """If only some files have been moved, remaining files still migrate."""
+
+    def test_only_unmoved_files_are_migrated(self, tmp_path: Path) -> None:
+        _make_legacy_workspace(tmp_path)
+        # Pre-move a subset of files manually
+        (tmp_path / "agent").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "AGENT.md").rename(tmp_path / "agent" / "AGENT.md")
+
+        actions = migrate_workspace(tmp_path)
+        moved = [a for a in actions if a.startswith("Moved")]
+
+        # AGENT.md was already moved — it should not appear again
+        agent_md_moves = [a for a in moved if "AGENT.md" in a]
+        assert agent_md_moves == []
+
+        # The other identity files should still be migrated
+        assert any("USER.md" in a for a in moved)
+        assert any("SOUL.md" in a for a in moved)
+        assert any("HEARTBEAT.md" in a for a in moved)
+
+    def test_partial_migration_leaves_all_files_intact(self, tmp_path: Path) -> None:
+        _make_legacy_workspace(tmp_path)
+        # Pre-move config only
+        (tmp_path / "config").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "agent.yaml").rename(tmp_path / "config" / "agent.yaml")
+
+        migrate_workspace(tmp_path)
+
+        # Config files
+        assert (tmp_path / "config" / "agent.yaml").exists()
+        assert (tmp_path / "config" / ".env").exists()
+        # Identity files should still have been migrated
+        assert (tmp_path / "agent" / "AGENT.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# 4. Idempotent re-runs
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    """Running migrate_workspace twice is safe and produces no new moves."""
+
+    def test_second_run_returns_no_moved_actions(self, tmp_path: Path) -> None:
+        _make_legacy_workspace(tmp_path)
+        migrate_workspace(tmp_path)
+        second_actions = migrate_workspace(tmp_path)
+
+        moved_second = [a for a in second_actions if a.startswith("Moved")]
+        assert moved_second == []
+
+    def test_second_run_does_not_alter_files(self, tmp_path: Path) -> None:
+        _make_legacy_workspace(tmp_path)
+        migrate_workspace(tmp_path)
+
+        content_after_first = (tmp_path / "agent" / "AGENT.md").read_text()
+        migrate_workspace(tmp_path)
+        content_after_second = (tmp_path / "agent" / "AGENT.md").read_text()
+
+        assert content_after_first == content_after_second
+
+
+# ---------------------------------------------------------------------------
+# 5. SQLite WAL/SHM companion files
+# ---------------------------------------------------------------------------
+
+
+class TestSQLiteCompanionFiles:
+    """WAL and SHM files should migrate alongside the main conversations.db."""
+
+    def test_wal_file_migrates_with_db(self, tmp_path: Path) -> None:
+        _write(tmp_path / ".openpaw" / "conversations.db", "sqlite")
+        _write(tmp_path / ".openpaw" / "conversations.db-wal", "wal")
+
+        migrate_workspace(tmp_path)
+
+        assert (tmp_path / "data" / "conversations.db").exists()
+        assert (tmp_path / "data" / "conversations.db-wal").exists()
+        assert not (tmp_path / ".openpaw" / "conversations.db-wal").exists()
+
+    def test_shm_file_migrates_with_db(self, tmp_path: Path) -> None:
+        _write(tmp_path / ".openpaw" / "conversations.db", "sqlite")
+        _write(tmp_path / ".openpaw" / "conversations.db-shm", "shm")
+
+        migrate_workspace(tmp_path)
+
+        assert (tmp_path / "data" / "conversations.db-shm").exists()
+        assert not (tmp_path / ".openpaw" / "conversations.db-shm").exists()
+
+    def test_all_three_db_files_migrate_together(self, tmp_path: Path) -> None:
+        _write(tmp_path / ".openpaw" / "conversations.db", "sqlite")
+        _write(tmp_path / ".openpaw" / "conversations.db-wal", "wal")
+        _write(tmp_path / ".openpaw" / "conversations.db-shm", "shm")
+
+        migrate_workspace(tmp_path)
+
+        for fname in ("conversations.db", "conversations.db-wal", "conversations.db-shm"):
+            assert (tmp_path / "data" / fname).exists(), f"Missing data/{fname}"
+            assert not (tmp_path / ".openpaw" / fname).exists(), (
+                f".openpaw/{fname} still present"
+            )
+
+    def test_missing_wal_shm_does_not_error(self, tmp_path: Path) -> None:
+        """Only the main DB exists — migration should complete without error."""
+        _write(tmp_path / ".openpaw" / "conversations.db", "sqlite")
+
+        actions = migrate_workspace(tmp_path)
+
+        assert (tmp_path / "data" / "conversations.db").exists()
+        # No WAL/SHM files mentioned in actions (they didn't exist)
+        assert not any("wal" in a for a in actions)
+        assert not any("shm" in a for a in actions)
+
+
+# ---------------------------------------------------------------------------
+# 6. Empty .openpaw/ cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestOpenpawCleanup:
+    """The .openpaw/ directory should be removed after its contents are migrated."""
+
+    def test_empty_openpaw_is_removed(self, tmp_path: Path) -> None:
+        _write(tmp_path / ".openpaw" / "sessions.json", "{}")
+
+        migrate_workspace(tmp_path)
+
+        assert not (tmp_path / ".openpaw").exists()
+
+    def test_non_empty_openpaw_is_not_removed(self, tmp_path: Path) -> None:
+        """If .openpaw/ still has files after migration, leave it alone."""
+        _write(tmp_path / ".openpaw" / "sessions.json", "{}")
+        # Add an unrecognised file that won't be migrated
+        _write(tmp_path / ".openpaw" / "unknown_file.dat", "mystery")
+
+        migrate_workspace(tmp_path)
+
+        # .openpaw/ should still exist because unknown_file.dat remains
+        assert (tmp_path / ".openpaw").exists()
+        assert (tmp_path / ".openpaw" / "unknown_file.dat").exists()
+
+    def test_absent_openpaw_does_not_error(self, tmp_path: Path) -> None:
+        """No .openpaw/ directory at all — should be a no-op."""
+        migrate_workspace(tmp_path)  # Must not raise
+
+    def test_cleanup_appears_in_actions(self, tmp_path: Path) -> None:
+        _write(tmp_path / ".openpaw" / "sessions.json", "{}")
+
+        actions = migrate_workspace(tmp_path)
+        removed = [a for a in actions if "Removed" in a and ".openpaw" in a]
+        assert len(removed) == 1
+
+
+# ---------------------------------------------------------------------------
+# 7. File conflict — both old and new exist
+# ---------------------------------------------------------------------------
+
+
+class TestFileConflict:
+    """When both source and destination exist, skip and warn. Never overwrite."""
+
+    def test_existing_destination_is_not_overwritten(self, tmp_path: Path) -> None:
+        _write(tmp_path / "AGENT.md", "old content")
+        (tmp_path / "agent").mkdir(parents=True, exist_ok=True)
+        _write(tmp_path / "agent" / "AGENT.md", "new content")
+
+        migrate_workspace(tmp_path)
+
+        # Destination retains its content
+        assert (tmp_path / "agent" / "AGENT.md").read_text() == "new content"
+
+    def test_source_is_left_in_place_on_conflict(self, tmp_path: Path) -> None:
+        _write(tmp_path / "USER.md", "original")
+        (tmp_path / "agent").mkdir(parents=True, exist_ok=True)
+        _write(tmp_path / "agent" / "USER.md", "migrated already")
+
+        migrate_workspace(tmp_path)
+
+        # Source file is NOT deleted when there's a conflict
+        assert (tmp_path / "USER.md").exists()
+        assert (tmp_path / "USER.md").read_text() == "original"
+
+    def test_conflict_does_not_appear_in_actions(self, tmp_path: Path) -> None:
+        _write(tmp_path / "SOUL.md", "old")
+        (tmp_path / "agent").mkdir(parents=True, exist_ok=True)
+        _write(tmp_path / "agent" / "SOUL.md", "new")
+
+        actions = migrate_workspace(tmp_path)
+
+        soul_moves = [a for a in actions if "SOUL.md" in a and a.startswith("Moved")]
+        assert soul_moves == []
+
+    def test_conflict_on_one_file_does_not_block_others(self, tmp_path: Path) -> None:
+        """A conflict on AGENT.md should not prevent USER.md from migrating."""
+        _write(tmp_path / "AGENT.md", "old agent")
+        _write(tmp_path / "USER.md", "user content")
+        (tmp_path / "agent").mkdir(parents=True, exist_ok=True)
+        _write(tmp_path / "agent" / "AGENT.md", "already there")
+
+        migrate_workspace(tmp_path)
+
+        # USER.md should have migrated despite AGENT.md conflict
+        assert (tmp_path / "agent" / "USER.md").exists()
+        assert (tmp_path / "agent" / "USER.md").read_text() == "user content"
+
+
+# ---------------------------------------------------------------------------
+# 8. Directory migration
+# ---------------------------------------------------------------------------
+
+
+class TestDirectoryMigration:
+    """Directories are moved with their full contents."""
+
+    def test_tools_dir_migrates_with_contents(self, tmp_path: Path) -> None:
+        _write(tmp_path / "tools" / "alpha.py", "# alpha")
+        _write(tmp_path / "tools" / "beta.py", "# beta")
+
+        migrate_workspace(tmp_path)
+
+        assert (tmp_path / "agent" / "tools" / "alpha.py").exists()
+        assert (tmp_path / "agent" / "tools" / "beta.py").exists()
+        assert not (tmp_path / "tools").exists()
+
+    def test_crons_dir_migrates_with_contents(self, tmp_path: Path) -> None:
+        _write(tmp_path / "crons" / "daily.yaml", "schedule: 0 9 * * *")
+        _write(tmp_path / "crons" / "weekly.yml", "schedule: 0 0 * * 0")
+
+        migrate_workspace(tmp_path)
+
+        assert (tmp_path / "config" / "crons" / "daily.yaml").exists()
+        assert (tmp_path / "config" / "crons" / "weekly.yml").exists()
+        assert not (tmp_path / "crons").exists()
+
+    def test_uploads_dir_migrates_with_date_partitions(self, tmp_path: Path) -> None:
+        _write(tmp_path / "uploads" / "2026-01-01" / "img.jpg", "jpeg")
+        _write(tmp_path / "uploads" / "2026-01-02" / "doc.pdf", "pdf")
+
+        migrate_workspace(tmp_path)
+
+        assert (tmp_path / "data" / "uploads" / "2026-01-01" / "img.jpg").exists()
+        assert (tmp_path / "data" / "uploads" / "2026-01-02" / "doc.pdf").exists()
+        assert not (tmp_path / "uploads").exists()
+
+    def test_dir_conflict_leaves_source_in_place(self, tmp_path: Path) -> None:
+        """If destination directory exists, skip move and preserve source."""
+        _write(tmp_path / "tools" / "old_tool.py", "# old")
+        (tmp_path / "agent" / "tools").mkdir(parents=True, exist_ok=True)
+        _write(tmp_path / "agent" / "tools" / "new_tool.py", "# new")
+
+        migrate_workspace(tmp_path)
+
+        # Old source dir still exists (not moved because destination exists)
+        assert (tmp_path / "tools").exists()
+        # New destination is untouched
+        assert (tmp_path / "agent" / "tools" / "new_tool.py").exists()
+        # Old file is NOT moved into destination
+        assert not (tmp_path / "agent" / "tools" / "old_tool.py").exists()
+
+    def test_memory_sessions_renamed_to_logs(self, tmp_path: Path) -> None:
+        _write(tmp_path / "memory" / "sessions" / "heartbeat" / "run.jsonl", '{"ok":1}')
+        _write(tmp_path / "memory" / "sessions" / "cron" / "job.jsonl", '{"cron":1}')
+
+        migrate_workspace(tmp_path)
+
+        assert (tmp_path / "memory" / "logs" / "heartbeat" / "run.jsonl").exists()
+        assert (tmp_path / "memory" / "logs" / "cron" / "job.jsonl").exists()
+        assert not (tmp_path / "memory" / "sessions").exists()
+
+
+# ---------------------------------------------------------------------------
+# 9. Target directory creation
+# ---------------------------------------------------------------------------
+
+
+class TestTargetDirectoryCreation:
+    """All required target directories should be created by migrate_workspace."""
+
+    def test_all_top_level_dirs_are_created(self, tmp_path: Path) -> None:
+        migrate_workspace(tmp_path)
+
+        for d in ("agent", "config", "data", "memory", "workspace"):
+            assert (tmp_path / d).is_dir(), f"Missing top-level directory: {d}/"
+
+    def test_memory_subdirs_are_created(self, tmp_path: Path) -> None:
+        migrate_workspace(tmp_path)
+
+        assert (tmp_path / "memory" / "conversations").is_dir()
+        assert (tmp_path / "memory" / "logs").is_dir()
+
+    def test_creation_actions_in_result(self, tmp_path: Path) -> None:
+        actions = migrate_workspace(tmp_path)
+        created = [a for a in actions if a.startswith("Created")]
+        assert len(created) > 0
+
+
+# ---------------------------------------------------------------------------
+# 10. Already-migrated workspace — complete no-op
+# ---------------------------------------------------------------------------
+
+
+class TestAlreadyMigratedWorkspace:
+    """A workspace fully on the new layout produces zero move actions."""
+
+    def test_no_moves_on_new_layout(self, tmp_path: Path) -> None:
+        _make_new_workspace(tmp_path)
+        actions = migrate_workspace(tmp_path)
+        moved = [a for a in actions if a.startswith("Moved")]
+        assert moved == []
+
+    def test_no_removed_entries_on_new_layout(self, tmp_path: Path) -> None:
+        _make_new_workspace(tmp_path)
+        actions = migrate_workspace(tmp_path)
+        removed = [a for a in actions if a.startswith("Removed")]
+        assert removed == []
+
+    def test_files_remain_at_new_locations(self, tmp_path: Path) -> None:
+        _make_new_workspace(tmp_path)
+        migrate_workspace(tmp_path)
+
+        assert (tmp_path / "agent" / "AGENT.md").read_text() == "# Agent"
+        assert (tmp_path / "config" / "agent.yaml").read_text() == "name: test"
+        assert (tmp_path / "data" / "sessions.json").read_text() == "{}"
+
+
+# ---------------------------------------------------------------------------
+# 11. Unit tests for private helpers
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateFileHelper:
+    """Unit tests for the _migrate_file internal helper."""
+
+    def test_moves_file_when_source_exists(self, tmp_path: Path) -> None:
+        _write(tmp_path / "old.txt", "content")
+        actions: list[str] = []
+        _migrate_file(tmp_path, "old.txt", "subdir/new.txt", actions)
+
+        assert (tmp_path / "subdir" / "new.txt").read_text() == "content"
+        assert not (tmp_path / "old.txt").exists()
+        assert any("old.txt" in a for a in actions)
+
+    def test_no_op_when_source_missing(self, tmp_path: Path) -> None:
+        actions: list[str] = []
+        _migrate_file(tmp_path, "nonexistent.txt", "target.txt", actions)
+        assert actions == []
+
+    def test_skips_when_destination_exists(self, tmp_path: Path) -> None:
+        _write(tmp_path / "old.txt", "source")
+        _write(tmp_path / "new.txt", "destination")
+        actions: list[str] = []
+        _migrate_file(tmp_path, "old.txt", "new.txt", actions)
+
+        assert (tmp_path / "new.txt").read_text() == "destination"
+        assert (tmp_path / "old.txt").exists()
+        assert actions == []
+
+    def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        _write(tmp_path / "file.txt", "hello")
+        actions: list[str] = []
+        _migrate_file(tmp_path, "file.txt", "a/b/c/file.txt", actions)
+
+        assert (tmp_path / "a" / "b" / "c" / "file.txt").exists()
+
+
+class TestMigrateDirHelper:
+    """Unit tests for the _migrate_dir internal helper."""
+
+    def test_moves_directory_when_source_exists(self, tmp_path: Path) -> None:
+        _write(tmp_path / "old_dir" / "file.txt", "content")
+        actions: list[str] = []
+        _migrate_dir(tmp_path, "old_dir", "new_dir", actions)
+
+        assert (tmp_path / "new_dir" / "file.txt").read_text() == "content"
+        assert not (tmp_path / "old_dir").exists()
+        assert any("old_dir" in a for a in actions)
+
+    def test_no_op_when_source_missing(self, tmp_path: Path) -> None:
+        actions: list[str] = []
+        _migrate_dir(tmp_path, "missing_dir", "target_dir", actions)
+        assert actions == []
+
+    def test_skips_when_destination_exists(self, tmp_path: Path) -> None:
+        _write(tmp_path / "old_dir" / "old.txt", "old")
+        (tmp_path / "new_dir").mkdir()
+        _write(tmp_path / "new_dir" / "new.txt", "new")
+        actions: list[str] = []
+        _migrate_dir(tmp_path, "old_dir", "new_dir", actions)
+
+        assert (tmp_path / "old_dir").exists()
+        assert (tmp_path / "new_dir" / "new.txt").read_text() == "new"
+        assert actions == []
+
+
+class TestCleanupEmptyDirHelper:
+    """Unit tests for the _cleanup_empty_dir internal helper."""
+
+    def test_removes_empty_directory(self, tmp_path: Path) -> None:
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        actions: list[str] = []
+        _cleanup_empty_dir(empty_dir, actions)
+
+        assert not empty_dir.exists()
+        assert any("Removed" in a for a in actions)
+
+    def test_does_not_remove_non_empty_directory(self, tmp_path: Path) -> None:
+        non_empty = tmp_path / "nonempty"
+        non_empty.mkdir()
+        _write(non_empty / "file.txt", "data")
+        actions: list[str] = []
+        _cleanup_empty_dir(non_empty, actions)
+
+        assert non_empty.exists()
+        assert actions == []
+
+    def test_no_op_when_directory_absent(self, tmp_path: Path) -> None:
+        actions: list[str] = []
+        _cleanup_empty_dir(tmp_path / "does_not_exist", actions)
+        assert actions == []

--- a/tests/test_workspace_subagent.py
+++ b/tests/test_workspace_subagent.py
@@ -16,11 +16,13 @@ def mock_workspace(tmp_path: Path) -> AgentWorkspace:
     workspace_path = tmp_path / "test_workspace"
     workspace_path.mkdir()
 
-    # Create required markdown files
-    (workspace_path / "AGENT.md").write_text("# Agent")
-    (workspace_path / "USER.md").write_text("# User")
-    (workspace_path / "SOUL.md").write_text("# Soul")
-    (workspace_path / "HEARTBEAT.md").write_text("# Heartbeat")
+    # Create required markdown files in the agent/ subdirectory.
+    agent_path = workspace_path / "agent"
+    agent_path.mkdir(parents=True, exist_ok=True)
+    (agent_path / "AGENT.md").write_text("# Agent")
+    (agent_path / "USER.md").write_text("# User")
+    (agent_path / "SOUL.md").write_text("# Soul")
+    (agent_path / "HEARTBEAT.md").write_text("# Heartbeat")
 
     loader = WorkspaceLoader(tmp_path)
     return loader.load("test_workspace")


### PR DESCRIPTION
## Summary

- Restructures flat workspace layout into 5-directory hierarchy: `agent/`, `config/`, `data/`, `memory/`, `workspace/`
- Centralizes all workspace-relative paths in `openpaw/core/paths.py` (single source of truth)
- Adds write-protection for framework-managed directories (`data/`, `config/`, `memory/logs`, `memory/conversations`) with `HEARTBEAT.md` exception
- Defaults agent write operations to `workspace/` subdirectory transparently
- Auto-migrates existing workspaces on startup (idempotent, zero manual steps)
- Updates `openpaw init` to scaffold new structure
- Updates prompts, README, and all store/loader path references

## Test plan

- [x] 1580 tests passing (168 net new from baseline 1412)
- [x] All 4 production workspaces migrated and booted successfully (krieger, gilfoyle, dr_wilson, joan_holloway)
- [x] Krieger integration-tested via Telegram (most complex workspace)
- [x] Migration idempotent — re-running on already-migrated workspace is a no-op
- [x] Lint and type check: no regressions (pre-existing counts unchanged)

Closes #32