### PR TITLE
develop → main: cron fixes and channel history tool

### DIFF
--- a/docs/channels.md
+++ b/docs/channels.md
@@ -125,7 +125,7 @@ To get your Telegram user ID:
 - Message [@userinfobot](https://t.me/userinfobot)
 - It will reply with your user ID
 
-Only listed users can message the bot. Messages from other users are silently ignored.
+Only listed users can DM the bot. Messages from other users are silently ignored.
 
 #### Group Allowlist
 
@@ -140,7 +140,7 @@ To get a group ID:
 2. It will post the group's chat ID (negative number for groups)
 3. Remove the bot after getting the ID
 
-Only messages from listed groups are processed.
+When a group is in `allowed_groups`, **any user** in that group can interact with the bot — they do not need to be individually listed in `allowed_users`. The `allowed_users` list controls who can DM the bot directly.
 
 ### Supported Message Types
 
@@ -310,7 +310,7 @@ channel:
   allowed_groups: [123456789012345678]  # Guild IDs
 ```
 
-When `allowed_groups` is set, messages from other servers are rejected even if the user is in `allowed_users`.
+When a guild is in `allowed_groups`, **any user** in that guild can interact with the bot — they do not need to be individually listed in `allowed_users`. The `allowed_users` list controls who can DM the bot directly. Messages from guilds not in the allowlist are rejected unless the sender is individually allowlisted.
 
 ### Activation Filters
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -379,9 +379,9 @@ channels:
 
 **token** — Channel-specific bot token.
 
-**allowed_users** — List of allowed user IDs for this workspace.
+**allowed_users** — List of allowed user IDs. Controls who can DM the bot and serves as a fallback for messages from non-allowed groups.
 
-**allowed_groups** — List of allowed group/guild IDs for this workspace.
+**allowed_groups** — List of allowed group/guild IDs. When a group is allowed, **any user** in that group can interact with the bot without being individually listed in `allowed_users`.
 
 **mention_required** — Only respond in group channels when @mentioned (default: `false`).
 

--- a/openpaw/builtins/loader.py
+++ b/openpaw/builtins/loader.py
@@ -38,6 +38,7 @@ class BuiltinLoader:
         ],
         "spawn": ["max_concurrent"],
         "file_persistence": ["max_file_size", "clear_data_after_save"],
+        "channel_history": ["max_messages_per_request", "content_truncation"],
         "md2pdf": ["theme", "max_diagram_width", "self_heal", "self_heal_model", "max_heal_iterations"],
     }
 

--- a/openpaw/builtins/registry.py
+++ b/openpaw/builtins/registry.py
@@ -139,6 +139,13 @@ class BuiltinRegistry:
         except ImportError as e:
             logger.debug(f"md2pdf tool not available: {e}")
 
+        try:
+            from openpaw.builtins.tools.channel_history import ChannelHistoryToolBuiltin
+
+            self.register_tool(ChannelHistoryToolBuiltin)
+        except ImportError as e:
+            logger.debug(f"Channel history tool not available: {e}")
+
         # Processors (sorted by metadata.priority in BuiltinLoader.load_processors)
         try:
             from openpaw.builtins.processors.file_persistence import FilePersistenceProcessor

--- a/openpaw/builtins/tools/channel_history.py
+++ b/openpaw/builtins/tools/channel_history.py
@@ -1,0 +1,509 @@
+"""Channel history browsing builtin tool.
+
+Allows agents to browse and search message history from history-capable
+channel adapters (e.g., Discord). Supports pagination, keyword filtering,
+user filtering, and bot message exclusion.
+"""
+
+import logging
+from datetime import UTC
+from typing import Any
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from openpaw.builtins.base import (
+    BaseBuiltinTool,
+    BuiltinMetadata,
+    BuiltinPrerequisite,
+    BuiltinType,
+)
+from openpaw.builtins.tools._channel_context import get_current_session_key
+from openpaw.channels.base import ChannelAdapter
+
+logger = logging.getLogger(__name__)
+
+# Per-message content truncation (consistent with format_channel_context)
+_MESSAGE_TRUNCATION = 500
+
+# Total output cap (consistent with read_file safety valve)
+_OUTPUT_CAP = 50_000
+
+# Over-fetch multiplier when filters are active
+_OVER_FETCH_RATIO = 3
+
+# Hard cap on adapter fetch when filters are active
+_OVER_FETCH_CAP = 300
+
+
+class BrowseChannelHistoryInput(BaseModel):
+    """Input schema for browse_channel_history."""
+
+    channel: str | None = Field(
+        default=None,
+        description=(
+            "Channel name to query (e.g., 'discord', 'discord-work'). "
+            "Required when multiple history-capable channels exist. "
+            "Auto-selected when only one exists."
+        ),
+    )
+    limit: int = Field(
+        default=50,
+        ge=1,
+        le=100,
+        description="Maximum number of messages to return (1-100).",
+    )
+    before: str | None = Field(
+        default=None,
+        description=(
+            "Pagination cursor — message ID. Fetches messages sent before this "
+            "message. Use the oldest_message_id from a previous call's footer."
+        ),
+    )
+    keyword: str | None = Field(
+        default=None,
+        description="Case-insensitive substring filter on message content.",
+    )
+    user: str | None = Field(
+        default=None,
+        description="Filter by display name (case-insensitive substring match).",
+    )
+    include_bots: bool = Field(
+        default=False,
+        description="Include bot messages in results (default: excluded).",
+    )
+
+
+class ChannelHistoryToolBuiltin(BaseBuiltinTool):
+    """On-demand channel history browser for history-capable adapters.
+
+    Enables agents to browse message history beyond the initial context
+    window, paginate through older messages, and filter by keyword or user.
+
+    Capabilities:
+    - Paginate through channel history (newest to oldest)
+    - Filter by keyword (case-insensitive substring)
+    - Filter by user (case-insensitive display name substring)
+    - Exclude bot messages (default on)
+    - Auto-select the channel when only one supports history
+
+    Config options:
+        max_messages_per_request: Hard cap on messages returned (default: 100)
+        content_truncation: Per-message content char limit (default: 500)
+
+    Wired at startup via set_channels(). If no channel supports history
+    browsing, the tool is removed from the agent by WorkspaceRunner.
+    """
+
+    metadata = BuiltinMetadata(
+        name="channel_history",
+        display_name="Channel History Browser",
+        description="Browse and search message history from history-capable channel adapters",
+        builtin_type=BuiltinType.TOOL,
+        group="communication",
+        prerequisites=BuiltinPrerequisite(),  # Runtime gating, not API-key gating
+    )
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        """Initialize the channel history tool.
+
+        Args:
+            config: Optional configuration dict containing:
+                - max_messages_per_request: Hard cap on messages (default: 100)
+                - content_truncation: Per-message char limit (default: 500)
+        """
+        super().__init__(config)
+
+        self.max_messages_per_request: int = self.config.get("max_messages_per_request", 100)
+        self.content_truncation: int = self.config.get("content_truncation", _MESSAGE_TRUNCATION)
+
+        # Channel adapters — set via set_channels() at workspace startup
+        self._channels: dict[str, ChannelAdapter] | None = None
+
+        logger.debug("ChannelHistoryToolBuiltin initialized")
+
+    def set_channels(self, channels: dict[str, "ChannelAdapter"]) -> None:
+        """Set the history-capable channel adapter references.
+
+        Called by WorkspaceRunner after channels are set up. Only channels
+        with supports_history_browsing == True should be passed.
+
+        Args:
+            channels: Dict mapping channel name -> ChannelAdapter for
+                history-capable channels only.
+        """
+        self._channels = channels
+        logger.info(
+            "ChannelHistoryTool connected to %d channel(s): %s",
+            len(channels),
+            list(channels.keys()),
+        )
+
+    def get_langchain_tool(self) -> Any:
+        """Return the browse_channel_history tool as a list."""
+        return [self._create_browse_tool()]
+
+    def _create_browse_tool(self) -> StructuredTool:
+        """Create the browse_channel_history StructuredTool."""
+
+        def browse_sync(
+            channel: str | None = None,
+            limit: int = 50,
+            before: str | None = None,
+            keyword: str | None = None,
+            user: str | None = None,
+            include_bots: bool = False,
+        ) -> str:
+            """Sync wrapper — delegates to the async implementation via run_coroutine.
+
+            Used by LangChain when the tool is called in a non-async context.
+            """
+            import asyncio
+            import contextvars
+
+            try:
+                asyncio.get_running_loop()
+                import concurrent.futures
+
+                ctx = contextvars.copy_context()
+                with concurrent.futures.ThreadPoolExecutor() as pool:
+                    future = pool.submit(
+                        ctx.run,
+                        asyncio.run,
+                        _browse_async(channel, limit, before, keyword, user, include_bots),
+                    )
+                    return future.result()
+            except RuntimeError:
+                return asyncio.run(
+                    _browse_async(channel, limit, before, keyword, user, include_bots)
+                )
+
+        async def _browse_async(
+            channel: str | None,
+            limit: int,
+            before: str | None,
+            keyword: str | None,
+            user: str | None,
+            include_bots: bool,
+        ) -> str:
+            """Fetch and format channel history with optional filtering."""
+            if self._channels is None:
+                return "[Error: Channel history tool not connected to any channels]"
+
+            if not self._channels:
+                return "[Error: No history-capable channels available in this workspace]"
+
+            # Resolve which channel adapter to use
+            adapter, error = _resolve_adapter(self._channels, channel)
+            if error:
+                return error
+            if adapter is None:
+                return "[Error: Failed to resolve channel adapter]"
+
+            # Determine the platform channel ID from session context
+            channel_id, id_error = _resolve_channel_id(adapter)
+            if id_error:
+                return id_error
+
+            # Clamp limit to configured max
+            effective_limit = min(limit, self.max_messages_per_request)
+
+            # Over-fetch when text filters are active so we have enough after filtering.
+            # Bot exclusion is intentionally excluded from this check: bots are
+            # typically a small fraction of messages, so the 3x multiplier is not
+            # warranted on every default call where include_bots=False.
+            has_filters = bool(keyword or user)
+            fetch_limit = (
+                min(effective_limit * _OVER_FETCH_RATIO, _OVER_FETCH_CAP)
+                if has_filters
+                else effective_limit
+            )
+
+            try:
+                entries = await adapter.fetch_channel_history(
+                    channel_id=channel_id,
+                    limit=fetch_limit,
+                    before_message_id=before,
+                )
+            except Exception as exc:
+                logger.warning("fetch_channel_history failed: %s", exc, exc_info=True)
+                return (
+                    "[No messages retrieved. The bot may lack permission to read "
+                    "history in this channel.]"
+                )
+
+            if not entries:
+                return "[No messages found in channel history]"
+
+            # Apply client-side filters
+            filtered = entries
+            if not include_bots:
+                filtered = [e for e in filtered if not e.is_bot]
+            if keyword:
+                kw = keyword.lower()
+                filtered = [e for e in filtered if kw in e.content.lower()]
+            if user:
+                usr = user.lower()
+                filtered = [e for e in filtered if usr in e.display_name.lower()]
+
+            if not filtered:
+                qualifier = _build_filter_qualifier(keyword, user, include_bots)
+                return f"[No messages found matching filters in #{adapter.name}{qualifier}]"
+
+            # Truncate to the requested limit after filtering
+            matched_count = len(filtered)
+            results = filtered[:effective_limit]
+
+            # Use the adapter's name as the canonical channel identifier now that
+            # it is fully resolved — avoids re-indexing self._channels.
+            resolved_channel_name = adapter.name
+            output = _format_history_output(
+                entries=results,
+                channel_name=resolved_channel_name,
+                adapter_type=adapter.name,
+                requested_limit=effective_limit,
+                matched_count=matched_count,
+                before_cursor=before,
+                content_truncation=self.content_truncation,
+            )
+
+            # Total output cap
+            if len(output) > _OUTPUT_CAP:
+                output = output[:_OUTPUT_CAP]
+                output += (
+                    "\n[Output truncated at 50K characters. "
+                    "Use pagination or narrower filters.]"
+                )
+
+            return output
+
+        async def browse_async(
+            channel: str | None = None,
+            limit: int = 50,
+            before: str | None = None,
+            keyword: str | None = None,
+            user: str | None = None,
+            include_bots: bool = False,
+        ) -> str:
+            """Browse channel message history with optional filtering.
+
+            Args:
+                channel: Channel name to query. Auto-selected when only one
+                    history-capable channel exists.
+                limit: Maximum messages to return (1-100).
+                before: Pagination cursor — message ID from previous call's footer.
+                keyword: Case-insensitive substring filter on content.
+                user: Filter by display name substring (case-insensitive).
+                include_bots: Include bot messages (default: excluded).
+
+            Returns:
+                Formatted history output with timestamps, user IDs, and
+                a pagination footer. Error string on failure.
+            """
+            return await _browse_async(channel, limit, before, keyword, user, include_bots)
+
+        return StructuredTool.from_function(
+            func=browse_sync,
+            coroutine=browse_async,
+            name="browse_channel_history",
+            description=(
+                "Browse message history from a channel (e.g., Discord). "
+                "Supports pagination via the 'before' cursor, keyword and user filtering, "
+                "and bot message exclusion. Use this to access messages beyond the "
+                "initial context window or to search what was discussed in the past."
+            ),
+            args_schema=BrowseChannelHistoryInput,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_adapter(
+    channels: dict[str, "ChannelAdapter"],
+    channel_name: str | None,
+) -> tuple["ChannelAdapter | None", str | None]:
+    """Resolve which adapter to use.
+
+    Args:
+        channels: Available history-capable channels.
+        channel_name: Requested channel name, or None for auto-selection.
+
+    Returns:
+        Tuple of (adapter, error_string). One of the two will be None.
+    """
+    if channel_name is not None:
+        adapter = channels.get(channel_name)
+        if adapter is None:
+            available = ", ".join(sorted(channels.keys()))
+            return None, (
+                f"[Error: Channel '{channel_name}' not found or does not support "
+                f"history browsing. Available: {available}]"
+            )
+        return adapter, None
+
+    # Auto-selection: only works when exactly one history-capable channel exists
+    if len(channels) == 1:
+        return next(iter(channels.values())), None
+
+    available = ", ".join(sorted(channels.keys()))
+    return None, (
+        f"[Error: Multiple history-capable channels available. "
+        f"Specify channel= with one of: {available}]"
+    )
+
+
+def _resolve_channel_id(adapter: "ChannelAdapter") -> tuple[str, str | None]:
+    """Resolve the platform channel ID from context or return an error.
+
+    Uses the current session key from _channel_context contextvars to extract
+    the channel ID. Fails gracefully when running outside a user session (e.g.,
+    from a cron job without a channel context).
+
+    Args:
+        adapter: The selected channel adapter.
+
+    Returns:
+        Tuple of (channel_id, error_string). One will be None.
+    """
+    session_key = get_current_session_key()
+    if not session_key:
+        return "", (
+            "[Error: No active session context. "
+            "Cannot determine which channel to browse. "
+            "This tool must be called from within a channel session.]"
+        )
+
+    # Session key format: "{channel_name}:{channel_id}"
+    # channel_name can contain colons (e.g., "discord-work"), but channel_id
+    # is always the last segment.
+    parts = session_key.rsplit(":", 1)
+    if len(parts) != 2 or not parts[1]:
+        return "", (
+            f"[Error: Unable to extract channel ID from session key '{session_key}'. "
+            f"Provide the channel_id explicitly or ensure you are in a guild channel.]"
+        )
+
+    channel_id = parts[1]
+
+    # Detect DMs: Discord DM session keys use the user ID as channel_id,
+    # but we can't tell without platform context. We surface an informative
+    # message if the fetch returns empty (handled in the caller).
+    return channel_id, None
+
+
+def _build_filter_qualifier(
+    keyword: str | None,
+    user: str | None,
+    include_bots: bool,
+) -> str:
+    """Build a human-readable description of active filters for no-result messages.
+
+    Args:
+        keyword: Active keyword filter, or None.
+        user: Active user filter, or None.
+        include_bots: Whether bot messages are included.
+
+    Returns:
+        Qualifier string like " (keyword='deploy', user='Alice')" or "".
+    """
+    parts = []
+    if keyword:
+        parts.append(f"keyword='{keyword}'")
+    if user:
+        parts.append(f"user='{user}'")
+    if not include_bots:
+        parts.append("bots excluded")
+    return f" ({', '.join(parts)})" if parts else ""
+
+
+def _format_history_output(
+    entries: list[Any],
+    channel_name: str,
+    adapter_type: str,
+    requested_limit: int,
+    matched_count: int,
+    before_cursor: str | None,
+    content_truncation: int,
+) -> str:
+    """Format channel history entries as readable text.
+
+    Args:
+        entries: ChannelHistoryEntry list (already filtered and truncated to limit).
+        channel_name: Human-readable channel name for the header.
+        adapter_type: Platform type string (e.g., "discord") for the header.
+        requested_limit: The limit the agent requested.
+        matched_count: Total matched entries before truncation to limit.
+        before_cursor: The 'before' cursor used in this request, for header display.
+        content_truncation: Per-message character truncation limit.
+
+    Returns:
+        Formatted multi-line string suitable for agent consumption.
+    """
+    lines: list[str] = []
+
+    # Header
+    count = len(entries)
+    lines.append(
+        f"[Channel History: #{channel_name} ({adapter_type}) — {count} message(s), oldest first]"
+    )
+    if before_cursor:
+        lines.append(f"[Showing messages before ID: {before_cursor}]")
+    lines.append("")
+
+    # Message lines
+    for entry in entries:
+        timestamp_str = _format_timestamp(entry.timestamp)
+        content = entry.content
+        if len(content) > content_truncation:
+            content = content[:content_truncation] + "..."
+
+        suffix = ""
+        if entry.attachments_summary:
+            suffix = f" {entry.attachments_summary}"
+
+        lines.append(
+            f"[{timestamp_str}] {entry.display_name} (id:{entry.user_id}): {content}{suffix}"
+        )
+
+    # Pagination footer
+    lines.append("")
+    if entries:
+        oldest_id = entries[0].message_id
+        if oldest_id:
+            lines.append(
+                f"[Pagination: oldest_message_id={oldest_id} — "
+                f"use before=\"{oldest_id}\" to load older messages]"
+            )
+
+    if matched_count > requested_limit:
+        lines.append(
+            f"[Showing {requested_limit} of {matched_count} matched — "
+            f"use before= to continue paging]"
+        )
+    elif count == requested_limit:
+        lines.append(
+            f"[Showing {count} of {requested_limit} requested — more history may be available]"
+        )
+
+    return "\n".join(lines)
+
+
+def _format_timestamp(ts: Any) -> str:
+    """Format a datetime to a consistent UTC string for agent output.
+
+    Args:
+        ts: datetime object (naive or timezone-aware).
+
+    Returns:
+        Formatted string like "2026-03-08 14:30 UTC".
+    """
+    try:
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC)
+        utc_ts = ts.astimezone(UTC)
+        return utc_ts.strftime("%Y-%m-%d %H:%M UTC")  # type: ignore[no-any-return]
+    except Exception:
+        return str(ts)

--- a/openpaw/builtins/tools/cron.py
+++ b/openpaw/builtins/tools/cron.py
@@ -337,10 +337,15 @@ class CronToolBuiltin(BaseBuiltinTool):
             """
             tasks = self.store.list_tasks()
 
+            # Filter out expired one-shot tasks (defense against stale entries)
+            now = datetime.now(UTC)
+            tasks = [
+                t for t in tasks
+                if not (t.task_type == "once" and t.run_at and t.run_at < now)
+            ]
+
             if not tasks:
                 return "No scheduled tasks."
-
-            now = datetime.now(UTC)
             lines = ["Scheduled tasks:\n"]
 
             for task in tasks:

--- a/openpaw/channels/base.py
+++ b/openpaw/channels/base.py
@@ -54,6 +54,18 @@ class ChannelAdapter(ABC):
         """
         ...
 
+    @property
+    def supports_history_browsing(self) -> bool:
+        """Whether this adapter supports on-demand history browsing.
+
+        Adapters that implement fetch_channel_history() with full historical
+        access (not just recent cached messages) should override this to True.
+
+        Returns:
+            True if the adapter supports browsing arbitrary channel history.
+        """
+        return False
+
     @staticmethod
     def _passes_trigger_filter(content: str, triggers: list[str]) -> bool:
         """Check if message content matches any configured trigger keyword.

--- a/openpaw/channels/discord.py
+++ b/openpaw/channels/discord.py
@@ -134,6 +134,11 @@ class DiscordChannel(ChannelAdapter):
         self._approval_callback: Callable[[str, bool], Coroutine[Any, Any, None]] | None = None
         self._channel_event_callback: Callable[..., Any] | None = None
 
+    @property
+    def supports_history_browsing(self) -> bool:
+        """Discord supports full channel history via the channel.history() API."""
+        return True
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
@@ -487,11 +492,11 @@ class DiscordChannel(ChannelAdapter):
     def _is_allowed(self, message: discord.Message) -> bool:
         """Check whether the message sender is permitted to use this workspace.
 
-        Security model (mirrors TelegramChannel):
+        Security model:
         - allow_all=True  → everyone is allowed (insecure, use with caution)
-        - allowed_users non-empty → user.id must be in the set
-        - No allowed_users → deny all (secure default)
-        - In a guild + allowed_groups non-empty → guild.id must be in the set
+        - In a guild + allowed_groups contains the guild → allowed (any user in that guild)
+        - allowed_users non-empty → user.id must be in the set (DMs and non-allowed guilds)
+        - No allowlists match → deny (secure default)
 
         Args:
             message: The incoming discord.Message.
@@ -502,22 +507,23 @@ class DiscordChannel(ChannelAdapter):
         if self.allow_all:
             return True
 
-        user_id = message.author.id
+        # Guild allowlist: if the message is from an allowed guild, permit it
+        # without requiring the user to be individually allowlisted.
+        if message.guild and self.allowed_groups:
+            if message.guild.id in self.allowed_groups:
+                return True
+            # Message is from a guild not in the allowlist — fall through to
+            # user check (user might be individually allowed for DMs).
 
-        # User allowlist check
+        # User allowlist check (DMs and non-allowed guilds)
+        user_id = message.author.id
         if self.allowed_users:
             if user_id not in self.allowed_users:
                 return False
-        else:
-            # No user allowlist configured and allow_all is False — deny
-            return False
+            return True
 
-        # Guild allowlist check for server messages
-        if message.guild and self.allowed_groups:
-            if message.guild.id not in self.allowed_groups:
-                return False
-
-        return True
+        # No allowlists matched — deny
+        return False
 
     def _passes_activation_filter(self, message: discord.Message) -> bool:
         """Check whether the message passes activation filters (mention OR trigger).
@@ -825,6 +831,7 @@ class DiscordChannel(ChannelAdapter):
                         content=msg.content or "",
                         is_bot=msg.author.bot,
                         attachments_summary=attachments_summary,
+                        message_id=str(msg.id),
                     )
                 )
 

--- a/openpaw/channels/telegram.py
+++ b/openpaw/channels/telegram.py
@@ -351,9 +351,9 @@ class TelegramChannel(ChannelAdapter):
 
         Security model:
         - If allow_all is True, all users are allowed (insecure)
-        - If allowed_users is set, user must be in the list
-        - If in a group chat and allowed_groups is set, group must be in the list
-        - If neither allow_all nor allowlists are set, deny by default (secure)
+        - If in a group chat and allowed_groups contains the group → allowed (any user)
+        - If allowed_users is set, user must be in the list (DMs and non-allowed groups)
+        - If neither allow_all nor allowlists match, deny by default (secure)
         """
         if not update.effective_user:
             return False
@@ -362,23 +362,23 @@ class TelegramChannel(ChannelAdapter):
         if self.allow_all:
             return True
 
-        user_id = update.effective_user.id
         chat_id = update.effective_chat.id if update.effective_chat else None
 
-        # Check user allowlist
+        # Group allowlist: if the message is from an allowed group, permit it
+        # without requiring the user to be individually allowlisted.
+        if chat_id and chat_id < 0 and self.allowed_groups:
+            if chat_id in self.allowed_groups:
+                return True
+
+        # User allowlist check (DMs and non-allowed groups)
+        user_id = update.effective_user.id
         if self.allowed_users:
             if user_id not in self.allowed_users:
                 return False
-        else:
-            # No user allowlist and not allow_all = deny
-            return False
+            return True
 
-        # Check group allowlist for group chats
-        if chat_id and chat_id < 0:
-            if self.allowed_groups and chat_id not in self.allowed_groups:
-                return False
-
-        return True
+        # No allowlists matched — deny
+        return False
 
     def _passes_activation_filter(self, update: Update) -> bool:
         """Check whether the message passes activation filters (mention OR trigger).

--- a/openpaw/core/config/models.py
+++ b/openpaw/core/config/models.py
@@ -246,6 +246,19 @@ class Md2pdfBuiltinConfig(BuiltinItemConfig):
     max_heal_iterations: int = Field(default=3, description="Maximum repair attempts per broken diagram")
 
 
+class ChannelHistoryBuiltinConfig(BuiltinItemConfig):
+    """Configuration for the channel history browsing tool."""
+
+    max_messages_per_request: int = Field(
+        default=100,
+        description="Hard cap on messages returned per request (default: 100)",
+    )
+    content_truncation: int = Field(
+        default=500,
+        description="Per-message content character truncation limit (default: 500)",
+    )
+
+
 class FilePersistenceBuiltinConfig(BuiltinItemConfig):
     """Configuration for the file persistence processor."""
 
@@ -284,6 +297,7 @@ class BuiltinsConfig(BaseModel):
     spawn: SpawnBuiltinConfig = Field(default_factory=SpawnBuiltinConfig)
     file_persistence: FilePersistenceBuiltinConfig = Field(default_factory=FilePersistenceBuiltinConfig)
     md2pdf: Md2pdfBuiltinConfig = Field(default_factory=Md2pdfBuiltinConfig)
+    channel_history: ChannelHistoryBuiltinConfig = Field(default_factory=ChannelHistoryBuiltinConfig)
 
     model_config = {"extra": "allow"}
 
@@ -312,6 +326,7 @@ class WorkspaceBuiltinsConfig(BaseModel):
     spawn: SpawnBuiltinConfig | None = None
     file_persistence: FilePersistenceBuiltinConfig | None = None
     md2pdf: Md2pdfBuiltinConfig | None = None
+    channel_history: ChannelHistoryBuiltinConfig | None = None
 
     model_config = {"extra": "allow"}
 

--- a/openpaw/core/prompts/framework.py
+++ b/openpaw/core/prompts/framework.py
@@ -304,6 +304,19 @@ SECTION_CHANNEL_CONTEXT = (
     "while being informed by the surrounding conversation."
 )
 
+# Channel history browsing - conditional on channel_history builtin
+SECTION_CHANNEL_HISTORY = (
+    "\n\n## Channel History Browsing\n\n"
+    "You can browse message history from channels that support it (e.g., Discord) "
+    "using the `browse_channel_history` tool. This gives you access to messages "
+    "beyond the initial context window, including messages sent while you were offline.\n\n"
+    "- Use pagination (`before` parameter) to navigate further back in time\n"
+    "- Filter by keyword, user, or exclude bot messages\n"
+    "- Message IDs in the output can be used as pagination cursors\n"
+    "- Channel logs at `memory/logs/channel/` only contain real-time witnessed messages; "
+    "this tool accesses the full platform history"
+)
+
 # Channel logs - conditional on channel logging being enabled
 SECTION_CHANNEL_LOGS = (
     "\n\n## Channel Logs\n\n"
@@ -363,6 +376,10 @@ def build_capability_summary(enabled_builtins: list[str] | None) -> str:
         capabilities.append("- **File Sharing**: Send workspace files to users")
     if _is_enabled("memory_search"):
         capabilities.append("- **Memory Search**: Semantic search over past conversations")
+    if _is_enabled("channel_history"):
+        capabilities.append(
+            "- **Channel History**: Browse and search message history from supported channels"
+        )
     if _is_enabled("elevenlabs"):
         capabilities.append("- **Text-to-Speech**: Voice response generation")
 

--- a/openpaw/core/prompts/system_events.py
+++ b/openpaw/core/prompts/system_events.py
@@ -139,3 +139,27 @@ CRON_RESULT_TRUNCATED_TEMPLATE = PromptTemplate(
     ),
     input_variables=["cron_name", "output", "session_path"],
 )
+
+# Dynamic task result (fits within truncation limit)
+DYNAMIC_TASK_RESULT_TEMPLATE = PromptTemplate(
+    template=(
+        "[SYSTEM] Your scheduled task [{task_id}] completed.\n"
+        "Original prompt: {prompt_preview}\n\n"
+        "{output}\n\n"
+        "Full session log: {session_path}\n"
+        "Review and take action if needed."
+    ),
+    input_variables=["task_id", "prompt_preview", "output", "session_path"],
+)
+
+# Dynamic task result (output was truncated)
+DYNAMIC_TASK_RESULT_TRUNCATED_TEMPLATE = PromptTemplate(
+    template=(
+        "[SYSTEM] Your scheduled task [{task_id}] completed (truncated).\n"
+        "Original prompt: {prompt_preview}\n\n"
+        "{output}\n\n"
+        "Full session log: {session_path}\n"
+        'Use read_file("{session_path}") for full context.'
+    ),
+    input_variables=["task_id", "prompt_preview", "output", "session_path"],
+)

--- a/openpaw/core/workspace.py
+++ b/openpaw/core/workspace.py
@@ -14,6 +14,7 @@ from openpaw.core.paths import AGENT_MD, HEARTBEAT_MD, SOUL_MD, USER_MD
 from openpaw.core.prompts.framework import (
     SECTION_AUTONOMOUS_PLANNING,
     SECTION_CHANNEL_CONTEXT,
+    SECTION_CHANNEL_HISTORY,
     SECTION_CHANNEL_LOGS,
     SECTION_CONVERSATION_MEMORY,
     SECTION_FILE_SHARING,
@@ -251,6 +252,10 @@ class AgentWorkspace:
         # Memory search - include if memory_search is enabled
         if enabled_builtins is None or "memory_search" in enabled_builtins:
             sections.append(SECTION_MEMORY_SEARCH)
+
+        # Channel history browsing - include if channel_history builtin is loaded
+        if enabled_builtins is None or "channel_history" in enabled_builtins:
+            sections.append(SECTION_CHANNEL_HISTORY)
 
         # Channel logs - include when persistent channel logging is active
         if channel_logging_enabled:

--- a/openpaw/model/channel.py
+++ b/openpaw/model/channel.py
@@ -27,6 +27,7 @@ class ChannelHistoryEntry:
     content: str
     is_bot: bool = False
     attachments_summary: str | None = None
+    message_id: str = ""  # Platform-specific message ID for pagination cursors
 
 
 @dataclass

--- a/openpaw/runtime/scheduling/cron.py
+++ b/openpaw/runtime/scheduling/cron.py
@@ -21,6 +21,8 @@ from openpaw.core.config.models import CronDefinition, CronOutputConfig
 from openpaw.core.prompts.system_events import (
     CRON_RESULT_TEMPLATE,
     CRON_RESULT_TRUNCATED_TEMPLATE,
+    DYNAMIC_TASK_RESULT_TEMPLATE,
+    DYNAMIC_TASK_RESULT_TRUNCATED_TEMPLATE,
     INJECTION_TRUNCATION_LIMIT,
 )
 from openpaw.model.cron import DynamicCronTask
@@ -75,10 +77,18 @@ class CronScheduler:
         self._jobs: dict[str, Any] = {}
         self._dynamic_store = DynamicCronStore(workspace_path)
         self._dynamic_jobs: dict[str, Any] = {}
+        self._running_jobs: set[str] = set()
 
     async def start(self) -> None:
         """Start the scheduler and register all cron jobs."""
-        self._scheduler = AsyncIOScheduler(timezone=self._tz)
+        self._scheduler = AsyncIOScheduler(
+            timezone=self._tz,
+            job_defaults={
+                "max_instances": 1,
+                "coalesce": True,
+                "misfire_grace_time": 300,
+            },
+        )
 
         # Load and schedule YAML-defined cron jobs
         loader = CronLoader(self.workspace_path)
@@ -111,6 +121,12 @@ class CronScheduler:
         Args:
             cron: The cron definition to execute.
         """
+        job_id = cron.name
+        if job_id in self._running_jobs:
+            logger.warning(f"Skipping cron job {cron.name}: previous execution still running")
+            return
+
+        self._running_jobs.add(job_id)
         logger.info(f"Executing cron job: {cron.name}")
         set_invocation_origin(f"cron:{cron.name}")
 
@@ -185,6 +201,7 @@ class CronScheduler:
         except Exception as e:
             logger.error(f"Failed to execute cron job {cron.name}: {e}", exc_info=True)
         finally:
+            self._running_jobs.discard(job_id)
             set_invocation_origin(None)
 
     @staticmethod
@@ -305,6 +322,21 @@ class CronScheduler:
         Args:
             task: DynamicCronTask to execute.
         """
+        job_id = f"dynamic_{task.id}"
+        if job_id in self._running_jobs:
+            logger.warning(f"Skipping dynamic task {task.id}: previous execution still running")
+            return
+
+        self._running_jobs.add(job_id)
+
+        # Remove one-shot tasks from store before execution.
+        # APScheduler DateTrigger guarantees single fire, so this is safe.
+        # Prevents list_scheduled() from showing ghost entries during execution.
+        if task.task_type == "once":
+            self._dynamic_store.remove_task(task.id)
+            if task.id in self._dynamic_jobs:
+                del self._dynamic_jobs[task.id]
+
         logger.info(f"Executing dynamic task: {task.id}")
         set_invocation_origin(f"dynamic_cron:{task.id[:8]}")
 
@@ -314,10 +346,11 @@ class CronScheduler:
             response = await agent_runner.run(message=task.prompt)
             duration_ms = (time_module.monotonic() - start_time) * 1000
 
-            # Write session log (audit only, no delivery routing for dynamic tasks)
+            # Write session log
+            session_path: str | None = None
             if self._session_logger:
                 try:
-                    self._session_logger.write_session(
+                    session_path = self._session_logger.write_session(
                         name=f"dynamic_{task.id}",
                         prompt=task.prompt,
                         response=response,
@@ -359,18 +392,39 @@ class CronScheduler:
                     f"Response ({len(response) if response else 0} chars) not sent."
                 )
 
-            # Clean up one-shot tasks after execution
-            if task.task_type == "once":
-                # Remove from storage (APScheduler auto-removes DateTrigger jobs)
-                if task.id in self._dynamic_jobs:
-                    del self._dynamic_jobs[task.id]
-                self._dynamic_store.remove_task(task.id)
+            # Inject result into agent queue (dynamic tasks always notify the main agent)
+            if self._result_callback and session_path and task.channel and task.chat_id:
+                try:
+                    channel = self.channels.get(task.channel)
+                    if channel:
+                        session_key = channel.build_session_key(task.chat_id)
+                        output = response
+                        if len(output) > INJECTION_TRUNCATION_LIMIT:
+                            output = output[:INJECTION_TRUNCATION_LIMIT]
+                            injection_content = DYNAMIC_TASK_RESULT_TRUNCATED_TEMPLATE.format(
+                                task_id=task.id[:8],
+                                prompt_preview=task.prompt[:80],
+                                output=output,
+                                session_path=session_path,
+                            )
+                        else:
+                            injection_content = DYNAMIC_TASK_RESULT_TEMPLATE.format(
+                                task_id=task.id[:8],
+                                prompt_preview=task.prompt[:80],
+                                output=output,
+                                session_path=session_path,
+                            )
+                        await self._result_callback(session_key, injection_content)
+                        logger.info(f"Dynamic task {task.id} result injected into agent queue")
+                except Exception as e:
+                    logger.warning(f"Failed to inject dynamic task result for {task.id}: {e}")
 
             logger.info(f"Dynamic task {task.id} completed successfully")
 
         except Exception as e:
             logger.error(f"Dynamic task {task.id} failed: {e}", exc_info=True)
         finally:
+            self._running_jobs.discard(job_id)
             set_invocation_origin(None)
 
     def _prune_expired_tasks(self, tasks: list[DynamicCronTask]) -> list[DynamicCronTask]:

--- a/openpaw/runtime/scheduling/loader.py
+++ b/openpaw/runtime/scheduling/loader.py
@@ -32,6 +32,7 @@ class CronLoader:
             return []
 
         cron_definitions: list[CronDefinition] = []
+        seen_names: dict[str, str] = {}  # name -> source filename
 
         for cron_file in sorted(
             list(self.crons_path.glob("*.yaml")) + list(self.crons_path.glob("*.yml"))
@@ -47,6 +48,14 @@ class CronLoader:
                 )
 
                 cron_def = CronDefinition(**expanded_data)
+
+                if cron_def.name in seen_names:
+                    raise ValueError(
+                        f"Duplicate cron name '{cron_def.name}' "
+                        f"(already defined in {seen_names[cron_def.name]})"
+                    )
+                seen_names[cron_def.name] = cron_file.name
+
                 cron_definitions.append(cron_def)
             except Exception as e:
                 raise ValueError(f"Failed to load cron definition from {cron_file}: {e}") from e

--- a/openpaw/workspace/runner.py
+++ b/openpaw/workspace/runner.py
@@ -693,6 +693,7 @@ class WorkspaceRunner:
             session_logger=subagent_session_logger,
         )
         self._connect_spawn_tool_to_runner()
+        self._connect_channel_history_tool()
 
         self._running = True
         self._queue_processor_task = asyncio.create_task(self._queue_processor())
@@ -716,6 +717,50 @@ class WorkspaceRunner:
                 self.logger.debug("SpawnTool not loaded for this workspace")
         except Exception as e:
             self.logger.warning(f"Failed to connect SpawnTool to runner: {e}")
+
+    def _connect_channel_history_tool(self) -> None:
+        """Connect ChannelHistoryTool to live channel adapters.
+
+        Checks whether any channel supports history browsing. If none do,
+        removes the tool from the agent to avoid presenting a broken
+        capability to the LLM. If at least one does, wires the adapter
+        references into the tool instance.
+        """
+        try:
+            history_tool = self._builtin_loader.get_tool_instance("channel_history")
+            if not history_tool:
+                self.logger.debug("ChannelHistoryTool not loaded for this workspace")
+                return
+
+            # Find channels that support history browsing
+            history_channels = {
+                name: ch
+                for name, ch in self._channels.items()
+                if ch.supports_history_browsing
+            }
+
+            if not history_channels:
+                # No history-capable channels — remove the tool so the LLM never
+                # sees a broken capability
+                self._agent_factory.remove_builtin_tools({"browse_channel_history"})
+                self._agent_factory.remove_enabled_builtin("channel_history")
+                self._agent_runner = self._agent_factory.create_agent(
+                    checkpointer=self._checkpointer
+                )
+                self._message_processor.update_agent_runner(self._agent_runner)
+                self.logger.info(
+                    "Removed channel_history tool (no history-capable channels)"
+                )
+                return
+
+            history_tool.set_channels(history_channels)
+            self.logger.info(
+                "Connected ChannelHistoryTool to %d channel(s): %s",
+                len(history_channels),
+                list(history_channels.keys()),
+            )
+        except Exception as e:
+            self.logger.warning(f"Failed to connect ChannelHistoryTool: {e}")
 
     def _connect_memory_search_tool(self) -> None:
         """Connect MemorySearchTool builtin to vector store and embedding provider.

--- a/tests/channels/test_discord.py
+++ b/tests/channels/test_discord.py
@@ -171,14 +171,33 @@ class TestAllowlist:
         msg = _make_mock_discord_message(user_id=111)
         assert channel._is_allowed(msg) is False
 
-    def test_guild_allowlist_blocks_wrong_guild(self) -> None:
-        """User is allowed but sending from a guild not in allowed_groups → denied."""
+    def test_allowed_guild_permits_any_user(self) -> None:
+        """Any user in an allowed guild is permitted, even without being in allowed_users."""
         channel = _make_discord_channel(
             allowed_users=[111],
             allowed_groups=[500],
         )
-        # Guild 999 is not in allowed_groups
+        # User 999 is NOT in allowed_users, but guild 500 is allowed
+        msg = _make_mock_discord_message(user_id=999, guild_id=500)
+        assert channel._is_allowed(msg) is True
+
+    def test_allowed_user_in_non_allowed_guild(self) -> None:
+        """User in allowed_users is permitted even from a non-allowed guild."""
+        channel = _make_discord_channel(
+            allowed_users=[111],
+            allowed_groups=[500],
+        )
+        # Guild 999 is not in allowed_groups, but user 111 is individually allowed
         msg = _make_mock_discord_message(user_id=111, guild_id=999)
+        assert channel._is_allowed(msg) is True
+
+    def test_unknown_user_in_non_allowed_guild_denied(self) -> None:
+        """User not in allowed_users and guild not in allowed_groups → denied."""
+        channel = _make_discord_channel(
+            allowed_users=[111],
+            allowed_groups=[500],
+        )
+        msg = _make_mock_discord_message(user_id=999, guild_id=999)
         assert channel._is_allowed(msg) is False
 
     def test_guild_allowlist_allows_correct_guild(self) -> None:
@@ -209,6 +228,24 @@ class TestAllowlist:
         )
         msg = _make_mock_discord_message(user_id=111, guild_id=12345)
         assert channel._is_allowed(msg) is True
+
+    def test_only_guild_allowlist_no_user_allowlist(self) -> None:
+        """When only allowed_groups is set (no allowed_users), guild members are allowed."""
+        channel = _make_discord_channel(
+            allowed_users=[],
+            allowed_groups=[500],
+        )
+        msg = _make_mock_discord_message(user_id=999, guild_id=500)
+        assert channel._is_allowed(msg) is True
+
+    def test_only_guild_allowlist_dm_denied(self) -> None:
+        """When only allowed_groups is set, DMs are denied (no user allowlist to match)."""
+        channel = _make_discord_channel(
+            allowed_users=[],
+            allowed_groups=[500],
+        )
+        msg = _make_mock_discord_message(user_id=999, guild_id=None)
+        assert channel._is_allowed(msg) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_channel_history_tool.py
+++ b/tests/test_channel_history_tool.py
@@ -1,0 +1,731 @@
+"""Tests for ChannelHistoryToolBuiltin."""
+
+import logging
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from openpaw.builtins.tools.channel_history import (
+    ChannelHistoryToolBuiltin,
+    _build_filter_qualifier,
+    _format_history_output,
+    _format_timestamp,
+    _resolve_adapter,
+    _resolve_channel_id,
+)
+from openpaw.channels.base import ChannelAdapter
+from openpaw.channels.discord import DiscordChannel
+from openpaw.model.channel import ChannelHistoryEntry
+from openpaw.workspace.runner import WorkspaceRunner
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_entry(
+    display_name: str = "Alice",
+    user_id: str = "111",
+    content: str = "Hello world",
+    is_bot: bool = False,
+    message_id: str = "1000",
+    timestamp: datetime | None = None,
+    attachments_summary: str | None = None,
+) -> ChannelHistoryEntry:
+    """Build a ChannelHistoryEntry for testing."""
+    return ChannelHistoryEntry(
+        timestamp=timestamp or datetime(2026, 3, 8, 14, 30, tzinfo=UTC),
+        user_id=user_id,
+        display_name=display_name,
+        content=content,
+        is_bot=is_bot,
+        attachments_summary=attachments_summary,
+        message_id=message_id,
+    )
+
+
+def _make_mock_discord_channel(
+    name: str = "discord",
+    entries: list[ChannelHistoryEntry] | None = None,
+) -> MagicMock:
+    """Build a MagicMock ChannelAdapter that supports history browsing."""
+    channel = MagicMock(spec=DiscordChannel)
+    channel.name = name
+    channel.supports_history_browsing = True
+    channel.fetch_channel_history = AsyncMock(return_value=entries or [])
+    return channel
+
+
+def _make_non_history_channel(name: str = "telegram") -> MagicMock:
+    """Build a MagicMock ChannelAdapter that does NOT support history browsing."""
+    channel = MagicMock(spec=ChannelAdapter)
+    channel.name = name
+    channel.supports_history_browsing = False
+    return channel
+
+
+@pytest.fixture
+def tool() -> ChannelHistoryToolBuiltin:
+    """Create an unconnected ChannelHistoryToolBuiltin."""
+    return ChannelHistoryToolBuiltin()
+
+
+@pytest.fixture
+def tool_with_discord(tool: ChannelHistoryToolBuiltin) -> ChannelHistoryToolBuiltin:
+    """Tool connected to a single mock Discord channel."""
+    channel = _make_mock_discord_channel()
+    tool.set_channels({"discord": channel})
+    return tool
+
+
+# ---------------------------------------------------------------------------
+# Metadata and initialization tests
+# ---------------------------------------------------------------------------
+
+
+def test_metadata() -> None:
+    """Metadata fields are correctly defined."""
+    meta = ChannelHistoryToolBuiltin.metadata
+    assert meta.name == "channel_history"
+    assert meta.display_name == "Channel History Browser"
+    assert meta.group == "communication"
+    assert meta.builtin_type.value == "tool"
+    assert len(meta.prerequisites.env_vars) == 0  # Runtime gating, no env vars
+
+
+def test_initialization_defaults() -> None:
+    """Default config values are applied correctly."""
+    t = ChannelHistoryToolBuiltin()
+    assert t.max_messages_per_request == 100
+    assert t.content_truncation == 500
+    assert t._channels is None
+
+
+def test_initialization_with_config() -> None:
+    """Custom config values override defaults."""
+    t = ChannelHistoryToolBuiltin(config={"max_messages_per_request": 50, "content_truncation": 200})
+    assert t.max_messages_per_request == 50
+    assert t.content_truncation == 200
+
+
+def test_get_langchain_tool_returns_list(tool: ChannelHistoryToolBuiltin) -> None:
+    """get_langchain_tool returns a one-element list."""
+    tools = tool.get_langchain_tool()
+    assert isinstance(tools, list)
+    assert len(tools) == 1
+    assert tools[0].name == "browse_channel_history"
+
+
+# ---------------------------------------------------------------------------
+# set_channels tests
+# ---------------------------------------------------------------------------
+
+
+def test_set_channels_stores_reference(tool: ChannelHistoryToolBuiltin) -> None:
+    """set_channels stores the channels dict on the instance."""
+    channels = {"discord": _make_mock_discord_channel()}
+    tool.set_channels(channels)
+    assert tool._channels is channels
+
+
+def test_set_channels_overrides_previous(tool: ChannelHistoryToolBuiltin) -> None:
+    """Calling set_channels twice replaces the previous reference."""
+    ch1 = {"discord": _make_mock_discord_channel()}
+    ch2 = {"discord-work": _make_mock_discord_channel(name="discord-work")}
+    tool.set_channels(ch1)
+    tool.set_channels(ch2)
+    assert tool._channels is ch2
+
+
+# ---------------------------------------------------------------------------
+# supports_history_browsing property tests
+# ---------------------------------------------------------------------------
+
+
+def test_base_adapter_does_not_support_history() -> None:
+    """ChannelAdapter base property returns False by default."""
+    channel = _make_non_history_channel()
+    assert channel.supports_history_browsing is False
+
+
+def test_discord_supports_history() -> None:
+    """DiscordChannel.supports_history_browsing returns True."""
+    channel = _make_mock_discord_channel()
+    assert channel.supports_history_browsing is True
+
+
+# ---------------------------------------------------------------------------
+# Channel resolution tests
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_adapter_single_auto_select() -> None:
+    """Single history-capable channel is auto-selected when channel=None."""
+    ch = _make_mock_discord_channel()
+    channels = {"discord": ch}
+    adapter, error = _resolve_adapter(channels, channel_name=None)
+    assert adapter is ch
+    assert error is None
+
+
+def test_resolve_adapter_multi_requires_explicit() -> None:
+    """Multiple channels require explicit channel= parameter."""
+    channels = {
+        "discord": _make_mock_discord_channel(),
+        "discord-work": _make_mock_discord_channel(name="discord-work"),
+    }
+    adapter, error = _resolve_adapter(channels, channel_name=None)
+    assert adapter is None
+    assert "Multiple history-capable channels" in error
+    assert "discord" in error
+    assert "discord-work" in error
+
+
+def test_resolve_adapter_explicit_found() -> None:
+    """Explicit channel= that exists is returned."""
+    ch = _make_mock_discord_channel()
+    channels = {"discord": ch, "discord-work": _make_mock_discord_channel(name="discord-work")}
+    adapter, error = _resolve_adapter(channels, channel_name="discord")
+    assert adapter is ch
+    assert error is None
+
+
+def test_resolve_adapter_explicit_not_found() -> None:
+    """Explicit channel= that does not exist returns a descriptive error."""
+    channels = {"discord": _make_mock_discord_channel()}
+    adapter, error = _resolve_adapter(channels, channel_name="slack")
+    assert adapter is None
+    assert "slack" in error
+    assert "discord" in error
+
+
+# ---------------------------------------------------------------------------
+# Tool invocation tests — async via pytest-asyncio or sync helper
+# ---------------------------------------------------------------------------
+
+
+def _call_tool_sync(tool_builtin: ChannelHistoryToolBuiltin, **kwargs) -> str:
+    """Invoke the browse_channel_history tool synchronously for tests.
+
+    Patches the session key context so the channel_id is resolvable.
+    Uses the coroutine (async) form of the tool to avoid thread pool issues.
+    """
+    import asyncio
+
+    lc_tool = tool_builtin.get_langchain_tool()[0]
+
+    async def _run() -> str:
+        with patch(
+            "openpaw.builtins.tools.channel_history.get_current_session_key",
+            return_value="discord:123456789",
+        ):
+            return await lc_tool.coroutine(**kwargs)
+
+    return asyncio.run(_run())
+
+
+def test_no_channels_connected() -> None:
+    """Returns error when channels have not been set."""
+    t = ChannelHistoryToolBuiltin()
+    result = _call_tool_sync(t)
+    assert "not connected" in result.lower() or "error" in result.lower()
+
+
+def test_empty_channels_dict() -> None:
+    """Returns error when channels dict is empty."""
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels({})
+    result = _call_tool_sync(t)
+    assert "No history-capable channels" in result
+
+
+def test_fetch_returns_empty() -> None:
+    """Returns appropriate message when fetch yields no entries."""
+    channel = _make_mock_discord_channel(entries=[])
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels({"discord": channel})
+    result = _call_tool_sync(t)
+    assert "No messages found" in result
+
+
+def test_basic_fetch_formats_output() -> None:
+    """Successful fetch returns formatted output with header and pagination."""
+    entries = [
+        _make_entry("Alice", "111", "Deploy started", message_id="1001"),
+        _make_entry("Bob", "222", "Deploy complete", message_id="1002"),
+    ]
+    channel = _make_mock_discord_channel(entries=entries)
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels({"discord": channel})
+    result = _call_tool_sync(t)
+
+    assert "Channel History" in result
+    assert "Alice" in result
+    assert "Bob" in result
+    assert "Deploy started" in result
+    assert "id:111" in result
+    assert "Pagination" in result
+
+
+def test_pagination_before_passed_to_adapter() -> None:
+    """The 'before' parameter is forwarded to fetch_channel_history."""
+    channel = _make_mock_discord_channel(entries=[_make_entry()])
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels({"discord": channel})
+
+    _call_tool_sync(t, before="9999")
+
+    channel.fetch_channel_history.assert_called_once()
+    call_kwargs = channel.fetch_channel_history.call_args
+    assert call_kwargs.kwargs.get("before_message_id") == "9999" or (
+        len(call_kwargs.args) >= 3 and call_kwargs.args[2] == "9999"
+    )
+
+
+def test_keyword_filter_case_insensitive() -> None:
+    """Keyword filter is applied case-insensitively."""
+    entries = [
+        _make_entry("Alice", "111", "Deploy started", message_id="1001"),
+        _make_entry("Bob", "222", "System is running", message_id="1002"),
+    ]
+    channel = _make_mock_discord_channel(entries=entries)
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels({"discord": channel})
+    result = _call_tool_sync(t, keyword="DEPLOY")
+
+    assert "Deploy started" in result
+    assert "System is running" not in result
+
+
+def test_user_filter_case_insensitive() -> None:
+    """User filter matches display name case-insensitively (substring)."""
+    entries = [
+        _make_entry("Alice Smith", "111", "Hello from Alice", message_id="1001"),
+        _make_entry("Bob Jones", "222", "Hello from Bob", message_id="1002"),
+    ]
+    channel = _make_mock_discord_channel(entries=entries)
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels({"discord": channel})
+    result = _call_tool_sync(t, user="alice")
+
+    assert "Hello from Alice" in result
+    assert "Hello from Bob" not in result
+
+
+def test_bot_messages_excluded_by_default() -> None:
+    """Bot messages are excluded when include_bots=False (default)."""
+    entries = [
+        _make_entry("Alice", "111", "Human message", is_bot=False, message_id="1001"),
+        _make_entry("BotUser", "999", "Bot reply", is_bot=True, message_id="1002"),
+    ]
+    channel = _make_mock_discord_channel(entries=entries)
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels({"discord": channel})
+    result = _call_tool_sync(t, include_bots=False)
+
+    assert "Human message" in result
+    assert "Bot reply" not in result
+
+
+def test_bot_messages_included_when_requested() -> None:
+    """Bot messages appear when include_bots=True."""
+    entries = [
+        _make_entry("Alice", "111", "Human message", is_bot=False, message_id="1001"),
+        _make_entry("BotUser", "999", "Bot reply", is_bot=True, message_id="1002"),
+    ]
+    channel = _make_mock_discord_channel(entries=entries)
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels({"discord": channel})
+    result = _call_tool_sync(t, include_bots=True)
+
+    assert "Human message" in result
+    assert "Bot reply" in result
+
+
+def test_over_fetch_with_keyword_filter() -> None:
+    """When keyword filter is active, adapter is called with 3x the requested limit."""
+    entries = [_make_entry(content="deploy here", message_id=str(i)) for i in range(10)]
+    channel = _make_mock_discord_channel(entries=entries)
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels({"discord": channel})
+
+    _call_tool_sync(t, limit=5, keyword="deploy")
+
+    call_kwargs = channel.fetch_channel_history.call_args
+    # The actual limit passed should be 5 * 3 = 15
+    fetched_limit = call_kwargs.kwargs.get("limit") or call_kwargs.args[1]
+    assert fetched_limit == 15
+
+
+def test_over_fetch_capped_at_300() -> None:
+    """Over-fetch never exceeds 300 entries."""
+    entries = [_make_entry(message_id=str(i)) for i in range(10)]
+    channel = _make_mock_discord_channel(entries=entries)
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels({"discord": channel})
+
+    # limit=100, keyword active → 100 * 3 = 300 (cap)
+    _call_tool_sync(t, limit=100, keyword="test")
+
+    call_kwargs = channel.fetch_channel_history.call_args
+    fetched_limit = call_kwargs.kwargs.get("limit") or call_kwargs.args[1]
+    assert fetched_limit == 300
+
+
+def test_no_over_fetch_without_filters() -> None:
+    """Without filters, adapter is called with exactly the requested limit."""
+    entries = [_make_entry(message_id=str(i)) for i in range(5)]
+    channel = _make_mock_discord_channel(entries=entries)
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels({"discord": channel})
+
+    _call_tool_sync(t, limit=10, include_bots=True)
+
+    call_kwargs = channel.fetch_channel_history.call_args
+    fetched_limit = call_kwargs.kwargs.get("limit") or call_kwargs.args[1]
+    assert fetched_limit == 10
+
+
+def test_no_results_after_filter() -> None:
+    """Returns informative message when filters produce zero results."""
+    entries = [_make_entry("Alice", content="unrelated stuff", message_id="1")]
+    channel = _make_mock_discord_channel(entries=entries)
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels({"discord": channel})
+    result = _call_tool_sync(t, keyword="nonexistent_keyword_xyz")
+
+    assert "No messages found matching filters" in result
+
+
+def test_output_includes_pagination_footer() -> None:
+    """Pagination footer shows oldest_message_id when entries have message_ids."""
+    entries = [
+        _make_entry(message_id="100"),
+        _make_entry(message_id="200"),
+    ]
+    channel = _make_mock_discord_channel(entries=entries)
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels({"discord": channel})
+    result = _call_tool_sync(t)
+
+    assert "Pagination" in result
+    # The oldest entry (index 0) should be the cursor
+    assert "100" in result
+
+
+def test_output_timestamps_are_utc() -> None:
+    """Output timestamps are formatted in UTC."""
+    ts = datetime(2026, 3, 8, 14, 30, tzinfo=UTC)
+    entries = [_make_entry(timestamp=ts, message_id="1")]
+    channel = _make_mock_discord_channel(entries=entries)
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels({"discord": channel})
+    result = _call_tool_sync(t)
+
+    assert "2026-03-08 14:30 UTC" in result
+
+
+def test_content_truncation_per_message() -> None:
+    """Long message content is truncated at the configured limit."""
+    long_content = "A" * 600
+    entries = [_make_entry(content=long_content, message_id="1")]
+    channel = _make_mock_discord_channel(entries=entries)
+    t = ChannelHistoryToolBuiltin(config={"content_truncation": 100})
+    t.set_channels({"discord": channel})
+    result = _call_tool_sync(t)
+
+    # Should contain exactly 100 A's followed by "..."
+    assert "A" * 100 + "..." in result
+    assert "A" * 101 not in result
+
+
+def test_total_output_capped_at_50k() -> None:
+    """Total output is capped at 50K characters."""
+    # Each message is ~550 chars; 200 messages would exceed 50K
+    entries = [
+        _make_entry(content="X" * 500, message_id=str(i)) for i in range(200)
+    ]
+    channel = _make_mock_discord_channel(entries=entries)
+    t = ChannelHistoryToolBuiltin(config={"max_messages_per_request": 100})
+    t.set_channels({"discord": channel})
+    result = _call_tool_sync(t, limit=100, include_bots=True)
+
+    assert len(result) <= 50_000 + 200  # Small tolerance for truncation suffix
+    assert "truncated" in result.lower()
+
+
+def test_channel_not_found_explicit() -> None:
+    """Explicit channel= that does not exist returns error with available list."""
+    channels = {"discord": _make_mock_discord_channel()}
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels(channels)
+    result = _call_tool_sync(t, channel="slack")
+
+    assert "Error" in result
+    assert "slack" in result
+    assert "discord" in result
+
+
+def test_multi_channel_no_selection_error() -> None:
+    """Multiple channels without channel= parameter returns error."""
+    channels = {
+        "discord": _make_mock_discord_channel(),
+        "discord-work": _make_mock_discord_channel(name="discord-work"),
+    }
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels(channels)
+    result = _call_tool_sync(t)
+
+    assert "Multiple history-capable channels" in result
+    assert "discord" in result
+
+
+def test_multi_channel_explicit_selection() -> None:
+    """Explicit channel= in multi-channel workspace selects correct adapter."""
+    entries_main = [_make_entry("Alice", content="main channel", message_id="1")]
+    entries_work = [_make_entry("Bob", content="work channel", message_id="2")]
+
+    channels = {
+        "discord": _make_mock_discord_channel(entries=entries_main),
+        "discord-work": _make_mock_discord_channel(name="discord-work", entries=entries_work),
+    }
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels(channels)
+
+    result = _call_tool_sync(t, channel="discord-work")
+
+    assert "work channel" in result
+    assert "main channel" not in result
+
+
+def test_adapter_fetch_exception_returns_friendly_error() -> None:
+    """Adapter fetch raising an exception returns a user-friendly error string."""
+    channel = _make_mock_discord_channel()
+    channel.fetch_channel_history = AsyncMock(side_effect=Exception("Forbidden"))
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels({"discord": channel})
+    result = _call_tool_sync(t)
+
+    assert "No messages retrieved" in result or "permission" in result.lower()
+
+
+def test_attachments_summary_in_output() -> None:
+    """Attachment summaries appear in formatted output."""
+    entries = [
+        _make_entry(
+            content="See attached",
+            message_id="1",
+            attachments_summary="[1 file: report.pdf]",
+        )
+    ]
+    channel = _make_mock_discord_channel(entries=entries)
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels({"discord": channel})
+    result = _call_tool_sync(t)
+
+    assert "[1 file: report.pdf]" in result
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_format_timestamp_utc_aware() -> None:
+    """UTC-aware datetime is formatted correctly."""
+    ts = datetime(2026, 3, 8, 14, 30, tzinfo=UTC)
+    assert _format_timestamp(ts) == "2026-03-08 14:30 UTC"
+
+
+def test_format_timestamp_naive_treated_as_utc() -> None:
+    """Naive datetime is treated as UTC."""
+    ts = datetime(2026, 3, 8, 9, 0)
+    result = _format_timestamp(ts)
+    assert "2026-03-08 09:00 UTC" == result
+
+
+def test_build_filter_qualifier_empty() -> None:
+    """No filters produces empty qualifier."""
+    assert _build_filter_qualifier(None, None, True) == ""
+
+
+def test_build_filter_qualifier_keyword_only() -> None:
+    """Keyword-only filter shows keyword."""
+    qualifier = _build_filter_qualifier("deploy", None, True)
+    assert "deploy" in qualifier
+
+
+def test_build_filter_qualifier_bots_excluded() -> None:
+    """Bots excluded note appears when include_bots=False."""
+    qualifier = _build_filter_qualifier(None, None, False)
+    assert "bots excluded" in qualifier
+
+
+def test_build_filter_qualifier_all_filters() -> None:
+    """All filters combined."""
+    qualifier = _build_filter_qualifier("deploy", "Alice", False)
+    assert "deploy" in qualifier
+    assert "Alice" in qualifier
+    assert "bots excluded" in qualifier
+
+
+def test_format_history_output_header() -> None:
+    """Output header includes channel name and adapter type."""
+    entries = [_make_entry(message_id="100")]
+    output = _format_history_output(
+        entries=entries,
+        channel_name="general",
+        adapter_type="discord",
+        requested_limit=10,
+        matched_count=1,
+        before_cursor=None,
+        content_truncation=500,
+    )
+    assert "general" in output
+    assert "discord" in output
+
+
+def test_format_history_output_before_cursor_in_header() -> None:
+    """Before cursor appears in header when provided."""
+    entries = [_make_entry(message_id="50")]
+    output = _format_history_output(
+        entries=entries,
+        channel_name="general",
+        adapter_type="discord",
+        requested_limit=10,
+        matched_count=1,
+        before_cursor="12345",
+        content_truncation=500,
+    )
+    assert "12345" in output
+    assert "before" in output.lower()
+
+
+def test_format_history_output_pagination_footer_empty_message_id() -> None:
+    """Pagination footer is skipped when oldest entry has empty message_id."""
+    entries = [_make_entry(message_id="")]
+    output = _format_history_output(
+        entries=entries,
+        channel_name="general",
+        adapter_type="discord",
+        requested_limit=10,
+        matched_count=1,
+        before_cursor=None,
+        content_truncation=500,
+    )
+    assert "Pagination" not in output
+
+
+def test_no_session_key_returns_error() -> None:
+    """Missing session key context returns a descriptive error."""
+    import asyncio
+
+    channel = _make_mock_discord_channel(entries=[_make_entry()])
+    t = ChannelHistoryToolBuiltin()
+    t.set_channels({"discord": channel})
+
+    lc_tool = t.get_langchain_tool()[0]
+
+    async def _run() -> str:
+        with patch(
+            "openpaw.builtins.tools.channel_history.get_current_session_key",
+            return_value=None,
+        ):
+            return await lc_tool.coroutine()
+
+    result = asyncio.run(_run())
+    assert "Error" in result
+    assert "session" in result.lower()
+
+
+def test_resolve_channel_id_malformed_session_key() -> None:
+    """_resolve_channel_id handles session keys without a colon gracefully."""
+    mock_adapter = MagicMock(spec=ChannelAdapter)
+
+    with patch(
+        "openpaw.builtins.tools.channel_history.get_current_session_key",
+        return_value="nocolonhere",
+    ):
+        channel_id, error = _resolve_channel_id(mock_adapter)
+
+    assert error is not None
+    assert "Error" in error
+    assert channel_id == ""
+
+
+# ---------------------------------------------------------------------------
+# Runner wiring tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_runner_for_history(
+    history_tool: Mock | None = None,
+    channels: dict | None = None,
+) -> MagicMock:
+    """Build a minimal mock WorkspaceRunner for _connect_channel_history_tool tests.
+
+    Mirrors the pattern used by test_memory_search_availability.py.
+    """
+    runner = MagicMock(spec=WorkspaceRunner)
+    runner.workspace_name = "test_workspace"
+    runner.logger = MagicMock()
+
+    runner._builtin_loader = MagicMock()
+    runner._builtin_loader.get_tool_instance.return_value = history_tool
+
+    runner._channels = channels if channels is not None else {}
+    runner._agent_factory = MagicMock()
+    runner._agent_factory.create_agent.return_value = MagicMock()
+    runner._agent_runner = MagicMock()
+    runner._message_processor = MagicMock()
+    runner._checkpointer = MagicMock()
+
+    return runner
+
+
+class TestConnectChannelHistoryTool:
+    """Runner wiring tests for WorkspaceRunner._connect_channel_history_tool."""
+
+    def test_no_history_channels_removes_tool(self) -> None:
+        """When no channels support history, the tool is removed from the agent."""
+        history_tool = MagicMock()
+        telegram = MagicMock(spec=ChannelAdapter)
+        telegram.supports_history_browsing = False
+
+        runner = _make_mock_runner_for_history(
+            history_tool=history_tool,
+            channels={"telegram": telegram},
+        )
+
+        WorkspaceRunner._connect_channel_history_tool(runner)
+
+        runner._agent_factory.remove_builtin_tools.assert_called_once_with(
+            {"browse_channel_history"}
+        )
+        runner._agent_factory.remove_enabled_builtin.assert_called_once_with(
+            "channel_history"
+        )
+        runner._agent_factory.create_agent.assert_called_once_with(
+            checkpointer=runner._checkpointer
+        )
+        runner._message_processor.update_agent_runner.assert_called_once()
+
+    def test_history_channels_present_calls_set_channels(self) -> None:
+        """When history-capable channels exist, set_channels is called with only those."""
+        history_tool = MagicMock()
+        discord_ch = _make_mock_discord_channel()
+        telegram_ch = MagicMock(spec=ChannelAdapter)
+        telegram_ch.supports_history_browsing = False
+
+        runner = _make_mock_runner_for_history(
+            history_tool=history_tool,
+            channels={"discord": discord_ch, "telegram": telegram_ch},
+        )
+
+        WorkspaceRunner._connect_channel_history_tool(runner)
+
+        history_tool.set_channels.assert_called_once_with({"discord": discord_ch})
+        runner._agent_factory.remove_builtin_tools.assert_not_called()
+        runner._agent_factory.create_agent.assert_not_called()

--- a/tests/test_cron_timezone.py
+++ b/tests/test_cron_timezone.py
@@ -83,8 +83,11 @@ class TestCronSchedulerTimezone:
 
             await scheduler.start()
 
-            # Verify AsyncIOScheduler was called with the timezone
-            mock_scheduler_class.assert_called_once_with(timezone=ZoneInfo("America/Chicago"))
+            # Verify AsyncIOScheduler was called with the timezone and safe job defaults
+            mock_scheduler_class.assert_called_once_with(
+                timezone=ZoneInfo("America/Chicago"),
+                job_defaults={"max_instances": 1, "coalesce": True, "misfire_grace_time": 300},
+            )
 
     @pytest.mark.asyncio
     async def test_cron_trigger_receives_timezone(


### PR DESCRIPTION
## Summary

- **fix: prevent duplicate cron execution on scheduler restart** — APScheduler configured with `max_instances=1`, `coalesce=True`, `misfire_grace_time=300s`. Running-job guard and duplicate cron name validation.
- **feat: inject dynamic task results into agent context** — `schedule_at`/`schedule_every` completions now inject `[SYSTEM]` messages into the agent's conversation. Fixes stale `list_scheduled()` ghost entries.
- **feat: add channel history browsing tool for agents** — agents can browse channel message history
- **fix: allow any user in allowed groups without individual allowlisting**

## Test plan

- [x] 1973 tests passing
- [x] Manual validation: cron scheduling fix confirmed, dynamic task results visible in agent context