### PR TITLE
fix: resolve phantom cron tasks caused by truncated ID mismatch

### DIFF
--- a/openpaw/builtins/tools/cron.py
+++ b/openpaw/builtins/tools/cron.py
@@ -78,7 +78,7 @@ class ScheduleEveryInput(BaseModel):
 class CancelScheduledInput(BaseModel):
     """Input schema for canceling a scheduled task."""
 
-    task_id: str = Field(description="The unique ID of the task to cancel")
+    task_id: str = Field(description="The task ID or short prefix as shown by list_scheduled")
 
 
 class CronToolBuiltin(BaseBuiltinTool):
@@ -394,22 +394,25 @@ class CronToolBuiltin(BaseBuiltinTool):
         """Create the cancel_scheduled tool."""
 
         def cancel_scheduled(task_id: str) -> str:
-            """Cancel a scheduled task by ID.
+            """Cancel a scheduled task by ID or short prefix.
 
             Args:
-                task_id: The unique task ID to cancel.
+                task_id: The unique task ID or short prefix as shown by list_scheduled.
 
             Returns:
                 Confirmation message or error.
             """
-            success = self.store.remove_task(task_id)
+            try:
+                full_id = self.store.remove_task(task_id)
+            except ValueError as e:
+                return f"[Error: {e}]"
 
-            if success:
-                # Remove from live scheduler if available
-                self._remove_from_live_scheduler(task_id)
+            if full_id is not None:
+                # Remove from live scheduler using the resolved full UUID
+                self._remove_from_live_scheduler(full_id)
 
-                logger.info(f"Cancelled scheduled task: {task_id}")
-                return f"Successfully cancelled task {task_id}."
+                logger.info(f"Cancelled scheduled task: {full_id}")
+                return f"Successfully cancelled task {full_id}."
             else:
                 return f"[Error: Task {task_id} not found]"
 

--- a/openpaw/runtime/scheduling/cron.py
+++ b/openpaw/runtime/scheduling/cron.py
@@ -293,8 +293,12 @@ class CronScheduler:
     def remove_dynamic_job(self, task_id: str) -> bool:
         """Remove a dynamic task from the scheduler.
 
+        Note: This method expects a full UUID (used internally). For prefix-based
+        cancellation, use the CronTool's cancel_scheduled which resolves prefixes
+        via DynamicCronStore before calling _remove_from_live_scheduler.
+
         Args:
-            task_id: Unique task ID to remove.
+            task_id: Full UUID of the task to remove.
 
         Returns:
             True if removed, False if not found.

--- a/openpaw/stores/cron.py
+++ b/openpaw/stores/cron.py
@@ -127,27 +127,67 @@ class DynamicCronStore:
             self._save_unlocked(tasks)
         logger.info(f"Added dynamic cron task: {task.id} ({task.task_type})")
 
-    def remove_task(self, task_id: str) -> bool:
-        """Remove a task by ID and persist immediately.
+    @staticmethod
+    def _resolve_task_id(
+        tasks: list[DynamicCronTask], task_id: str
+    ) -> str | None:
+        """Resolve a full or prefix task ID to the canonical full UUID.
+
+        Pure function over an already-loaded task list. Supports both exact
+        UUID matches and short prefix lookups (as shown by list_scheduled()).
 
         Args:
-            task_id: Unique task ID to remove.
+            tasks: Pre-loaded list of tasks to search.
+            task_id: Full UUID or short prefix string.
 
         Returns:
-            True if task was found and removed, False otherwise.
+            The full UUID string if exactly one task matches, or None if no
+            task matches.
+
+        Raises:
+            ValueError: If the prefix is ambiguous (multiple tasks match).
+        """
+        matches = [t for t in tasks if t.id == task_id or t.id.startswith(task_id)]
+
+        if len(matches) == 1:
+            return matches[0].id
+
+        if len(matches) > 1:
+            conflicting = ", ".join(t.id[:8] for t in matches)
+            raise ValueError(
+                f"Ambiguous task ID prefix '{task_id}' matches {len(matches)} tasks: "
+                f"{conflicting}. Provide more characters to disambiguate."
+            )
+
+        return None
+
+    def remove_task(self, task_id: str) -> str | None:
+        """Remove a task by ID or short prefix and persist immediately.
+
+        Supports prefix lookups so agents can cancel tasks using the short IDs
+        shown by list_scheduled() without needing the full UUID.
+
+        Args:
+            task_id: Full UUID or short prefix of the task to remove.
+
+        Returns:
+            The resolved full task UUID on successful removal, or None if no
+            matching task was found.
+
+        Raises:
+            ValueError: If the prefix is ambiguous (multiple tasks match).
         """
         with self._lock:
             tasks = self._load_unlocked()
-            initial_count = len(tasks)
-            tasks = [t for t in tasks if t.id != task_id]
+            full_id = self._resolve_task_id(tasks, task_id)
+            if full_id is None:
+                logger.warning(f"Task not found for removal: {task_id}")
+                return None
 
-            if len(tasks) < initial_count:
-                self._save_unlocked(tasks)
-                logger.info(f"Removed dynamic cron task: {task_id}")
-                return True
-
-        logger.warning(f"Task not found for removal: {task_id}")
-        return False
+            tasks = [t for t in tasks if t.id != full_id]
+            self._save_unlocked(tasks)
+            logger.info(f"Removed dynamic cron task: {full_id}")
+            return full_id
 
     def list_tasks(self) -> list[DynamicCronTask]:
         """Return all tasks from storage.
@@ -158,19 +198,29 @@ class DynamicCronStore:
         return self.load()
 
     def get_task(self, task_id: str) -> DynamicCronTask | None:
-        """Get a single task by ID.
+        """Get a single task by full ID or short prefix.
+
+        Supports prefix lookups so agents can retrieve tasks using the short
+        IDs shown by list_scheduled() without needing the full UUID.
 
         Args:
-            task_id: Unique task ID to retrieve.
+            task_id: Full UUID or short prefix of the task to retrieve.
 
         Returns:
-            DynamicCronTask if found, None otherwise.
+            DynamicCronTask if exactly one match is found, None otherwise.
+
+        Raises:
+            ValueError: If the prefix is ambiguous (multiple tasks match).
         """
-        tasks = self.load()
-        for task in tasks:
-            if task.id == task_id:
-                return task
-        return None
+        with self._lock:
+            tasks = self._load_unlocked()
+            full_id = self._resolve_task_id(tasks, task_id)
+            if full_id is None:
+                return None
+            for task in tasks:
+                if task.id == full_id:
+                    return task
+            return None
 
     def update_task(self, task: DynamicCronTask) -> bool:
         """Update an existing task and persist immediately.

--- a/tests/test_cron_dynamic.py
+++ b/tests/test_cron_dynamic.py
@@ -179,7 +179,7 @@ class TestDynamicCronStore:
         assert tasks[1].id == "task-2"
 
     def test_remove_task(self, tmp_path: Any) -> None:
-        """Test removing a task by ID."""
+        """Test removing a task by full ID returns the resolved UUID."""
         store = DynamicCronStore(tmp_path)
 
         task = DynamicCronTask(
@@ -193,18 +193,112 @@ class TestDynamicCronStore:
         store.add_task(task)
         assert len(store.list_tasks()) == 1
 
-        success = store.remove_task("removable")
+        full_id = store.remove_task("removable")
 
-        assert success is True
+        assert full_id == "removable"
         assert len(store.list_tasks()) == 0
 
     def test_remove_nonexistent_task(self, tmp_path: Any) -> None:
-        """Test removing a task that doesn't exist returns False."""
+        """Test removing a task that doesn't exist returns None."""
         store = DynamicCronStore(tmp_path)
 
-        success = store.remove_task("nonexistent-id")
+        result = store.remove_task("nonexistent-id")
 
-        assert success is False
+        assert result is None
+
+    def test_remove_task_by_prefix(self, tmp_path: Any) -> None:
+        """Test removing a task using its 8-character ID prefix."""
+        store = DynamicCronStore(tmp_path)
+
+        # Use a well-known UUID so the prefix is deterministic
+        known_uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        task = DynamicCronTask(
+            id=known_uuid,
+            task_type="once",
+            prompt="Remove via prefix",
+            created_at=datetime.now(UTC),
+            run_at=datetime.now(UTC) + timedelta(hours=1),
+        )
+        store.add_task(task)
+        assert len(store.list_tasks()) == 1
+
+        # Remove using the 8-character prefix shown by list_scheduled()
+        full_id = store.remove_task(known_uuid[:8])
+
+        assert full_id == known_uuid
+        assert len(store.list_tasks()) == 0
+
+    def test_get_task_by_prefix(self, tmp_path: Any) -> None:
+        """Test retrieving a task using its 8-character ID prefix."""
+        store = DynamicCronStore(tmp_path)
+
+        known_uuid = "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+        task = DynamicCronTask(
+            id=known_uuid,
+            task_type="interval",
+            prompt="Find via prefix",
+            created_at=datetime.now(UTC),
+            interval_seconds=300,
+            next_run=datetime.now(UTC) + timedelta(minutes=5),
+        )
+        store.add_task(task)
+
+        retrieved = store.get_task(known_uuid[:8])
+
+        assert retrieved is not None
+        assert retrieved.id == known_uuid
+        assert retrieved.prompt == "Find via prefix"
+
+    def test_remove_task_ambiguous_prefix(self, tmp_path: Any) -> None:
+        """Test that an ambiguous prefix raises ValueError."""
+        store = DynamicCronStore(tmp_path)
+
+        # Two UUIDs that share the same first 8 characters
+        shared_prefix = "ffffffff"
+        task1 = DynamicCronTask(
+            id=f"{shared_prefix}-0000-0000-0000-000000000001",
+            task_type="once",
+            prompt="First task",
+            created_at=datetime.now(UTC),
+            run_at=datetime.now(UTC) + timedelta(hours=1),
+        )
+        task2 = DynamicCronTask(
+            id=f"{shared_prefix}-0000-0000-0000-000000000002",
+            task_type="once",
+            prompt="Second task",
+            created_at=datetime.now(UTC),
+            run_at=datetime.now(UTC) + timedelta(hours=2),
+        )
+        store.add_task(task1)
+        store.add_task(task2)
+
+        with pytest.raises(ValueError, match="Ambiguous task ID prefix"):
+            store.remove_task(shared_prefix)
+
+    def test_get_task_ambiguous_prefix(self, tmp_path: Any) -> None:
+        """Test that get_task with ambiguous prefix raises ValueError."""
+        store = DynamicCronStore(tmp_path)
+
+        shared_prefix = "eeeeeeee"
+        task1 = DynamicCronTask(
+            id=f"{shared_prefix}-0000-0000-0000-000000000001",
+            task_type="once",
+            prompt="First task",
+            created_at=datetime.now(UTC),
+            run_at=datetime.now(UTC) + timedelta(hours=1),
+        )
+        task2 = DynamicCronTask(
+            id=f"{shared_prefix}-0000-0000-0000-000000000002",
+            task_type="once",
+            prompt="Second task",
+            created_at=datetime.now(UTC),
+            run_at=datetime.now(UTC) + timedelta(hours=2),
+        )
+        store.add_task(task1)
+        store.add_task(task2)
+
+        with pytest.raises(ValueError, match="Ambiguous task ID prefix"):
+            store.get_task(shared_prefix)
 
     def test_get_task_by_id(self, tmp_path: Any) -> None:
         """Test retrieving a specific task by ID."""
@@ -655,6 +749,40 @@ class TestCronToolBuiltin:
 
         assert "[Error:" in result
         assert "not found" in result
+
+    @pytest.mark.asyncio
+    async def test_cancel_scheduled_by_prefix(self, tmp_path: Any) -> None:
+        """Test cancel_scheduled succeeds when given an 8-character prefix ID.
+
+        This is the real-world scenario: the agent calls list_scheduled() and
+        sees short IDs like [a1b2c3d4], then passes that prefix to
+        cancel_scheduled(). Without prefix matching the cancellation silently
+        fails because the store does exact UUID comparison.
+        """
+        config = {"workspace_path": str(tmp_path)}
+        tool = CronToolBuiltin(config)
+        tools = tool.get_langchain_tool()
+        cancel_tool = next(t for t in tools if t.name == "cancel_scheduled")
+
+        # Add a task with a known UUID
+        known_uuid = "c3d4e5f6-a7b8-9012-cdef-123456789012"
+        future_time = datetime.now(UTC) + timedelta(hours=1)
+        task = DynamicCronTask(
+            id=known_uuid,
+            task_type="once",
+            prompt="Cancel me by prefix",
+            created_at=datetime.now(UTC),
+            run_at=future_time,
+        )
+        tool.store.add_task(task)
+        assert len(tool.store.list_tasks()) == 1
+
+        # Cancel using only the 8-char prefix (as the agent would, from list_scheduled)
+        result = await cancel_tool.ainvoke({"task_id": known_uuid[:8]})
+
+        assert "Successfully cancelled" in result
+        assert known_uuid in result  # confirmation should echo the full UUID
+        assert len(tool.store.list_tasks()) == 0
 
     @pytest.mark.asyncio
     async def test_max_tasks_limit_enforced(self, tmp_path: Any) -> None:


### PR DESCRIPTION
## Summary
- `list_scheduled()` displayed 8-char task ID prefixes, but `cancel_scheduled()` and `store.remove_task()` required exact UUID match — making cancellation impossible and leaving zombie APScheduler jobs running indefinitely
- Added prefix resolution to `DynamicCronStore` via static `_resolve_task_id()` with ambiguous prefix detection
- `cancel_scheduled` now resolves short prefixes to full UUIDs before removing from both store and live scheduler

## Test plan
- [x] Cancel by 8-char prefix resolves to full UUID and removes task
- [x] Cancel by full UUID still works (backward compatible)
- [x] Ambiguous prefix returns clear error message
- [x] `get_task()` supports prefix lookup
- [x] 1978 tests passing, ruff clean

Closes #52