### PR TITLE
feat: skills loading + persistent cron management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,8 @@ openpaw/
 │   ├── session.py    # SessionState
 │   ├── subagent.py   # SubAgentRequest, SubAgentStatus
 │   ├── cron.py       # DynamicCronTask (pure dataclass)
-│   └── channel.py    # ChannelHistoryEntry, ChannelEvent
+│   ├── channel.py    # ChannelHistoryEntry, ChannelEvent
+│   └── skill.py      # SkillInfo (loaded skill metadata + content)
 ├── core/             # Configuration, logging, timezone, utilities
 │   ├── config/       # Pydantic config models and loaders
 │   │   ├── models.py         # WorkspaceConfig, GlobalConfig, CronDefinition, CronOutputConfig
@@ -105,7 +106,8 @@ openpaw/
 │   ├── message_processor.py  # Message processing loop
 │   ├── agent_factory.py      # Agent creation with middleware
 │   ├── lifecycle.py          # Startup/shutdown hooks
-│   └── tool_loader.py        # Custom tool loading
+│   ├── tool_loader.py        # Custom tool loading
+│   └── skill_loader.py       # SKILL.md loading from agent/skills/
 ├── runtime/          # Runtime services
 │   ├── orchestrator.py       # OpenPawOrchestrator
 │   ├── queue/        # Message queueing
@@ -167,6 +169,8 @@ openpaw/
 **`openpaw/workspace/loader.py`** - `WorkspaceLoader` loads agent workspaces from `agent_workspaces/<name>/`. Returns an `AgentWorkspace` instance from `core/`. Each workspace requires: `AGENT.md`, `USER.md`, `SOUL.md`, `HEARTBEAT.md`. Optional `agent.yaml` and `crons/*.yaml` are loaded if present.
 
 **`openpaw/workspace/tool_loader.py`** - Dynamically loads LangChain tools from workspace `tools/` directories. Imports Python files and extracts `@tool` decorated functions (BaseTool instances).
+
+**`openpaw/workspace/skill_loader.py`** - Loads skills from workspace `agent/skills/` directories. Parses SKILL.md files with optional YAML frontmatter, returns `list[SkillInfo]`. Follows the same conventions as `tool_loader.py` (sorted glob, `_` prefix skipping, logging).
 
 **`openpaw/runtime/queue/lane.py`** - Lane-based FIFO queue with configurable concurrency per lane (main, subagent, cron). Supports OpenClaw-style queue modes: `collect`, `steer`, `followup`, `interrupt`.
 
@@ -738,6 +742,55 @@ builtins:
 - Agent calls `schedule_at` with timestamp 10 minutes from now
 - Task fires, agent sends reminder to user's chat
 
+### Persistent Cron Management (CronManager)
+
+Agents can create, list, update, and delete persistent YAML cron jobs via the `cron_manager` builtin. Unlike dynamic scheduling (`schedule_at`/`schedule_every`) which uses in-memory task scheduling, cron manager writes YAML files to `config/crons/` that persist across restarts and are loaded by the cron scheduler at startup.
+
+**Available Tools**:
+- `create_cron` — Create a new persistent cron job (validates expression, writes YAML, hot-adds to scheduler)
+- `list_crons` — List all YAML crons with name, schedule, enabled status, and next run time
+- `update_cron` — Update fields on an existing cron job (hot-reloads in scheduler)
+- `delete_cron` — Remove a cron job file and unregister from scheduler
+
+**Difference from Dynamic Scheduling**:
+| Feature | Dynamic (`schedule_at`/`schedule_every`) | Persistent (`create_cron`/`update_cron`) |
+|---------|------------------------------------------|------------------------------------------|
+| Storage | `data/dynamic_crons.json` | `config/crons/{name}.yaml` |
+| Scheduling | One-time or interval-based | Standard cron expressions |
+| Lifecycle | Auto-cleaned after execution (one-time) | Permanent until deleted |
+| Restarts | Loaded from JSON on restart | Loaded from YAML on restart |
+| Use case | "Remind me in 10 minutes" | "Daily summary at 9am" |
+
+**Hot-Reload**: Changes are applied to the live scheduler immediately via `CronScheduler.reload_cron()`. No workspace restart required. If the scheduler is unavailable, changes are persisted to disk and take effect on next startup.
+
+**Name Validation**: Cron names must be lowercase alphanumeric with hyphens only (regex: `^[a-z0-9][a-z0-9-]*$`). Names become filenames (`{name}.yaml`), so path traversal is inherently prevented.
+
+**YAML Output Format** (matches `CronDefinition` schema):
+```yaml
+name: morning-check
+schedule: "0 7 * * *"
+enabled: true
+prompt: |
+  Check system health and report any issues.
+output:
+  channel: telegram
+  target_id: 8480590125
+  delivery: channel
+```
+
+**Configuration** (optional, in `agent.yaml` or global config):
+```yaml
+builtins:
+  cron_manager:
+    enabled: true
+```
+
+**Components**:
+- `CronManagerBuiltin` in `openpaw/builtins/tools/cron_manager.py` — tool implementation
+- `CronScheduler.reload_cron()` / `remove_cron()` in `openpaw/runtime/scheduling/cron.py` — hot-reload support
+- `CronManagerBuiltinConfig` in `openpaw/core/config/models.py` — typed config
+- Wired via `lifecycle.py._connect_cron_manager_to_scheduler()` (same pattern as CronTool)
+
 ### Web Browsing
 
 Agents can interact with websites via Playwright-based browser automation. The browser builtin provides accessibility tree snapshots where elements are numbered, allowing agents to reference elements by numeric ID instead of writing CSS selectors.
@@ -1009,6 +1062,55 @@ Missing dependencies are auto-installed at workspace startup.
 
 **Loading**: Tools are dynamically imported at workspace startup. The tool loader checks requirements.txt first, installs missing packages, then extracts all `BaseTool` instances from each Python file in the tools directory.
 
+### Skills System
+
+Workspaces can define reusable knowledge or behavioral patterns as skills. Each skill lives in its own subdirectory under `agent/skills/` and is defined by a `SKILL.md` file.
+
+**Directory Structure**:
+
+```
+agent/skills/
+├── research-patterns/
+│   └── SKILL.md
+├── code-review/
+│   └── SKILL.md
+└── _disabled-skill/     # Skipped (underscore prefix)
+    └── SKILL.md
+```
+
+**SKILL.md Format** — Optional YAML frontmatter followed by content:
+
+```markdown
+---
+name: research-patterns
+description: Patterns for conducting technical research across multiple sources
+version: "1.0"
+---
+
+# Research Patterns
+
+(full skill content — instructions, examples, templates)
+```
+
+**Frontmatter Fields**:
+- `name` — Skill display name (falls back to directory name if omitted)
+- `description` — Short description, truncated to 1024 chars (empty if omitted)
+- `version` — Optional, not used by the framework
+
+**Behavior**:
+- Skills are loaded at workspace startup by `WorkspaceLoader` via `load_workspace_skills()`
+- Full content is injected into the system prompt as a `<skills>` XML block between `</framework>` and `<workspace_context>`
+- Directories prefixed with `_` are skipped
+- If no frontmatter is present, the entire file becomes the content with directory name as the skill name
+- Invalid YAML frontmatter degrades gracefully (logged warning, falls back to directory name)
+- Empty or missing `agent/skills/` directory is silently ignored
+
+**Components**:
+- `SkillInfo` dataclass in `openpaw/model/skill.py` — pure data model (name, description, content, path)
+- `load_workspace_skills()` in `openpaw/workspace/skill_loader.py` — scans directories, parses frontmatter
+- `AgentWorkspace.skills` field in `openpaw/core/workspace.py` — stores loaded skills
+- `AgentWorkspace._build_skills_section()` — formats skills for system prompt injection
+
 ### Builtins System
 
 OpenPaw provides optional built-in capabilities that are conditionally available based on API keys. Builtins come in two types:
@@ -1017,6 +1119,7 @@ OpenPaw provides optional built-in capabilities that are conditionally available
 - `brave_search` - Web search via Brave API (requires `BRAVE_API_KEY`)
 - `elevenlabs` - Text-to-speech for voice responses (requires `ELEVENLABS_API_KEY`)
 - `cron` - Agent self-scheduling (no API key required, see "Dynamic Scheduling" section)
+- `cron_manager` - Persistent YAML cron management (no API key required, see "Persistent Cron Management" section)
 - `send_message` - Mid-execution messaging to keep users informed during long operations (no API key required)
 - `followup` - Self-continuation for multi-step autonomous workflows with depth limiting (no API key required)
 - `task_tracker` - Task management via TASKS.yaml for persistent cross-session work tracking (no API key required)
@@ -1040,6 +1143,7 @@ builtins/
 │   ├── brave_search.py
 │   ├── elevenlabs_tts.py
 │   ├── cron.py       # Agent self-scheduling
+│   ├── cron_manager.py  # Persistent YAML cron management (create/list/update/delete)
 │   ├── spawn.py      # Sub-agent spawning (spawn_agent, list, get_result, cancel)
 │   ├── browser.py    # Web automation with Playwright + accessibility tree
 │   ├── _channel_context.py # Shared contextvars for channel/session state

--- a/openpaw/builtins/loader.py
+++ b/openpaw/builtins/loader.py
@@ -186,6 +186,18 @@ class BuiltinLoader:
             if user_aliases:
                 config["user_aliases"] = user_aliases
 
+        # Inject channel routing config for cron_manager tool
+        if name == "cron_manager":
+            if self.workspace_path:
+                from openpaw.core.paths import CRONS_DIR
+                config["crons_dir"] = str(self.workspace_path / str(CRONS_DIR))
+            if self.channel_config:
+                channel_type = self.channel_config.get("type", "telegram")
+                config["default_channel"] = channel_type
+                allowed_users = self.channel_config.get("allowed_users", [])
+                if allowed_users:
+                    config["default_target_id"] = allowed_users[0]
+
         # Inject channel routing config for send_message tool
         if name == "send_message" and self.channel_config:
             channel_type = self.channel_config.get("type", "telegram")

--- a/openpaw/builtins/registry.py
+++ b/openpaw/builtins/registry.py
@@ -146,6 +146,13 @@ class BuiltinRegistry:
         except ImportError as e:
             logger.debug(f"Channel history tool not available: {e}")
 
+        try:
+            from openpaw.builtins.tools.cron_manager import CronManagerBuiltin
+
+            self.register_tool(CronManagerBuiltin)
+        except ImportError as e:
+            logger.debug(f"Cron manager not available: {e}")
+
         # Processors (sorted by metadata.priority in BuiltinLoader.load_processors)
         try:
             from openpaw.builtins.processors.file_persistence import FilePersistenceProcessor

--- a/openpaw/builtins/tools/cron_manager.py
+++ b/openpaw/builtins/tools/cron_manager.py
@@ -1,0 +1,585 @@
+"""Persistent cron management builtin for agent-controlled YAML cron jobs."""
+
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+from apscheduler.triggers.cron import CronTrigger
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from openpaw.builtins.base import (
+    BaseBuiltinTool,
+    BuiltinMetadata,
+    BuiltinPrerequisite,
+    BuiltinType,
+)
+from openpaw.core.config.models import CronDefinition, CronOutputConfig
+from openpaw.runtime.scheduling.loader import CronLoader
+
+logger = logging.getLogger(__name__)
+
+# Regex for valid cron job names: alphanumeric and hyphens only.
+_VALID_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+
+class CreateCronInput(BaseModel):
+    """Input schema for creating a persistent cron job."""
+
+    name: str = Field(
+        description=(
+            "Unique name for this cron job. "
+            "Use lowercase letters, digits, and hyphens only "
+            "(e.g., 'morning-check', 'daily-summary'). "
+            "This becomes the filename and job ID."
+        )
+    )
+    schedule: str = Field(
+        description=(
+            "Standard cron expression: 'minute hour day-of-month month day-of-week'. "
+            "Examples: '0 9 * * *' (daily at 9am), '*/15 * * * *' (every 15 min), "
+            "'0 0 * * 0' (every Sunday midnight). "
+            "Runs in the workspace timezone."
+        )
+    )
+    prompt: str = Field(
+        description=(
+            "The instruction the agent will execute when this cron fires. "
+            "Include all necessary context — the cron agent has no memory of "
+            "previous conversations."
+        )
+    )
+    enabled: bool = Field(
+        default=True,
+        description="Whether the cron job is active immediately after creation.",
+    )
+    delivery: str = Field(
+        default="channel",
+        description=(
+            "Where to deliver results: 'channel' (send to user), "
+            "'agent' (inject into main agent queue), or 'both'."
+        ),
+    )
+
+
+class UpdateCronInput(BaseModel):
+    """Input schema for updating an existing cron job."""
+
+    name: str = Field(description="Name of the existing cron job to update.")
+    schedule: str | None = Field(
+        default=None,
+        description=(
+            "New cron expression to set. Leave unset to keep the current schedule."
+        ),
+    )
+    prompt: str | None = Field(
+        default=None,
+        description="New prompt to set. Leave unset to keep the current prompt.",
+    )
+    enabled: bool | None = Field(
+        default=None,
+        description=(
+            "Set to true to enable or false to disable. "
+            "Leave unset to keep the current state."
+        ),
+    )
+    delivery: str | None = Field(
+        default=None,
+        description=(
+            "New delivery mode: 'channel', 'agent', or 'both'. "
+            "Leave unset to keep the current delivery mode."
+        ),
+    )
+
+
+class DeleteCronInput(BaseModel):
+    """Input schema for deleting a cron job."""
+
+    name: str = Field(description="Name of the cron job to permanently delete.")
+
+
+class CronManagerBuiltin(BaseBuiltinTool):
+    """Persistent cron management — create, list, update, and delete YAML cron jobs.
+
+    Unlike the dynamic cron tool (which uses in-memory task scheduling), this
+    builtin writes YAML files to the workspace ``config/crons/`` directory.
+    Jobs created here survive restarts and are loaded by the cron scheduler at
+    startup alongside any hand-authored cron files.
+
+    All changes are also applied to the live scheduler immediately so there is
+    no need to restart the workspace.
+
+    Config options:
+        crons_dir: Absolute path to the workspace's config/crons/ directory.
+        default_channel: Channel name for cron output routing (default: "telegram").
+        default_target_id: Target user/channel ID for routing (default: None).
+        timezone: Workspace timezone for schedule display (default: "UTC").
+    """
+
+    metadata = BuiltinMetadata(
+        name="cron_manager",
+        display_name="Cron Manager",
+        description="Create, list, update, and delete persistent YAML cron jobs",
+        builtin_type=BuiltinType.TOOL,
+        group="automation",
+        prerequisites=BuiltinPrerequisite(),  # No external dependencies required
+    )
+
+    def __init__(self, config: dict[str, Any] | None = None):
+        """Initialize the cron manager builtin.
+
+        Args:
+            config: Configuration dict containing:
+                - crons_dir: Absolute path to config/crons/ directory (required)
+                - default_channel: Channel name for output routing (default: "telegram")
+                - default_target_id: Target ID for output routing (default: None)
+                - timezone: Display timezone string (default: "UTC")
+        """
+        super().__init__(config)
+
+        crons_dir = self.config.get("crons_dir")
+        if not crons_dir:
+            raise ValueError("CronManagerBuiltin requires 'crons_dir' in config")
+
+        self.crons_dir = Path(crons_dir)
+        self.default_channel = self.config.get("default_channel", "telegram")
+        self.default_target_id: int | None = self.config.get("default_target_id")
+        self.timezone = self.config.get("timezone", "UTC")
+
+        # Scheduler reference — injected after startup via set_scheduler()
+        self.scheduler: Any = None
+
+        logger.info(f"CronManagerBuiltin initialized (crons_dir={self.crons_dir})")
+
+    def get_langchain_tool(self) -> list[Any]:
+        """Return cron management tools as a list of LangChain StructuredTools."""
+        return [
+            self._create_create_cron_tool(),
+            self._create_list_crons_tool(),
+            self._create_update_cron_tool(),
+            self._create_delete_cron_tool(),
+        ]
+
+    def set_scheduler(self, scheduler: Any) -> None:
+        """Connect a live CronScheduler for immediate hot-reload on changes.
+
+        Called by lifecycle.py after the scheduler has started. Without a
+        scheduler reference, file changes are still persisted to disk and
+        will take effect on the next workspace restart.
+
+        Args:
+            scheduler: CronScheduler instance.
+        """
+        self.scheduler = scheduler
+        logger.info("CronManager connected to live scheduler")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _validate_name(self, name: str) -> str | None:
+        """Return an error message if the name is invalid, otherwise None."""
+        if not _VALID_NAME_RE.match(name):
+            return (
+                f"Invalid cron name '{name}'. "
+                "Use lowercase letters, digits, and hyphens only "
+                "(e.g., 'morning-check', 'daily-summary'). "
+                "Must start with a letter or digit."
+            )
+        return None
+
+    def _validate_schedule(self, schedule: str) -> str | None:
+        """Return an error message if the cron expression is invalid, otherwise None."""
+        try:
+            CronTrigger.from_crontab(schedule)
+        except (ValueError, KeyError) as e:
+            return f"Invalid cron expression '{schedule}': {e}"
+        return None
+
+    def _validate_delivery(self, delivery: str) -> str | None:
+        """Return an error message if the delivery mode is invalid, otherwise None."""
+        allowed = {"channel", "agent", "both"}
+        if delivery not in allowed:
+            return f"Invalid delivery mode '{delivery}'. Must be one of: {allowed}"
+        return None
+
+    def _cron_file_path(self, name: str) -> Path:
+        """Return the canonical YAML file path for a given cron name."""
+        return self.crons_dir / f"{name}.yaml"
+
+    def _cron_exists(self, name: str) -> bool:
+        """Check if a YAML cron file exists for the given name."""
+        return self._cron_file_path(name).exists()
+
+    def _build_cron_dict(
+        self,
+        name: str,
+        schedule: str,
+        prompt: str,
+        enabled: bool,
+        delivery: str,
+    ) -> dict[str, Any]:
+        """Build the raw dict that maps 1-to-1 with the YAML file format."""
+        output: dict[str, Any] = {"channel": self.default_channel, "delivery": delivery}
+        if self.default_target_id is not None:
+            output["target_id"] = self.default_target_id
+
+        return {
+            "name": name,
+            "schedule": schedule,
+            "enabled": enabled,
+            "prompt": prompt,
+            "output": output,
+        }
+
+    def _write_cron_yaml(self, cron_dict: dict[str, Any]) -> None:
+        """Serialize a cron dict to YAML and write it to disk.
+
+        Creates the crons directory if it does not yet exist.
+        """
+        self.crons_dir.mkdir(parents=True, exist_ok=True)
+        path = self._cron_file_path(cron_dict["name"])
+        with path.open("w", encoding="utf-8") as f:
+            yaml.safe_dump(cron_dict, f, default_flow_style=False, sort_keys=False)
+
+    def _load_cron_dict(self, name: str) -> dict[str, Any] | None:
+        """Read and parse a YAML cron file. Returns None if not found."""
+        path = self._cron_file_path(name)
+        if not path.exists():
+            return None
+        with path.open(encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+
+    def _reload_in_scheduler(self, name: str) -> None:
+        """Hot-reload a YAML cron into the live scheduler if one is available."""
+        if not self.scheduler:
+            logger.debug(
+                "No live scheduler available — cron change will take effect on next restart"
+            )
+            return
+
+        try:
+            loader = CronLoader(self.crons_dir.parent.parent)
+            cron_def = loader.load_one(name)
+            self.scheduler.reload_cron(cron_def)
+            logger.info(f"Hot-reloaded cron job '{name}' in live scheduler")
+        except Exception as e:
+            logger.warning(f"Failed to hot-reload cron '{name}' in scheduler: {e}")
+
+    def _remove_from_scheduler(self, name: str) -> None:
+        """Remove a cron job from the live scheduler if one is available."""
+        if not self.scheduler:
+            logger.debug(
+                "No live scheduler available — removal will take effect on next restart"
+            )
+            return
+
+        try:
+            self.scheduler.remove_cron(name)
+            logger.info(f"Removed cron job '{name}' from live scheduler")
+        except Exception as e:
+            logger.debug(f"Cron '{name}' was not in live scheduler: {e}")
+
+    # ------------------------------------------------------------------
+    # Tool factories
+    # ------------------------------------------------------------------
+
+    def _create_create_cron_tool(self) -> StructuredTool:
+        """Create the create_cron tool."""
+
+        def create_cron(
+            name: str,
+            schedule: str,
+            prompt: str,
+            enabled: bool = True,
+            delivery: str = "channel",
+        ) -> str:
+            """Create a persistent YAML cron job and register it with the live scheduler.
+
+            Args:
+                name: Unique lowercase name for the cron job (hyphens allowed).
+                schedule: Standard cron expression (e.g., '0 9 * * *').
+                prompt: Instruction executed by the agent when the cron fires.
+                enabled: Whether the job starts active (default: True).
+                delivery: Output routing mode (channel/agent/both).
+
+            Returns:
+                Confirmation message or error string.
+            """
+            name = name.strip().lower()
+
+            # Validate name
+            name_error = self._validate_name(name)
+            if name_error:
+                return f"[Error: {name_error}]"
+
+            # Reject duplicates
+            if self._cron_exists(name):
+                return (
+                    f"[Error: A cron job named '{name}' already exists. "
+                    f"Use update_cron to modify it or delete_cron to remove it first.]"
+                )
+
+            # Validate schedule
+            schedule_error = self._validate_schedule(schedule)
+            if schedule_error:
+                return f"[Error: {schedule_error}]"
+
+            # Validate delivery
+            delivery_error = self._validate_delivery(delivery)
+            if delivery_error:
+                return f"[Error: {delivery_error}]"
+
+            # Validate the full definition via Pydantic before writing
+            output_config = CronOutputConfig(
+                channel=self.default_channel,
+                target_id=self.default_target_id,
+                delivery=delivery,
+            )
+            try:
+                CronDefinition(
+                    name=name,
+                    schedule=schedule,
+                    enabled=enabled,
+                    prompt=prompt,
+                    output=output_config,
+                )
+            except Exception as e:
+                return f"[Error: Invalid cron definition: {e}]"
+
+            # Write to disk
+            cron_dict = self._build_cron_dict(name, schedule, prompt, enabled, delivery)
+            try:
+                self._write_cron_yaml(cron_dict)
+            except OSError as e:
+                return f"[Error: Failed to write cron file: {e}]"
+
+            logger.info(f"Created cron job '{name}' ({schedule})")
+
+            # Hot-add to live scheduler
+            if enabled:
+                self._reload_in_scheduler(name)
+
+            status = "enabled" if enabled else "disabled"
+            return (
+                f"Created cron job '{name}'.\n"
+                f"  Schedule: {schedule} ({self.timezone})\n"
+                f"  Status: {status}\n"
+                f"  Delivery: {delivery}\n"
+                f"  File: config/crons/{name}.yaml"
+            )
+
+        return StructuredTool.from_function(
+            func=create_cron,
+            name="create_cron",
+            description=(
+                "Create a persistent cron job that survives workspace restarts. "
+                "Writes a YAML file to config/crons/ and registers it with the "
+                "live scheduler immediately. "
+                "Use this for recurring tasks that should run on a schedule "
+                "(e.g., daily summaries, health checks, reminders)."
+            ),
+            args_schema=CreateCronInput,
+        )
+
+    def _create_list_crons_tool(self) -> StructuredTool:
+        """Create the list_crons tool."""
+
+        def list_crons() -> str:
+            """List all persistent YAML cron jobs in the workspace.
+
+            Returns:
+                Formatted list of cron jobs with name, schedule, status, and next run.
+            """
+            if not self.crons_dir.exists():
+                return "No cron jobs defined. Use create_cron to add one."
+
+            loader = CronLoader(self.crons_dir.parent.parent)
+            try:
+                cron_defs = loader.load_all()
+            except Exception as e:
+                return f"[Error: Failed to load cron definitions: {e}]"
+
+            if not cron_defs:
+                return "No cron jobs defined. Use create_cron to add one."
+
+            lines = [f"Persistent cron jobs ({len(cron_defs)} total):\n"]
+
+            for cron in cron_defs:
+                status = "enabled" if cron.enabled else "disabled"
+
+                # Compute next run time from live scheduler if available
+                next_run = "unknown"
+                if self.scheduler and cron.enabled:
+                    try:
+                        job = self.scheduler._jobs.get(cron.name)
+                        if job:
+                            next_run_dt = job.next_run_time
+                            if next_run_dt:
+                                next_run = next_run_dt.strftime("%Y-%m-%d %H:%M %Z")
+                    except Exception:
+                        pass  # best-effort
+
+                prompt_preview = cron.prompt.strip()[:60]
+                if len(cron.prompt.strip()) > 60:
+                    prompt_preview += "..."
+
+                lines.append(
+                    f"  [{cron.name}]\n"
+                    f"    Schedule: {cron.schedule} ({self.timezone}) — next: {next_run}\n"
+                    f"    Status: {status}  Delivery: {cron.output.delivery}\n"
+                    f"    Prompt: {prompt_preview}\n"
+                )
+
+            return "\n".join(lines)
+
+        return StructuredTool.from_function(
+            func=list_crons,
+            name="list_crons",
+            description=(
+                "List all persistent YAML cron jobs defined in this workspace. "
+                "Shows name, schedule, enabled status, next run time, and a "
+                "preview of each job's prompt."
+            ),
+        )
+
+    def _create_update_cron_tool(self) -> StructuredTool:
+        """Create the update_cron tool."""
+
+        def update_cron(
+            name: str,
+            schedule: str | None = None,
+            prompt: str | None = None,
+            enabled: bool | None = None,
+            delivery: str | None = None,
+        ) -> str:
+            """Update fields on an existing YAML cron job.
+
+            Only provided fields are modified; omitted fields keep their current values.
+
+            Args:
+                name: Name of the cron job to update.
+                schedule: New cron expression (optional).
+                prompt: New prompt text (optional).
+                enabled: New enabled state (optional).
+                delivery: New delivery mode (optional).
+
+            Returns:
+                Confirmation message or error string.
+            """
+            if not self._cron_exists(name):
+                return (
+                    f"[Error: Cron job '{name}' not found. "
+                    f"Use list_crons to see available jobs.]"
+                )
+
+            cron_dict = self._load_cron_dict(name)
+            if not cron_dict:
+                return f"[Error: Failed to read cron file for '{name}'.]"
+
+            # Apply updates
+            if schedule is not None:
+                schedule_error = self._validate_schedule(schedule)
+                if schedule_error:
+                    return f"[Error: {schedule_error}]"
+                cron_dict["schedule"] = schedule
+
+            if prompt is not None:
+                cron_dict["prompt"] = prompt
+
+            if enabled is not None:
+                cron_dict["enabled"] = enabled
+
+            if delivery is not None:
+                delivery_error = self._validate_delivery(delivery)
+                if delivery_error:
+                    return f"[Error: {delivery_error}]"
+                if "output" not in cron_dict or not isinstance(cron_dict["output"], dict):
+                    cron_dict["output"] = {"channel": self.default_channel}
+                cron_dict["output"]["delivery"] = delivery
+
+            # Validate the updated definition via Pydantic before writing
+            try:
+                CronDefinition(**cron_dict)
+            except Exception as e:
+                return f"[Error: Updated cron definition is invalid: {e}]"
+
+            try:
+                self._write_cron_yaml(cron_dict)
+            except OSError as e:
+                return f"[Error: Failed to write cron file: {e}]"
+
+            logger.info(f"Updated cron job '{name}'")
+
+            # Re-register with live scheduler — reload_cron handles enable/disable
+            self._reload_in_scheduler(name)
+
+            updated_fields = [
+                k for k, v in [
+                    ("schedule", schedule),
+                    ("prompt", prompt),
+                    ("enabled", enabled),
+                    ("delivery", delivery),
+                ]
+                if v is not None
+            ]
+            return (
+                f"Updated cron job '{name}'.\n"
+                f"  Modified fields: {', '.join(updated_fields)}\n"
+                f"  Schedule: {cron_dict['schedule']} ({self.timezone})\n"
+                f"  Status: {'enabled' if cron_dict.get('enabled', True) else 'disabled'}"
+            )
+
+        return StructuredTool.from_function(
+            func=update_cron,
+            name="update_cron",
+            description=(
+                "Update one or more fields of an existing persistent cron job. "
+                "Only the fields you provide will be changed; others remain as-is. "
+                "Changes are written to disk and applied to the live scheduler immediately."
+            ),
+            args_schema=UpdateCronInput,
+        )
+
+    def _create_delete_cron_tool(self) -> StructuredTool:
+        """Create the delete_cron tool."""
+
+        def delete_cron(name: str) -> str:
+            """Permanently delete a YAML cron job and remove it from the live scheduler.
+
+            Args:
+                name: Name of the cron job to delete.
+
+            Returns:
+                Confirmation message or error string.
+            """
+            if not self._cron_exists(name):
+                return (
+                    f"[Error: Cron job '{name}' not found. "
+                    f"Use list_crons to see available jobs.]"
+                )
+
+            # Remove from live scheduler first (before file is gone)
+            self._remove_from_scheduler(name)
+
+            # Remove YAML file
+            try:
+                self._cron_file_path(name).unlink()
+            except OSError as e:
+                return f"[Error: Failed to delete cron file: {e}]"
+
+            logger.info(f"Deleted cron job '{name}'")
+            return f"Deleted cron job '{name}'. The file config/crons/{name}.yaml has been removed."
+
+        return StructuredTool.from_function(
+            func=delete_cron,
+            name="delete_cron",
+            description=(
+                "Permanently delete a persistent cron job. "
+                "Removes the YAML file from config/crons/ and unregisters the job "
+                "from the live scheduler. This action cannot be undone."
+            ),
+            args_schema=DeleteCronInput,
+        )

--- a/openpaw/core/config/models.py
+++ b/openpaw/core/config/models.py
@@ -182,6 +182,10 @@ class CronBuiltinConfig(BuiltinItemConfig):
     )
 
 
+class CronManagerBuiltinConfig(BuiltinItemConfig):
+    """Configuration for the persistent cron management builtin."""
+
+
 class SendFileBuiltinConfig(BuiltinItemConfig):
     """Configuration for the send_file tool."""
 
@@ -291,6 +295,7 @@ class BuiltinsConfig(BaseModel):
     elevenlabs: BuiltinItemConfig = Field(default_factory=BuiltinItemConfig)
     shell: BuiltinItemConfig = Field(default_factory=BuiltinItemConfig)
     cron: CronBuiltinConfig = Field(default_factory=CronBuiltinConfig)
+    cron_manager: CronManagerBuiltinConfig = Field(default_factory=CronManagerBuiltinConfig)
     send_file: SendFileBuiltinConfig = Field(default_factory=SendFileBuiltinConfig)
     docling: DoclingBuiltinConfig = Field(default_factory=DoclingBuiltinConfig)
     browser: BrowserBuiltinConfig = Field(default_factory=BrowserBuiltinConfig)
@@ -320,6 +325,7 @@ class WorkspaceBuiltinsConfig(BaseModel):
     elevenlabs: BuiltinItemConfig | None = None
     shell: BuiltinItemConfig | None = None
     cron: CronBuiltinConfig | None = None
+    cron_manager: CronManagerBuiltinConfig | None = None
     send_file: SendFileBuiltinConfig | None = None
     docling: DoclingBuiltinConfig | None = None
     browser: BrowserBuiltinConfig | None = None

--- a/openpaw/core/workspace.py
+++ b/openpaw/core/workspace.py
@@ -39,6 +39,10 @@ if TYPE_CHECKING:
     from openpaw.core.config import WorkspaceConfig
     from openpaw.core.config.models import CronDefinition
 
+# Import SkillInfo at runtime (not TYPE_CHECKING) — it's a pure dataclass with
+# no framework dependencies, so it's safe to import in core/.
+from openpaw.model.skill import SkillInfo
+
 logger = logging.getLogger(__name__)
 
 
@@ -56,6 +60,7 @@ class AgentWorkspace:
     tools_path: Path
     config: "WorkspaceConfig | None" = None
     crons: "list[CronDefinition]" = field(default_factory=list)
+    skills: list[SkillInfo] = field(default_factory=list)
 
     def reload_files(self) -> None:
         """Re-read workspace markdown files from disk.
@@ -120,6 +125,11 @@ class AgentWorkspace:
         if framework_context:
             sections.append(f"<framework>\n{framework_context}\n</framework>")
 
+        # Skills — injected before workspace context so agents know what's available
+        if self.skills:
+            skills_section = self._build_skills_section()
+            sections.append(f"<skills>\n{skills_section}\n</skills>")
+
         # Workspace context — tells the agent its workspace name and top-level contents
         workspace_context = self._build_workspace_context()
         sections.append(f"<workspace_context>\n{workspace_context}\n</workspace_context>")
@@ -157,6 +167,30 @@ class AgentWorkspace:
                     lines.append(f"  {name}")
         except OSError:
             lines.append("  (unable to list contents)")
+
+        return "\n".join(lines)
+
+    def _build_skills_section(self) -> str:
+        """Build the skills section of the system prompt.
+
+        Formats each skill's name, description, and full content into a
+        structured block. Skills without descriptions omit the description line.
+
+        Returns:
+            Formatted skills section string, ready to wrap in ``<skills>`` tags.
+        """
+        lines = ["## Available Skills"]
+
+        for skill in self.skills:
+            lines.append("")
+            lines.append(f"### {skill.name}")
+
+            if skill.description:
+                lines.append(skill.description)
+
+            lines.append("")
+            lines.append("---")
+            lines.append(skill.content.strip())
 
         return "\n".join(lines)
 

--- a/openpaw/model/skill.py
+++ b/openpaw/model/skill.py
@@ -1,0 +1,27 @@
+"""Domain models for agent skills."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class SkillInfo:
+    """Represents a loaded skill from a workspace skills/ directory.
+
+    Skills are markdown documents that inject reusable knowledge or behavioral
+    patterns into the agent's system prompt. Each skill lives in its own
+    subdirectory under agent/skills/ and is defined by a SKILL.md file with
+    optional YAML frontmatter.
+
+    Attributes:
+        name: Skill name from frontmatter, or directory name as fallback.
+        description: Short description from frontmatter (max 1024 chars).
+            Empty string if no frontmatter is present.
+        content: Full SKILL.md body content (after frontmatter is stripped).
+        path: Absolute path to the skill's directory.
+    """
+
+    name: str
+    description: str
+    content: str
+    path: Path

--- a/openpaw/runtime/scheduling/cron.py
+++ b/openpaw/runtime/scheduling/cron.py
@@ -261,6 +261,42 @@ class CronScheduler:
             del self._jobs[name]
             logger.info(f"Removed cron job: {name}")
 
+    def reload_cron(self, cron_def: CronDefinition) -> None:
+        """Remove the old job (if present) and re-add it from the updated definition.
+
+        Used by CronManagerBuiltin to apply in-place changes to YAML cron jobs
+        without requiring a workspace restart.
+
+        If the definition has ``enabled=False``, the job is removed and not
+        re-added, effectively pausing it.
+
+        Args:
+            cron_def: Updated cron definition to register.
+        """
+        if cron_def.name in self._jobs:
+            self.remove_job(cron_def.name)
+
+        if cron_def.enabled:
+            self.add_job(cron_def)
+            logger.info(f"Reloaded cron job: {cron_def.name} ({cron_def.schedule})")
+        else:
+            logger.info(f"Cron job '{cron_def.name}' is disabled — skipped re-registration")
+
+    def remove_cron(self, name: str) -> None:
+        """Remove a YAML-defined cron job from the live scheduler.
+
+        Public wrapper around :meth:`remove_job` for use by CronManagerBuiltin.
+        Silently does nothing if the job is not currently registered (e.g., it
+        was disabled and never added to the APScheduler instance) or if the
+        scheduler has not been started yet.
+
+        Args:
+            name: The cron job name to remove.
+        """
+        if not self._scheduler or name not in self._jobs:
+            return
+        self.remove_job(name)
+
     def add_dynamic_job(self, task: DynamicCronTask) -> None:
         """Add a dynamic task to the scheduler.
 

--- a/openpaw/workspace/lifecycle.py
+++ b/openpaw/workspace/lifecycle.py
@@ -249,6 +249,8 @@ class LifecycleManager:
 
             # Connect CronTool to live scheduler for dynamic task scheduling
             self._connect_cron_tool_to_scheduler()
+            # Connect CronManager to live scheduler for persistent cron hot-reload
+            self._connect_cron_manager_to_scheduler()
 
         except ImportError as e:
             self._logger.warning(f"Cron scheduler not available: {e}")
@@ -319,6 +321,18 @@ class LifecycleManager:
                 self._logger.debug("CronTool not loaded for this workspace")
         except Exception as e:
             self._logger.warning(f"Failed to connect CronTool to scheduler: {e}")
+
+    def _connect_cron_manager_to_scheduler(self) -> None:
+        """Connect CronManagerBuiltin to the live CronScheduler for hot-reload support."""
+        try:
+            cron_manager = self._builtin_loader.get_tool_instance("cron_manager")
+            if cron_manager:
+                cron_manager.set_scheduler(self._cron_scheduler)
+                self._logger.info("Connected CronManager to live scheduler")
+            else:
+                self._logger.debug("CronManager not loaded for this workspace")
+        except Exception as e:
+            self._logger.warning(f"Failed to connect CronManager to scheduler: {e}")
 
     def get_channels(self) -> dict[str, ChannelAdapter]:
         """Get the initialized channels.

--- a/openpaw/workspace/loader.py
+++ b/openpaw/workspace/loader.py
@@ -18,6 +18,7 @@ from openpaw.core.paths import (
     USER_MD,
 )
 from openpaw.core.workspace import AgentWorkspace
+from openpaw.workspace.skill_loader import load_workspace_skills
 
 logger = logging.getLogger(__name__)
 
@@ -83,9 +84,10 @@ class WorkspaceLoader:
         skills_path = workspace_path / str(SKILLS_DIR)
         tools_path = workspace_path / str(TOOLS_DIR)
 
-        # Load optional workspace config and crons
+        # Load optional workspace config, crons, and skills
         workspace_config = self._load_workspace_config(workspace_path)
         crons = self._load_crons(workspace_path)
+        skills = load_workspace_skills(skills_path)
 
         return AgentWorkspace(
             name=workspace_name,
@@ -98,6 +100,7 @@ class WorkspaceLoader:
             tools_path=tools_path,
             config=workspace_config,
             crons=crons,
+            skills=skills,
         )
 
     def _read_file(self, path: Path) -> str:

--- a/openpaw/workspace/skill_loader.py
+++ b/openpaw/workspace/skill_loader.py
@@ -1,0 +1,147 @@
+"""Skill loader for workspace-defined agent skills."""
+
+import logging
+from pathlib import Path
+
+import yaml
+
+from openpaw.model.skill import SkillInfo
+
+logger = logging.getLogger(__name__)
+
+_FRONTMATTER_DELIMITER = "---"
+_MAX_DESCRIPTION_LENGTH = 1024
+_SKILL_FILENAME = "SKILL.md"
+
+
+def load_workspace_skills(skills_path: Path) -> list[SkillInfo]:
+    """Load all skills from a workspace's agent/skills/ directory.
+
+    Scans for SKILL.md files in immediate subdirectories of skills_path.
+    Each subdirectory represents one skill. Directories prefixed with ``_``
+    are skipped (private/disabled convention).
+
+    SKILL.md files may contain an optional YAML frontmatter block delimited
+    by ``---`` lines at the start of the file. Recognized frontmatter keys:
+
+    - ``name``: Skill display name (falls back to directory name)
+    - ``description``: Short description (truncated to 1024 chars)
+
+    Any content after the frontmatter block (or the full file if no
+    frontmatter is present) becomes the skill's ``content``.
+
+    Args:
+        skills_path: Absolute path to the workspace's agent/skills/ directory.
+
+    Returns:
+        List of SkillInfo instances, sorted by directory name.
+        Returns an empty list if the directory doesn't exist or is empty.
+    """
+    if not skills_path.exists():
+        logger.debug(f"Skills directory does not exist: {skills_path}")
+        return []
+
+    if not skills_path.is_dir():
+        logger.warning(f"Skills path is not a directory: {skills_path}")
+        return []
+
+    skills: list[SkillInfo] = []
+
+    for skill_dir in sorted(skills_path.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+
+        # Skip private/disabled skill directories
+        if skill_dir.name.startswith("_"):
+            continue
+
+        skill_file = skill_dir / _SKILL_FILENAME
+        if not skill_file.exists():
+            logger.debug(f"No {_SKILL_FILENAME} in skill directory: {skill_dir.name}")
+            continue
+
+        try:
+            skill = _load_skill(skill_dir, skill_file)
+            skills.append(skill)
+        except Exception as e:
+            logger.error(f"Failed to load skill from {skill_dir.name}: {e}")
+            continue
+
+    if skills:
+        skill_names = [s.name for s in skills]
+        logger.info(f"Loaded {len(skills)} skills: {skill_names}")
+
+    return skills
+
+
+def _load_skill(skill_dir: Path, skill_file: Path) -> SkillInfo:
+    """Parse a SKILL.md file and return a SkillInfo instance.
+
+    Args:
+        skill_dir: Path to the skill's directory (used for name fallback).
+        skill_file: Path to the SKILL.md file.
+
+    Returns:
+        Populated SkillInfo instance.
+    """
+    raw = skill_file.read_text(encoding="utf-8")
+    frontmatter, content = _parse_frontmatter(raw)
+
+    name = str(frontmatter.get("name") or skill_dir.name)
+    raw_description = str(frontmatter.get("description") or "")
+    description = raw_description[:_MAX_DESCRIPTION_LENGTH]
+
+    return SkillInfo(
+        name=name,
+        description=description,
+        content=content,
+        path=skill_dir,
+    )
+
+
+def _parse_frontmatter(text: str) -> tuple[dict, str]:
+    """Extract YAML frontmatter and body content from a markdown string.
+
+    Frontmatter is an optional YAML block at the very start of the file,
+    enclosed between two ``---`` delimiter lines::
+
+        ---
+        name: my-skill
+        description: Does something useful
+        ---
+
+        # Skill Content
+
+    Args:
+        text: Full file content to parse.
+
+    Returns:
+        A two-tuple of (frontmatter_dict, body_content). If no valid
+        frontmatter block is present, returns ({}, original_text).
+    """
+    lines = text.split("\n")
+
+    # Frontmatter must start on the very first line
+    if not lines or lines[0].strip() != _FRONTMATTER_DELIMITER:
+        return {}, text
+
+    # Find the closing delimiter
+    try:
+        closing_index = next(
+            i for i, line in enumerate(lines[1:], start=1)
+            if line.strip() == _FRONTMATTER_DELIMITER
+        )
+    except StopIteration:
+        # Opening delimiter found but no closing delimiter — treat as plain content
+        return {}, text
+
+    frontmatter_block = "\n".join(lines[1:closing_index])
+    body = "\n".join(lines[closing_index + 1:]).lstrip("\n")
+
+    try:
+        parsed = yaml.safe_load(frontmatter_block) or {}
+    except yaml.YAMLError as e:
+        logger.warning(f"Failed to parse frontmatter YAML: {e}")
+        parsed = {}
+
+    return parsed, body

--- a/tests/test_cron_manager.py
+++ b/tests/test_cron_manager.py
@@ -1,0 +1,651 @@
+"""Tests for CronManagerBuiltin and CronScheduler hot-reload methods."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, Mock
+
+import pytest
+import yaml
+
+from openpaw.builtins.tools.cron_manager import CronManagerBuiltin
+from openpaw.core.config.models import CronDefinition, CronOutputConfig
+from openpaw.runtime.scheduling.cron import CronScheduler
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workspace_path(tmp_path: Path) -> Path:
+    """Return a temporary workspace root with config/crons/ pre-created."""
+    crons_dir = tmp_path / "config" / "crons"
+    crons_dir.mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.fixture
+def crons_dir(workspace_path: Path) -> Path:
+    """Return the config/crons directory within the temporary workspace."""
+    return workspace_path / "config" / "crons"
+
+
+@pytest.fixture
+def builtin(crons_dir: Path) -> CronManagerBuiltin:
+    """Return a CronManagerBuiltin pointed at the temp crons directory."""
+    config = {
+        "crons_dir": str(crons_dir),
+        "default_channel": "telegram",
+        "default_target_id": 123456789,
+        "timezone": "UTC",
+    }
+    return CronManagerBuiltin(config=config)
+
+
+def _get_tool(builtin: CronManagerBuiltin, name: str):
+    """Extract a named StructuredTool from a CronManagerBuiltin."""
+    tools = {t.name: t for t in builtin.get_langchain_tool()}
+    return tools[name]
+
+
+# ---------------------------------------------------------------------------
+# CronManagerBuiltin — create_cron
+# ---------------------------------------------------------------------------
+
+
+class TestCreateCron:
+    """Tests for the create_cron tool."""
+
+    def test_create_valid_cron_writes_yaml_file(
+        self, builtin: CronManagerBuiltin, crons_dir: Path
+    ) -> None:
+        """A valid create request should write a correctly structured YAML file."""
+        tool = _get_tool(builtin, "create_cron")
+        result = tool.invoke(
+            {
+                "name": "morning-check",
+                "schedule": "0 9 * * *",
+                "prompt": "Check the morning status.",
+            }
+        )
+
+        assert "Created cron job 'morning-check'" in result
+        assert "0 9 * * *" in result
+
+        cron_file = crons_dir / "morning-check.yaml"
+        assert cron_file.exists(), "YAML file should be written to disk"
+
+        with cron_file.open() as f:
+            data = yaml.safe_load(f)
+
+        assert data["name"] == "morning-check"
+        assert data["schedule"] == "0 9 * * *"
+        assert data["prompt"] == "Check the morning status."
+        assert data["enabled"] is True
+        assert data["output"]["channel"] == "telegram"
+        assert data["output"]["target_id"] == 123456789
+        assert data["output"]["delivery"] == "channel"
+
+    def test_create_cron_with_all_fields(
+        self, builtin: CronManagerBuiltin, crons_dir: Path
+    ) -> None:
+        """All optional fields are written correctly when provided."""
+        tool = _get_tool(builtin, "create_cron")
+        tool.invoke(
+            {
+                "name": "daily-summary-1",
+                "schedule": "0 18 * * *",
+                "prompt": "Generate end-of-day summary.",
+                "enabled": False,
+                "delivery": "agent",
+            }
+        )
+
+        with (crons_dir / "daily-summary-1.yaml").open() as f:
+            data = yaml.safe_load(f)
+
+        assert data["enabled"] is False
+        assert data["output"]["delivery"] == "agent"
+
+    def test_create_cron_invalid_schedule_returns_error(
+        self, builtin: CronManagerBuiltin, crons_dir: Path
+    ) -> None:
+        """An unparseable cron expression should return an error, not write a file."""
+        tool = _get_tool(builtin, "create_cron")
+        result = tool.invoke(
+            {
+                "name": "bad-schedule",
+                "schedule": "not-a-cron",
+                "prompt": "This should fail.",
+            }
+        )
+
+        assert "[Error:" in result
+        assert not (crons_dir / "bad-schedule.yaml").exists()
+
+    def test_create_cron_invalid_name_path_separator_returns_error(
+        self, builtin: CronManagerBuiltin, crons_dir: Path
+    ) -> None:
+        """Names containing path separators should be rejected."""
+        tool = _get_tool(builtin, "create_cron")
+        result = tool.invoke(
+            {
+                "name": "my/cron",
+                "schedule": "0 9 * * *",
+                "prompt": "Path traversal attempt.",
+            }
+        )
+
+        assert "[Error:" in result
+        assert not any(crons_dir.iterdir())
+
+    def test_create_cron_uppercase_name_is_normalized_to_lowercase(
+        self, builtin: CronManagerBuiltin, crons_dir: Path
+    ) -> None:
+        """Uppercase input is lowercased before validation, so 'Morning' becomes 'morning'."""
+        tool = _get_tool(builtin, "create_cron")
+        result = tool.invoke(
+            {
+                "name": "Morning",
+                "schedule": "0 9 * * *",
+                "prompt": "Uppercase name is normalized.",
+            }
+        )
+
+        # The name is lowercased by create_cron before validation — succeeds as 'morning'
+        assert "Created cron job 'morning'" in result
+        assert (crons_dir / "morning.yaml").exists()
+
+    def test_create_cron_invalid_name_special_chars_returns_error(
+        self, builtin: CronManagerBuiltin, crons_dir: Path
+    ) -> None:
+        """Names with special characters like dots should be rejected."""
+        tool = _get_tool(builtin, "create_cron")
+        result = tool.invoke(
+            {
+                "name": "my..cron",
+                "schedule": "0 9 * * *",
+                "prompt": "Dots in name.",
+            }
+        )
+
+        assert "[Error:" in result
+
+    def test_create_cron_duplicate_name_returns_error(
+        self, builtin: CronManagerBuiltin, crons_dir: Path
+    ) -> None:
+        """Creating a cron with the same name as an existing file should return an error."""
+        tool = _get_tool(builtin, "create_cron")
+        tool.invoke(
+            {
+                "name": "duplicate-job",
+                "schedule": "0 9 * * *",
+                "prompt": "First creation.",
+            }
+        )
+
+        result = tool.invoke(
+            {
+                "name": "duplicate-job",
+                "schedule": "*/15 * * * *",
+                "prompt": "Second creation should fail.",
+            }
+        )
+
+        assert "[Error:" in result
+        assert "already exists" in result
+
+        # Original file should be unchanged
+        with (crons_dir / "duplicate-job.yaml").open() as f:
+            data = yaml.safe_load(f)
+        assert data["prompt"] == "First creation."
+
+    def test_create_disabled_cron_does_not_call_scheduler(
+        self, builtin: CronManagerBuiltin
+    ) -> None:
+        """A disabled cron should write the file but not trigger hot-reload."""
+        mock_scheduler = Mock()
+        builtin.set_scheduler(mock_scheduler)
+
+        tool = _get_tool(builtin, "create_cron")
+        tool.invoke(
+            {
+                "name": "inactive-job",
+                "schedule": "0 9 * * *",
+                "prompt": "Disabled from the start.",
+                "enabled": False,
+            }
+        )
+
+        mock_scheduler.reload_cron.assert_not_called()
+
+    def test_create_enabled_cron_triggers_hot_reload(
+        self, builtin: CronManagerBuiltin, workspace_path: Path
+    ) -> None:
+        """An enabled cron should trigger hot-reload on the live scheduler."""
+        mock_scheduler = Mock()
+        builtin.set_scheduler(mock_scheduler)
+
+        tool = _get_tool(builtin, "create_cron")
+        tool.invoke(
+            {
+                "name": "active-job",
+                "schedule": "0 9 * * *",
+                "prompt": "Active from creation.",
+                "enabled": True,
+            }
+        )
+
+        mock_scheduler.reload_cron.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# CronManagerBuiltin — list_crons
+# ---------------------------------------------------------------------------
+
+
+class TestListCrons:
+    """Tests for the list_crons tool."""
+
+    def test_list_crons_with_existing_jobs(
+        self, builtin: CronManagerBuiltin, crons_dir: Path
+    ) -> None:
+        """list_crons should return formatted output for each defined job."""
+        # Write two cron files directly
+        for name, schedule in [("job-alpha", "0 8 * * *"), ("job-beta", "*/30 * * * *")]:
+            data = {
+                "name": name,
+                "schedule": schedule,
+                "enabled": True,
+                "prompt": f"Prompt for {name}.",
+                "output": {"channel": "telegram", "target_id": 123456789, "delivery": "channel"},
+            }
+            with (crons_dir / f"{name}.yaml").open("w") as f:
+                yaml.safe_dump(data, f)
+
+        tool = _get_tool(builtin, "list_crons")
+        result = tool.invoke({})
+
+        assert "job-alpha" in result
+        assert "job-beta" in result
+        assert "0 8 * * *" in result
+        assert "*/30 * * * *" in result
+
+    def test_list_crons_empty_returns_no_jobs_message(
+        self, builtin: CronManagerBuiltin
+    ) -> None:
+        """list_crons should inform the user when no jobs are defined."""
+        tool = _get_tool(builtin, "list_crons")
+        result = tool.invoke({})
+
+        assert "No cron jobs" in result
+
+    def test_list_crons_shows_disabled_status(
+        self, builtin: CronManagerBuiltin, crons_dir: Path
+    ) -> None:
+        """list_crons should show the disabled status for inactive jobs."""
+        data = {
+            "name": "paused-job",
+            "schedule": "0 12 * * *",
+            "enabled": False,
+            "prompt": "Paused.",
+            "output": {"channel": "telegram", "target_id": 123456789, "delivery": "channel"},
+        }
+        with (crons_dir / "paused-job.yaml").open("w") as f:
+            yaml.safe_dump(data, f)
+
+        tool = _get_tool(builtin, "list_crons")
+        result = tool.invoke({})
+
+        assert "disabled" in result
+
+    def test_list_crons_truncates_long_prompt(
+        self, builtin: CronManagerBuiltin, crons_dir: Path
+    ) -> None:
+        """Prompts longer than 60 characters should be truncated in the listing."""
+        long_prompt = "A" * 80
+        data = {
+            "name": "verbose-job",
+            "schedule": "0 9 * * *",
+            "enabled": True,
+            "prompt": long_prompt,
+            "output": {"channel": "telegram", "target_id": 123456789, "delivery": "channel"},
+        }
+        with (crons_dir / "verbose-job.yaml").open("w") as f:
+            yaml.safe_dump(data, f)
+
+        tool = _get_tool(builtin, "list_crons")
+        result = tool.invoke({})
+
+        assert "..." in result
+        # Full 80-char prompt should not appear verbatim
+        assert long_prompt not in result
+
+
+# ---------------------------------------------------------------------------
+# CronManagerBuiltin — update_cron
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateCron:
+    """Tests for the update_cron tool."""
+
+    def _write_cron(self, crons_dir: Path, name: str = "existing-job") -> None:
+        """Helper to write a baseline cron YAML file."""
+        data = {
+            "name": name,
+            "schedule": "0 9 * * *",
+            "enabled": True,
+            "prompt": "Original prompt.",
+            "output": {"channel": "telegram", "target_id": 123456789, "delivery": "channel"},
+        }
+        with (crons_dir / f"{name}.yaml").open("w") as f:
+            yaml.safe_dump(data, f)
+
+    def test_update_schedule_field_only(
+        self, builtin: CronManagerBuiltin, crons_dir: Path
+    ) -> None:
+        """Updating schedule should change only that field, leaving others intact."""
+        self._write_cron(crons_dir)
+        tool = _get_tool(builtin, "update_cron")
+        result = tool.invoke({"name": "existing-job", "schedule": "*/15 * * * *"})
+
+        assert "Updated cron job 'existing-job'" in result
+        assert "schedule" in result
+
+        with (crons_dir / "existing-job.yaml").open() as f:
+            data = yaml.safe_load(f)
+
+        assert data["schedule"] == "*/15 * * * *"
+        assert data["prompt"] == "Original prompt."
+        assert data["enabled"] is True
+
+    def test_update_prompt_field_only(
+        self, builtin: CronManagerBuiltin, crons_dir: Path
+    ) -> None:
+        """Updating prompt should change only that field."""
+        self._write_cron(crons_dir)
+        tool = _get_tool(builtin, "update_cron")
+        tool.invoke({"name": "existing-job", "prompt": "Updated prompt."})
+
+        with (crons_dir / "existing-job.yaml").open() as f:
+            data = yaml.safe_load(f)
+
+        assert data["prompt"] == "Updated prompt."
+        assert data["schedule"] == "0 9 * * *"
+
+    def test_update_enabled_field_to_false(
+        self, builtin: CronManagerBuiltin, crons_dir: Path
+    ) -> None:
+        """Disabling a cron should persist the change to disk."""
+        self._write_cron(crons_dir)
+        tool = _get_tool(builtin, "update_cron")
+        tool.invoke({"name": "existing-job", "enabled": False})
+
+        with (crons_dir / "existing-job.yaml").open() as f:
+            data = yaml.safe_load(f)
+
+        assert data["enabled"] is False
+
+    def test_update_delivery_field(
+        self, builtin: CronManagerBuiltin, crons_dir: Path
+    ) -> None:
+        """Updating delivery mode should be persisted to the output section."""
+        self._write_cron(crons_dir)
+        tool = _get_tool(builtin, "update_cron")
+        tool.invoke({"name": "existing-job", "delivery": "both"})
+
+        with (crons_dir / "existing-job.yaml").open() as f:
+            data = yaml.safe_load(f)
+
+        assert data["output"]["delivery"] == "both"
+
+    def test_update_nonexistent_cron_returns_error(
+        self, builtin: CronManagerBuiltin
+    ) -> None:
+        """Updating a cron that does not exist should return an error."""
+        tool = _get_tool(builtin, "update_cron")
+        result = tool.invoke({"name": "ghost-job", "prompt": "New prompt."})
+
+        assert "[Error:" in result
+        assert "not found" in result
+
+    def test_update_invalid_schedule_returns_error_and_leaves_file_unchanged(
+        self, builtin: CronManagerBuiltin, crons_dir: Path
+    ) -> None:
+        """An invalid schedule on update should not modify the file on disk."""
+        self._write_cron(crons_dir)
+        tool = _get_tool(builtin, "update_cron")
+        result = tool.invoke({"name": "existing-job", "schedule": "bad-expression"})
+
+        assert "[Error:" in result
+
+        with (crons_dir / "existing-job.yaml").open() as f:
+            data = yaml.safe_load(f)
+
+        assert data["schedule"] == "0 9 * * *"
+
+    def test_update_triggers_scheduler_hot_reload(
+        self, builtin: CronManagerBuiltin, crons_dir: Path
+    ) -> None:
+        """update_cron should always trigger hot-reload on the live scheduler."""
+        self._write_cron(crons_dir)
+        mock_scheduler = Mock()
+        builtin.set_scheduler(mock_scheduler)
+
+        tool = _get_tool(builtin, "update_cron")
+        tool.invoke({"name": "existing-job", "prompt": "Refreshed."})
+
+        mock_scheduler.reload_cron.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# CronManagerBuiltin — delete_cron
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteCron:
+    """Tests for the delete_cron tool."""
+
+    def _write_cron(self, crons_dir: Path, name: str = "target-job") -> Path:
+        """Helper to write a cron YAML file and return its path."""
+        data = {
+            "name": name,
+            "schedule": "0 9 * * *",
+            "enabled": True,
+            "prompt": "To be deleted.",
+            "output": {"channel": "telegram", "target_id": 123456789, "delivery": "channel"},
+        }
+        path = crons_dir / f"{name}.yaml"
+        with path.open("w") as f:
+            yaml.safe_dump(data, f)
+        return path
+
+    def test_delete_cron_removes_yaml_file(
+        self, builtin: CronManagerBuiltin, crons_dir: Path
+    ) -> None:
+        """Deleting a cron should remove the YAML file from disk."""
+        path = self._write_cron(crons_dir)
+        assert path.exists()
+
+        tool = _get_tool(builtin, "delete_cron")
+        result = tool.invoke({"name": "target-job"})
+
+        assert "Deleted cron job 'target-job'" in result
+        assert not path.exists()
+
+    def test_delete_cron_nonexistent_returns_error(
+        self, builtin: CronManagerBuiltin
+    ) -> None:
+        """Deleting a cron that does not exist should return an error."""
+        tool = _get_tool(builtin, "delete_cron")
+        result = tool.invoke({"name": "phantom-job"})
+
+        assert "[Error:" in result
+        assert "not found" in result
+
+    def test_delete_cron_calls_remove_from_scheduler(
+        self, builtin: CronManagerBuiltin, crons_dir: Path
+    ) -> None:
+        """delete_cron should remove the job from the live scheduler."""
+        self._write_cron(crons_dir)
+        mock_scheduler = Mock()
+        builtin.set_scheduler(mock_scheduler)
+
+        tool = _get_tool(builtin, "delete_cron")
+        tool.invoke({"name": "target-job"})
+
+        mock_scheduler.remove_cron.assert_called_once_with("target-job")
+
+
+# ---------------------------------------------------------------------------
+# CronManagerBuiltin — name validation
+# ---------------------------------------------------------------------------
+
+
+class TestNameValidation:
+    """Tests for the internal _validate_name() regex."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "morning-check",
+            "daily-summary-1",
+            "healthcheck",
+            "a",
+            "abc123",
+            "job-0",
+        ],
+    )
+    def test_valid_names_return_no_error(
+        self, builtin: CronManagerBuiltin, name: str
+    ) -> None:
+        """Valid names conforming to the regex should return None."""
+        assert builtin._validate_name(name) is None
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Morning",          # uppercase
+            "my/cron",          # forward slash
+            "my\\cron",         # backslash
+            "my..cron",         # double dot
+            "-starts-with-dash",# leading hyphen
+            "",                 # empty string
+            "has space",        # space
+            "ALLCAPS",          # all uppercase
+            "under_score",      # underscore (not allowed by regex)
+        ],
+    )
+    def test_invalid_names_return_error_message(
+        self, builtin: CronManagerBuiltin, name: str
+    ) -> None:
+        """Invalid names should return a non-None error message."""
+        assert builtin._validate_name(name) is not None
+
+
+# ---------------------------------------------------------------------------
+# CronScheduler — reload_cron
+# ---------------------------------------------------------------------------
+
+
+class TestCronSchedulerReloadCron:
+    """Tests for CronScheduler.reload_cron()."""
+
+    @pytest.fixture
+    def scheduler(self, tmp_path: Path) -> CronScheduler:
+        """Return a CronScheduler with a mocked APScheduler instance."""
+        sched = CronScheduler(
+            workspace_path=tmp_path,
+            agent_factory=Mock(),
+            channels={"telegram": Mock()},
+        )
+        # Inject a mock APScheduler so we do not need to call async start()
+        mock_apscheduler = MagicMock()
+        sched._scheduler = mock_apscheduler
+        return sched
+
+    def _make_cron_def(self, name: str, enabled: bool) -> CronDefinition:
+        return CronDefinition(
+            name=name,
+            schedule="0 9 * * *",
+            enabled=enabled,
+            prompt="Test prompt.",
+            output=CronOutputConfig(channel="telegram", target_id=123456789),
+        )
+
+    def test_reload_enabled_cron_removes_then_adds(self, scheduler: CronScheduler) -> None:
+        """reload_cron on an enabled job should remove the old entry and add a new one."""
+        cron_def = self._make_cron_def("my-job", enabled=True)
+        # Pre-populate _jobs so remove_job sees it
+        scheduler._jobs["my-job"] = Mock()
+
+        scheduler.reload_cron(cron_def)
+
+        # remove_job should have been called
+        scheduler._scheduler.remove_job.assert_called_once_with("my-job")
+        # add_job should have been called to re-register
+        scheduler._scheduler.add_job.assert_called_once()
+        assert "my-job" in scheduler._jobs
+
+    def test_reload_disabled_cron_removes_but_does_not_add(
+        self, scheduler: CronScheduler
+    ) -> None:
+        """reload_cron on a disabled job should remove the job but not re-add it."""
+        cron_def = self._make_cron_def("disabled-job", enabled=False)
+        scheduler._jobs["disabled-job"] = Mock()
+
+        scheduler.reload_cron(cron_def)
+
+        scheduler._scheduler.remove_job.assert_called_once_with("disabled-job")
+        scheduler._scheduler.add_job.assert_not_called()
+        assert "disabled-job" not in scheduler._jobs
+
+    def test_reload_cron_not_previously_registered(self, scheduler: CronScheduler) -> None:
+        """reload_cron for a job that was never registered should still add it when enabled."""
+        cron_def = self._make_cron_def("brand-new-job", enabled=True)
+        # _jobs is empty — no pre-existing entry
+
+        scheduler.reload_cron(cron_def)
+
+        # remove_job should NOT be called (job was not in _jobs)
+        scheduler._scheduler.remove_job.assert_not_called()
+        scheduler._scheduler.add_job.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# CronScheduler — remove_cron
+# ---------------------------------------------------------------------------
+
+
+class TestCronSchedulerRemoveCron:
+    """Tests for CronScheduler.remove_cron()."""
+
+    @pytest.fixture
+    def scheduler(self, tmp_path: Path) -> CronScheduler:
+        """Return a CronScheduler with a mocked APScheduler instance."""
+        sched = CronScheduler(
+            workspace_path=tmp_path,
+            agent_factory=Mock(),
+            channels={"telegram": Mock()},
+        )
+        mock_apscheduler = MagicMock()
+        sched._scheduler = mock_apscheduler
+        return sched
+
+    def test_remove_cron_delegates_to_remove_job(self, scheduler: CronScheduler) -> None:
+        """remove_cron should call remove_job with the supplied name."""
+        scheduler._jobs["some-job"] = Mock()
+
+        scheduler.remove_cron("some-job")
+
+        scheduler._scheduler.remove_job.assert_called_once_with("some-job")
+        assert "some-job" not in scheduler._jobs
+
+    def test_remove_cron_silently_ignores_missing_job(
+        self, scheduler: CronScheduler
+    ) -> None:
+        """remove_cron on a job that was never added should not raise."""
+        # No jobs pre-registered — should return silently
+        scheduler.remove_cron("nonexistent-job")
+
+        scheduler._scheduler.remove_job.assert_not_called()

--- a/tests/test_skill_loader.py
+++ b/tests/test_skill_loader.py
@@ -1,0 +1,495 @@
+"""Tests for workspace skill loading and system prompt integration."""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from openpaw.core.workspace import AgentWorkspace
+from openpaw.model.skill import SkillInfo
+from openpaw.workspace.skill_loader import load_workspace_skills
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_skills_dir(base: Path) -> Path:
+    """Create and return a skills directory under base."""
+    skills_dir = base / "skills"
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    return skills_dir
+
+
+def _make_skill(skills_dir: Path, name: str, content: str) -> Path:
+    """Create a skill subdirectory with a SKILL.md file and return the directory."""
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+    return skill_dir
+
+
+def _make_workspace(tmp_path: Path, skills: list[SkillInfo] | None = None) -> AgentWorkspace:
+    """Build a minimal AgentWorkspace suitable for system-prompt tests."""
+    workspace_path = tmp_path / "ws"
+    workspace_path.mkdir(parents=True, exist_ok=True)
+
+    return AgentWorkspace(
+        name="test-workspace",
+        path=workspace_path,
+        agent_md="# Agent",
+        user_md="# User",
+        soul_md="# Soul",
+        heartbeat_md="",
+        skills_path=workspace_path / "agent" / "skills",
+        tools_path=workspace_path / "agent" / "tools",
+        skills=skills or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestLoadValidSkill
+# ---------------------------------------------------------------------------
+
+class TestLoadValidSkill:
+    """SKILL.md with frontmatter produces correct SkillInfo fields."""
+
+    def test_name_from_frontmatter(self, tmp_path: Path) -> None:
+        skills_dir = _make_skills_dir(tmp_path)
+        _make_skill(
+            skills_dir,
+            "my-skill",
+            "---\nname: My Custom Skill\ndescription: Does useful things\n---\n\n# Body content\n",
+        )
+
+        skills = load_workspace_skills(skills_dir)
+
+        assert len(skills) == 1
+        assert skills[0].name == "My Custom Skill"
+
+    def test_description_from_frontmatter(self, tmp_path: Path) -> None:
+        skills_dir = _make_skills_dir(tmp_path)
+        _make_skill(
+            skills_dir,
+            "my-skill",
+            "---\nname: My Skill\ndescription: Does useful things\n---\n\n# Body\n",
+        )
+
+        skills = load_workspace_skills(skills_dir)
+
+        assert skills[0].description == "Does useful things"
+
+    def test_content_excludes_frontmatter(self, tmp_path: Path) -> None:
+        skills_dir = _make_skills_dir(tmp_path)
+        _make_skill(
+            skills_dir,
+            "my-skill",
+            "---\nname: My Skill\ndescription: Short desc\n---\n\n# Skill Body\n\nSome details.\n",
+        )
+
+        skills = load_workspace_skills(skills_dir)
+
+        assert "# Skill Body" in skills[0].content
+        assert "Some details." in skills[0].content
+        # Frontmatter keys must not appear in body
+        assert "name: My Skill" not in skills[0].content
+        assert "description:" not in skills[0].content
+
+    def test_path_points_to_skill_directory(self, tmp_path: Path) -> None:
+        skills_dir = _make_skills_dir(tmp_path)
+        skill_dir = _make_skill(
+            skills_dir,
+            "my-skill",
+            "---\nname: My Skill\ndescription: Desc\n---\n\nBody.\n",
+        )
+
+        skills = load_workspace_skills(skills_dir)
+
+        assert skills[0].path == skill_dir
+
+
+# ---------------------------------------------------------------------------
+# TestLoadSkillWithoutFrontmatter
+# ---------------------------------------------------------------------------
+
+class TestLoadSkillWithoutFrontmatter:
+    """SKILL.md without frontmatter falls back to directory name and empty description."""
+
+    def test_name_falls_back_to_directory_name(self, tmp_path: Path) -> None:
+        skills_dir = _make_skills_dir(tmp_path)
+        _make_skill(skills_dir, "plain-skill", "# Just markdown content\n\nNo frontmatter here.\n")
+
+        skills = load_workspace_skills(skills_dir)
+
+        assert skills[0].name == "plain-skill"
+
+    def test_description_is_empty_string(self, tmp_path: Path) -> None:
+        skills_dir = _make_skills_dir(tmp_path)
+        _make_skill(skills_dir, "plain-skill", "# Just markdown content\n")
+
+        skills = load_workspace_skills(skills_dir)
+
+        assert skills[0].description == ""
+
+    def test_full_file_content_is_body(self, tmp_path: Path) -> None:
+        skills_dir = _make_skills_dir(tmp_path)
+        body = "# Just markdown content\n\nSome text here.\n"
+        _make_skill(skills_dir, "plain-skill", body)
+
+        skills = load_workspace_skills(skills_dir)
+
+        assert skills[0].content == body
+
+
+# ---------------------------------------------------------------------------
+# TestSkipUnderscoreDirectories
+# ---------------------------------------------------------------------------
+
+class TestSkipUnderscoreDirectories:
+    """Directories prefixed with `_` are ignored."""
+
+    def test_underscore_directory_is_skipped(self, tmp_path: Path) -> None:
+        skills_dir = _make_skills_dir(tmp_path)
+        _make_skill(skills_dir, "_disabled", "---\nname: Hidden\n---\n\nContent.\n")
+
+        skills = load_workspace_skills(skills_dir)
+
+        assert skills == []
+
+    def test_underscore_directory_skipped_alongside_valid_skill(self, tmp_path: Path) -> None:
+        skills_dir = _make_skills_dir(tmp_path)
+        _make_skill(skills_dir, "_draft", "---\nname: Draft\n---\n\nDraft content.\n")
+        _make_skill(skills_dir, "active-skill", "---\nname: Active\n---\n\nActive content.\n")
+
+        skills = load_workspace_skills(skills_dir)
+
+        assert len(skills) == 1
+        assert skills[0].name == "Active"
+
+
+# ---------------------------------------------------------------------------
+# TestEmptySkillsDirectory
+# ---------------------------------------------------------------------------
+
+class TestEmptySkillsDirectory:
+    """An empty skills directory returns an empty list."""
+
+    def test_empty_directory_returns_empty_list(self, tmp_path: Path) -> None:
+        skills_dir = _make_skills_dir(tmp_path)
+
+        skills = load_workspace_skills(skills_dir)
+
+        assert skills == []
+
+    def test_directory_with_no_skill_md_files_returns_empty_list(self, tmp_path: Path) -> None:
+        skills_dir = _make_skills_dir(tmp_path)
+        # Subdirectory exists but has no SKILL.md
+        (skills_dir / "incomplete-skill").mkdir()
+
+        skills = load_workspace_skills(skills_dir)
+
+        assert skills == []
+
+
+# ---------------------------------------------------------------------------
+# TestMissingSkillsDirectory
+# ---------------------------------------------------------------------------
+
+class TestMissingSkillsDirectory:
+    """A non-existent skills path returns an empty list without raising."""
+
+    def test_nonexistent_path_returns_empty_list(self, tmp_path: Path) -> None:
+        missing_path = tmp_path / "does" / "not" / "exist"
+
+        skills = load_workspace_skills(missing_path)
+
+        assert skills == []
+
+    def test_nonexistent_path_does_not_raise(self, tmp_path: Path) -> None:
+        missing_path = tmp_path / "nonexistent"
+
+        # Must not raise any exception
+        result = load_workspace_skills(missing_path)
+        assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# TestFrontmatterEdgeCases
+# ---------------------------------------------------------------------------
+
+class TestFrontmatterEdgeCases:
+    """Edge cases in frontmatter parsing."""
+
+    def test_unclosed_frontmatter_treated_as_plain_content(self, tmp_path: Path) -> None:
+        """A file with an opening `---` but no closing delimiter is treated as plain content."""
+        skills_dir = _make_skills_dir(tmp_path)
+        raw = "---\nname: Broken\ndescription: No closing delimiter\n\n# Body\n"
+        _make_skill(skills_dir, "broken-skill", raw)
+
+        skills = load_workspace_skills(skills_dir)
+
+        # Falls back to directory name (no frontmatter parsed)
+        assert skills[0].name == "broken-skill"
+        assert skills[0].description == ""
+        # Entire raw file is the content
+        assert skills[0].content == raw
+
+    def test_invalid_yaml_in_frontmatter_falls_back_gracefully(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Invalid YAML inside frontmatter logs a warning and falls back to directory name."""
+        skills_dir = _make_skills_dir(tmp_path)
+        _make_skill(
+            skills_dir,
+            "bad-yaml-skill",
+            "---\nname: [unclosed bracket\n---\n\n# Real body content\n",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="openpaw.workspace.skill_loader"):
+            skills = load_workspace_skills(skills_dir)
+
+        assert len(skills) == 1
+        assert skills[0].name == "bad-yaml-skill"
+        assert skills[0].description == ""
+        # Warning should have been logged
+        assert any("frontmatter" in record.message.lower() for record in caplog.records)
+
+    def test_frontmatter_missing_name_falls_back_to_dir_name(self, tmp_path: Path) -> None:
+        """Frontmatter without a `name` key uses the directory name."""
+        skills_dir = _make_skills_dir(tmp_path)
+        _make_skill(
+            skills_dir,
+            "unnamed-skill",
+            "---\ndescription: Only a description here\n---\n\nBody content.\n",
+        )
+
+        skills = load_workspace_skills(skills_dir)
+
+        assert skills[0].name == "unnamed-skill"
+        assert skills[0].description == "Only a description here"
+
+    def test_frontmatter_missing_description_yields_empty_string(self, tmp_path: Path) -> None:
+        """Frontmatter with a name but no description yields empty description."""
+        skills_dir = _make_skills_dir(tmp_path)
+        _make_skill(
+            skills_dir,
+            "named-only",
+            "---\nname: Named Only\n---\n\nBody.\n",
+        )
+
+        skills = load_workspace_skills(skills_dir)
+
+        assert skills[0].description == ""
+
+
+# ---------------------------------------------------------------------------
+# TestDescriptionTruncation
+# ---------------------------------------------------------------------------
+
+class TestDescriptionTruncation:
+    """Descriptions exceeding 1024 characters are truncated."""
+
+    def test_long_description_is_truncated_to_1024_chars(self, tmp_path: Path) -> None:
+        long_desc = "x" * 2000
+        skills_dir = _make_skills_dir(tmp_path)
+        _make_skill(
+            skills_dir,
+            "long-desc-skill",
+            f"---\nname: Long Desc\ndescription: {long_desc}\n---\n\nBody.\n",
+        )
+
+        skills = load_workspace_skills(skills_dir)
+
+        assert len(skills[0].description) == 1024
+        assert skills[0].description == "x" * 1024
+
+    def test_short_description_is_not_truncated(self, tmp_path: Path) -> None:
+        desc = "Short and sweet"
+        skills_dir = _make_skills_dir(tmp_path)
+        _make_skill(
+            skills_dir,
+            "short-desc-skill",
+            f"---\nname: Short Desc\ndescription: {desc}\n---\n\nBody.\n",
+        )
+
+        skills = load_workspace_skills(skills_dir)
+
+        assert skills[0].description == desc
+
+
+# ---------------------------------------------------------------------------
+# TestSkillSorting
+# ---------------------------------------------------------------------------
+
+class TestSkillSorting:
+    """Skills are returned sorted alphabetically by name."""
+
+    def test_skills_sorted_by_name(self, tmp_path: Path) -> None:
+        skills_dir = _make_skills_dir(tmp_path)
+        _make_skill(skills_dir, "zebra-skill", "---\nname: Zebra\n---\n\nZ content.\n")
+        _make_skill(skills_dir, "alpha-skill", "---\nname: Alpha\n---\n\nA content.\n")
+        _make_skill(skills_dir, "mango-skill", "---\nname: Mango\n---\n\nM content.\n")
+
+        skills = load_workspace_skills(skills_dir)
+
+        # load_workspace_skills sorts by iterdir() order (alphabetical by directory name)
+        names = [s.name for s in skills]
+        assert names == ["Alpha", "Mango", "Zebra"]
+
+
+# ---------------------------------------------------------------------------
+# TestSystemPromptSkillsSection
+# ---------------------------------------------------------------------------
+
+class TestSystemPromptSkillsSection:
+    """Skills are correctly embedded in the system prompt."""
+
+    def test_skills_block_present_when_skills_loaded(self, tmp_path: Path) -> None:
+        """System prompt includes a <skills> block when skills are populated."""
+        skill = SkillInfo(
+            name="Python Patterns",
+            description="Common Python design patterns.",
+            content="## Singleton\nUse module-level singletons...",
+            path=tmp_path / "python-patterns",
+        )
+        workspace = _make_workspace(tmp_path, skills=[skill])
+
+        prompt = workspace.build_system_prompt(enabled_builtins=[])
+
+        assert "<skills>" in prompt
+        assert "</skills>" in prompt
+
+    def test_skills_block_absent_when_no_skills(self, tmp_path: Path) -> None:
+        """System prompt omits the <skills> block when no skills are loaded."""
+        workspace = _make_workspace(tmp_path, skills=[])
+
+        prompt = workspace.build_system_prompt(enabled_builtins=[])
+
+        assert "<skills>" not in prompt
+
+    def test_skill_name_in_prompt(self, tmp_path: Path) -> None:
+        """Skill name appears as a markdown heading inside <skills>."""
+        skill = SkillInfo(
+            name="Error Handling",
+            description="Best practices for error handling.",
+            content="Always catch specific exceptions...",
+            path=tmp_path / "error-handling",
+        )
+        workspace = _make_workspace(tmp_path, skills=[skill])
+
+        prompt = workspace.build_system_prompt(enabled_builtins=[])
+
+        assert "### Error Handling" in prompt
+
+    def test_skill_description_in_prompt(self, tmp_path: Path) -> None:
+        """Skill description appears in the prompt when present."""
+        skill = SkillInfo(
+            name="Logging",
+            description="Structured logging conventions.",
+            content="Use structlog for structured output...",
+            path=tmp_path / "logging",
+        )
+        workspace = _make_workspace(tmp_path, skills=[skill])
+
+        prompt = workspace.build_system_prompt(enabled_builtins=[])
+
+        assert "Structured logging conventions." in prompt
+
+    def test_skill_content_in_prompt(self, tmp_path: Path) -> None:
+        """Skill body content appears in the prompt."""
+        skill = SkillInfo(
+            name="Testing",
+            description="",
+            content="Use pytest fixtures for reusable setup.",
+            path=tmp_path / "testing",
+        )
+        workspace = _make_workspace(tmp_path, skills=[skill])
+
+        prompt = workspace.build_system_prompt(enabled_builtins=[])
+
+        assert "Use pytest fixtures for reusable setup." in prompt
+
+    def test_skill_without_description_omits_description_line(self, tmp_path: Path) -> None:
+        """Skills with an empty description do not add a blank description line."""
+        skill = SkillInfo(
+            name="No Desc",
+            description="",
+            content="Some content here.",
+            path=tmp_path / "no-desc",
+        )
+        workspace = _make_workspace(tmp_path, skills=[skill])
+        prompt = workspace.build_system_prompt(enabled_builtins=[])
+
+        # The heading and separator should be present
+        assert "### No Desc" in prompt
+        # Blank description should not produce stray empty lines between heading and separator
+        # Verify heading is directly followed by the separator (no description between them)
+        skills_block_start = prompt.index("<skills>")
+        skills_block_end = prompt.index("</skills>")
+        skills_block = prompt[skills_block_start:skills_block_end]
+        heading_pos = skills_block.index("### No Desc")
+        sep_pos = skills_block.index("---")
+        assert sep_pos > heading_pos
+
+    def test_skills_section_formatting(self, tmp_path: Path) -> None:
+        """Skills section uses `### name / description / --- / content` structure."""
+        skill = SkillInfo(
+            name="My Skill",
+            description="A helpful skill.",
+            content="Detailed instructions here.",
+            path=tmp_path / "my-skill",
+        )
+        workspace = _make_workspace(tmp_path, skills=[skill])
+
+        prompt = workspace.build_system_prompt(enabled_builtins=[])
+
+        skills_start = prompt.index("<skills>") + len("<skills>")
+        skills_end = prompt.index("</skills>")
+        skills_block = prompt[skills_start:skills_end]
+
+        heading_pos = skills_block.index("### My Skill")
+        desc_pos = skills_block.index("A helpful skill.")
+        sep_pos = skills_block.index("---")
+        content_pos = skills_block.index("Detailed instructions here.")
+
+        assert heading_pos < desc_pos < sep_pos < content_pos
+
+    def test_multiple_skills_all_present_in_prompt(self, tmp_path: Path) -> None:
+        """Multiple skills all appear in the system prompt."""
+        skills = [
+            SkillInfo(
+                name="Skill Alpha",
+                description="Alpha description.",
+                content="Alpha body.",
+                path=tmp_path / "alpha",
+            ),
+            SkillInfo(
+                name="Skill Beta",
+                description="Beta description.",
+                content="Beta body.",
+                path=tmp_path / "beta",
+            ),
+        ]
+        workspace = _make_workspace(tmp_path, skills=skills)
+
+        prompt = workspace.build_system_prompt(enabled_builtins=[])
+
+        assert "### Skill Alpha" in prompt
+        assert "### Skill Beta" in prompt
+        assert "Alpha body." in prompt
+        assert "Beta body." in prompt
+
+    def test_skills_section_appears_before_workspace_context(self, tmp_path: Path) -> None:
+        """<skills> block is positioned before <workspace_context>."""
+        skill = SkillInfo(
+            name="Positioning Test",
+            description="",
+            content="Content.",
+            path=tmp_path / "positioning",
+        )
+        workspace = _make_workspace(tmp_path, skills=[skill])
+
+        prompt = workspace.build_system_prompt(enabled_builtins=[])
+
+        skills_pos = prompt.index("<skills>")
+        context_pos = prompt.index("<workspace_context>")
+        assert skills_pos < context_pos


### PR DESCRIPTION
## Summary

- **Skills Loading**: Load `SKILL.md` files from `agent/skills/{name}/` directories and inject their content into the agent system prompt as a `<skills>` XML block. Supports YAML frontmatter for name/description metadata with graceful fallback to directory names.
- **Persistent Cron Management**: New `cron_manager` builtin with `create_cron`, `list_crons`, `update_cron`, `delete_cron` tools for managing YAML cron files in `config/crons/` with hot-reload into the live scheduler.
- **CronScheduler hot-reload**: Added `reload_cron()` and `remove_cron()` public methods for in-place cron updates without workspace restart.

### New Files
- `openpaw/model/skill.py` — `SkillInfo` pure dataclass
- `openpaw/workspace/skill_loader.py` — SKILL.md frontmatter parser and loader
- `openpaw/builtins/tools/cron_manager.py` — `CronManagerBuiltin` (4 tools)
- `tests/test_skill_loader.py` — 29 tests
- `tests/test_cron_manager.py` — 43 tests

### Modified Files
- `openpaw/core/workspace.py` — Skills field + prompt injection
- `openpaw/workspace/loader.py` — Wire skill loading
- `openpaw/runtime/scheduling/cron.py` — `reload_cron()` / `remove_cron()`
- `openpaw/builtins/registry.py` — Register cron_manager
- `openpaw/builtins/loader.py` — Config injection for cron_manager
- `openpaw/workspace/lifecycle.py` — Scheduler wiring
- `openpaw/core/config/models.py` — `CronManagerBuiltinConfig`
- `CLAUDE.md` — Documentation for both features

## Test plan
- [x] 72 new tests passing (29 skill loader + 43 cron manager)
- [x] 2050 total tests passing, 0 failures
- [x] Ruff lint clean
- [ ] Manual: create workspace with `agent/skills/test-skill/SKILL.md`, verify `<skills>` appears in system prompt
- [ ] Manual: use `create_cron` tool via agent, verify YAML file written and job fires on schedule