### PR TITLE
ci: add sosoka-ops project board automation

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,15 @@
+name: Add to sosoka-ops
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/johnsosoka/projects/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Adds workflow to auto-add new issues and PRs to the sosoka-ops unified project board.

Same workflow deployed to 13 other repos today. Uses `actions/add-to-project@v1.0.2` with the `ADD_TO_PROJECT_PAT` secret (already configured).

After merge to main, develop should be updated as well.