### PR TITLE
feat: cross-channel messaging with primary channel escalation

### DIFF
--- a/openpaw/builtins/tools/send_file.py
+++ b/openpaw/builtins/tools/send_file.py
@@ -38,6 +38,20 @@ class SendFileInput(BaseModel):
         default=None,
         description="Optional display filename (defaults to actual filename)"
     )
+    channel: str | None = Field(
+        default=None,
+        description=(
+            "Target channel name for cross-channel file sending. "
+            "Omit to send to the current channel."
+        ),
+    )
+    target_id: int | None = Field(
+        default=None,
+        description=(
+            "Target user/chat/channel ID on the target channel. "
+            "Omit to use the channel's default target."
+        ),
+    )
 
 
 class SendFileTool(BaseBuiltinTool):
@@ -74,14 +88,75 @@ class SendFileTool(BaseBuiltinTool):
             self.workspace_path = Path(self.workspace_path).resolve()
         # Extract max file size from config (defaults to 50MB)
         self.max_file_size = config.get("max_file_size", DEFAULT_MAX_FILE_SIZE) if config else DEFAULT_MAX_FILE_SIZE
+        # Registry for cross-channel file sending (channel_name -> ChannelAdapter)
+        self._channel_registry: dict[str, Any] = {}
+        # Default target IDs per channel (channel_name -> target_id)
+        self._channel_targets: dict[str, int] = {}
+
+    def set_channel_registry(
+        self,
+        channels: dict[str, Any],
+        targets: dict[str, int],
+    ) -> None:
+        """Wire in the full channel registry for cross-channel file sending.
+
+        Called by WorkspaceRunner after channels are set up. Only wired when
+        two or more channels are present.
+
+        Args:
+            channels: Mapping of channel_name -> ChannelAdapter instance.
+            targets: Mapping of channel_name -> default target_id.
+        """
+        self._channel_registry = channels
+        self._channel_targets = targets
 
     def get_langchain_tool(self) -> Any:
         """Return the send_file tool as a LangChain StructuredTool."""
+
+        # Capture self so closures can access instance attributes without
+        # relying on contextvars (which are invisible across LangGraph threads).
+        tool_instance = self
+
+        def _resolve_file(file_path: str) -> tuple[bytes, int, str] | str:
+            """Validate and read file bytes.
+
+            Returns:
+                Tuple of (file_data, file_size, resolved_name) on success, or
+                an error string on failure.
+            """
+            if not tool_instance.workspace_path:
+                return "[Error: send_file not available (workspace_path not configured)]"
+
+            try:
+                resolved_path = resolve_sandboxed_path(tool_instance.workspace_path, file_path)
+            except ValueError as e:
+                return f"[Error: Invalid file path: {e}]"
+
+            if not resolved_path.exists():
+                return f"[Error: File not found: {file_path}]"
+
+            if not resolved_path.is_file():
+                return f"[Error: Path is not a file: {file_path}]"
+
+            try:
+                file_data = resolved_path.read_bytes()
+            except Exception as e:
+                return f"[Error: Failed to read file: {e}]"
+
+            file_size = len(file_data)
+            if file_size > tool_instance.max_file_size:
+                size_mb = file_size / (1024 * 1024)
+                max_mb = tool_instance.max_file_size / (1024 * 1024)
+                return f"[Error: File size ({size_mb:.1f} MB) exceeds maximum size of {max_mb:.1f} MB]"
+
+            return (file_data, file_size, resolved_path.name)
 
         def send_file_sync(
             file_path: str,
             caption: str | None = None,
             filename: str | None = None,
+            channel: str | None = None,
+            target_id: int | None = None,
         ) -> str:
             """Sync wrapper for send_file (for LangChain compatibility).
 
@@ -89,98 +164,125 @@ class SendFileTool(BaseBuiltinTool):
                 file_path: Relative path to file within workspace.
                 caption: Optional caption/message.
                 filename: Optional display filename override.
+                channel: Optional target channel name for cross-channel send.
+                target_id: Optional target ID on the remote channel.
 
             Returns:
                 Confirmation message or error.
             """
-            if not self.workspace_path:
+            if not tool_instance.workspace_path:
                 return "[Error: send_file not available (workspace_path not configured)]"
 
-            channel, session_key = get_channel_context()
+            file_result = _resolve_file(file_path)
+            if isinstance(file_result, str):
+                return file_result
 
-            if not channel or not session_key:
-                return "[Error: send_file not available in this context (no active session)]"
+            file_data, file_size, default_name = file_result
+            display_name = filename or default_name
+            mime_type, _ = mimetypes.guess_type(display_name)
 
-            try:
-                # Validate and resolve file path
-                try:
-                    resolved_path = resolve_sandboxed_path(self.workspace_path, file_path)
-                except ValueError as e:
-                    return f"[Error: Invalid file path: {e}]"
+            if channel is not None:
+                # Cross-channel path
+                registry = tool_instance._channel_registry
+                if not registry:
+                    return "[Error: Cross-channel file sending is not available in this context]"
 
-                # Check file exists
-                if not resolved_path.exists():
-                    return f"[Error: File not found: {file_path}]"
+                target_channel = registry.get(channel)
+                if target_channel is None:
+                    available = ", ".join(sorted(registry.keys()))
+                    return (
+                        f"[Error: Unknown channel '{channel}'. "
+                        f"Available channels: {available}]"
+                    )
 
-                if not resolved_path.is_file():
-                    return f"[Error: Path is not a file: {file_path}]"
+                resolved_target = next(
+                        (v for v in (target_id, tool_instance._channel_targets.get(channel)) if v is not None),
+                        None,
+                    )
+                if resolved_target is None:
+                    return (
+                        f"[Error: No target_id for channel '{channel}'. "
+                        f"Provide target_id explicitly.]"
+                    )
 
-                # Read file bytes
-                try:
-                    file_data = resolved_path.read_bytes()
-                except Exception as e:
-                    return f"[Error: Failed to read file: {e}]"
+                if not hasattr(target_channel, "send_file"):
+                    return f"[Error: Channel '{channel}' does not support file sending]"
 
-                # Check file size
-                file_size = len(file_data)
-                if file_size > self.max_file_size:
-                    size_mb = file_size / (1024 * 1024)
-                    max_mb = self.max_file_size / (1024 * 1024)
-                    return f"[Error: File size ({size_mb:.1f} MB) exceeds maximum size of {max_mb:.1f} MB]"
+                session_key = target_channel.build_session_key(str(resolved_target))
 
-                # Determine display filename
-                display_name = filename or resolved_path.name
-
-                # Infer MIME type
-                mime_type, _ = mimetypes.guess_type(display_name)
-
-                # Check if channel supports file sending
-                if not hasattr(channel, "send_file"):
-                    return "[Error: This channel does not support file sending]"
-
-                # Send file via channel
                 try:
                     try:
                         loop = asyncio.get_running_loop()
                         future = asyncio.run_coroutine_threadsafe(
-                            channel.send_file(
-                                session_key,
-                                file_data,
-                                display_name,
-                                mime_type,
-                                caption,
+                            target_channel.send_file(
+                                session_key, file_data, display_name, mime_type, caption
                             ),
-                            loop
+                            loop,
                         )
                         future.result(timeout=30.0)
                     except RuntimeError:
-                        # No running loop - safe to use asyncio.run
                         asyncio.run(
-                            channel.send_file(
-                                session_key,
-                                file_data,
-                                display_name,
-                                mime_type,
-                                caption,
+                            target_channel.send_file(
+                                session_key, file_data, display_name, mime_type, caption
                             )
                         )
-
                     size_kb = file_size / 1024
-                    return f"File sent: {display_name} ({size_kb:.1f} KB)"
+                    return f"File sent to {channel}: {display_name} ({size_kb:.1f} KB)"
                 except NotImplementedError:
-                    return "[Error: This channel does not support file sending]"
+                    return f"[Error: Channel '{channel}' does not support file sending]"
                 except Exception as e:
-                    logger.error(f"Failed to send file: {e}")
-                    return f"[Error: Failed to send file: {e}]"
+                    logger.error(f"Failed to send file cross-channel: {e}")
+                    return f"[Error: Failed to send file to channel '{channel}': {e}]"
 
+            # Default path — current session via contextvars
+            ctx_channel, ctx_session_key = get_channel_context()
+
+            if not ctx_channel or not ctx_session_key:
+                return "[Error: send_file not available in this context (no active session)]"
+
+            if not hasattr(ctx_channel, "send_file"):
+                return "[Error: This channel does not support file sending]"
+
+            try:
+                try:
+                    loop = asyncio.get_running_loop()
+                    future = asyncio.run_coroutine_threadsafe(
+                        ctx_channel.send_file(
+                            ctx_session_key,
+                            file_data,
+                            display_name,
+                            mime_type,
+                            caption,
+                        ),
+                        loop
+                    )
+                    future.result(timeout=30.0)
+                except RuntimeError:
+                    # No running loop - safe to use asyncio.run
+                    asyncio.run(
+                        ctx_channel.send_file(
+                            ctx_session_key,
+                            file_data,
+                            display_name,
+                            mime_type,
+                            caption,
+                        )
+                    )
+
+                size_kb = file_size / 1024
+                return f"File sent: {display_name} ({size_kb:.1f} KB)"
+            except NotImplementedError:
+                return "[Error: This channel does not support file sending]"
             except Exception as e:
-                logger.error(f"Unexpected error in send_file: {e}")
-                return f"[Error: Unexpected error: {e}]"
+                logger.error(f"Failed to send file: {e}")
+                return f"[Error: Failed to send file: {e}]"
 
         async def send_file_async(
             file_path: str,
             caption: str | None = None,
             filename: str | None = None,
+            channel: str | None = None,
+            target_id: int | None = None,
         ) -> str:
             """Send a file from the workspace to the user.
 
@@ -188,76 +290,92 @@ class SendFileTool(BaseBuiltinTool):
                 file_path: Relative path to file within workspace.
                 caption: Optional caption/message.
                 filename: Optional display filename override.
+                channel: Optional target channel name for cross-channel send.
+                target_id: Optional target ID on the remote channel.
 
             Returns:
                 Confirmation message or error.
             """
-            if not self.workspace_path:
+            if not tool_instance.workspace_path:
                 return "[Error: send_file not available (workspace_path not configured)]"
 
-            channel, session_key = get_channel_context()
+            file_result = _resolve_file(file_path)
+            if isinstance(file_result, str):
+                return file_result
 
-            if not channel or not session_key:
+            file_data, file_size, default_name = file_result
+            display_name = filename or default_name
+            mime_type, _ = mimetypes.guess_type(display_name)
+
+            if channel is not None:
+                # Cross-channel path
+                registry = tool_instance._channel_registry
+                if not registry:
+                    return "[Error: Cross-channel file sending is not available in this context]"
+
+                target_channel = registry.get(channel)
+                if target_channel is None:
+                    available = ", ".join(sorted(registry.keys()))
+                    return (
+                        f"[Error: Unknown channel '{channel}'. "
+                        f"Available channels: {available}]"
+                    )
+
+                resolved_target = next(
+                        (v for v in (target_id, tool_instance._channel_targets.get(channel)) if v is not None),
+                        None,
+                    )
+                if resolved_target is None:
+                    return (
+                        f"[Error: No target_id for channel '{channel}'. "
+                        f"Provide target_id explicitly.]"
+                    )
+
+                if not hasattr(target_channel, "send_file"):
+                    return f"[Error: Channel '{channel}' does not support file sending]"
+
+                session_key = target_channel.build_session_key(str(resolved_target))
+
+                try:
+                    await target_channel.send_file(
+                        session_key, file_data, display_name, mime_type, caption
+                    )
+                    logger.info(
+                        f"Sent file '{display_name}' to {channel}:{resolved_target}"
+                    )
+                    size_kb = file_size / 1024
+                    return f"File sent to {channel}: {display_name} ({size_kb:.1f} KB)"
+                except NotImplementedError:
+                    return f"[Error: Channel '{channel}' does not support file sending]"
+                except Exception as e:
+                    logger.error(f"Failed to send file cross-channel: {e}")
+                    return f"[Error: Failed to send file to channel '{channel}': {e}]"
+
+            # Default path — current session via contextvars
+            ctx_channel, ctx_session_key = get_channel_context()
+
+            if not ctx_channel or not ctx_session_key:
                 return "[Error: send_file not available in this context (no active session)]"
 
+            if not hasattr(ctx_channel, "send_file"):
+                return "[Error: This channel does not support file sending]"
+
             try:
-                # Validate and resolve file path
-                try:
-                    resolved_path = resolve_sandboxed_path(self.workspace_path, file_path)
-                except ValueError as e:
-                    return f"[Error: Invalid file path: {e}]"
-
-                # Check file exists
-                if not resolved_path.exists():
-                    return f"[Error: File not found: {file_path}]"
-
-                if not resolved_path.is_file():
-                    return f"[Error: Path is not a file: {file_path}]"
-
-                # Read file bytes
-                try:
-                    file_data = resolved_path.read_bytes()
-                except Exception as e:
-                    return f"[Error: Failed to read file: {e}]"
-
-                # Check file size
-                file_size = len(file_data)
-                if file_size > self.max_file_size:
-                    size_mb = file_size / (1024 * 1024)
-                    max_mb = self.max_file_size / (1024 * 1024)
-                    return f"[Error: File size ({size_mb:.1f} MB) exceeds maximum size of {max_mb:.1f} MB]"
-
-                # Determine display filename
-                display_name = filename or resolved_path.name
-
-                # Infer MIME type
-                mime_type, _ = mimetypes.guess_type(display_name)
-
-                # Check if channel supports file sending
-                if not hasattr(channel, "send_file"):
-                    return "[Error: This channel does not support file sending]"
-
-                # Send file via channel
-                try:
-                    await channel.send_file(
-                        session_key,
-                        file_data,
-                        display_name,
-                        mime_type,
-                        caption,
-                    )
-                    logger.info(f"Sent file '{display_name}' to {session_key}")
-                    size_kb = file_size / 1024
-                    return f"File sent: {display_name} ({size_kb:.1f} KB)"
-                except NotImplementedError:
-                    return "[Error: This channel does not support file sending]"
-                except Exception as e:
-                    logger.error(f"Failed to send file: {e}")
-                    return f"[Error: Failed to send file: {e}]"
-
+                await ctx_channel.send_file(
+                    ctx_session_key,
+                    file_data,
+                    display_name,
+                    mime_type,
+                    caption,
+                )
+                logger.info(f"Sent file '{display_name}' to {ctx_session_key}")
+                size_kb = file_size / 1024
+                return f"File sent: {display_name} ({size_kb:.1f} KB)"
+            except NotImplementedError:
+                return "[Error: This channel does not support file sending]"
             except Exception as e:
-                logger.error(f"Unexpected error in send_file: {e}")
-                return f"[Error: Unexpected error: {e}]"
+                logger.error(f"Failed to send file: {e}")
+                return f"[Error: Failed to send file: {e}]"
 
         return StructuredTool.from_function(
             func=send_file_sync,

--- a/openpaw/builtins/tools/send_message.py
+++ b/openpaw/builtins/tools/send_message.py
@@ -28,6 +28,20 @@ class SendMessageInput(BaseModel):
     content: str = Field(
         description="The message text to send to the user"
     )
+    channel: str | None = Field(
+        default=None,
+        description=(
+            "Target channel name for cross-channel messaging. "
+            "Omit to send to the current channel."
+        ),
+    )
+    target_id: int | None = Field(
+        default=None,
+        description=(
+            "Target user/chat/channel ID on the target channel. "
+            "Omit to use the channel's default target."
+        ),
+    )
 
 
 class SendMessageTool(BaseBuiltinTool):
@@ -57,6 +71,12 @@ class SendMessageTool(BaseBuiltinTool):
 
     def __init__(self, config: dict[str, Any] | None = None):
         super().__init__(config)
+        # Registry for cross-channel messaging (channel_name -> ChannelAdapter)
+        self._channel_registry: dict[str, Any] = {}
+        # Default target IDs per channel (channel_name -> target_id)
+        self._channel_targets: dict[str, int] = {}
+        # Optional async callback for injecting [SYSTEM] events into a session
+        self._system_event_callback: Any = None
 
     def set_session_context(self, channel: Any, session_key: str) -> None:
         """Set the active session context for message routing.
@@ -76,57 +96,215 @@ class SendMessageTool(BaseBuiltinTool):
         """
         clear_channel_context()
 
+    def set_channel_registry(
+        self,
+        channels: dict[str, Any],
+        targets: dict[str, int],
+        system_event_callback: Any = None,
+    ) -> None:
+        """Wire in the full channel registry for cross-channel messaging.
+
+        Called by WorkspaceRunner after channels are set up. Only wired when
+        two or more channels are present.
+
+        Args:
+            channels: Mapping of channel_name -> ChannelAdapter instance.
+            targets: Mapping of channel_name -> default target_id.
+            system_event_callback: Optional async callable(session_key, content)
+                that injects a [SYSTEM] event into the target session queue.
+        """
+        self._channel_registry = channels
+        self._channel_targets = targets
+        self._system_event_callback = system_event_callback
+
     def get_langchain_tool(self) -> Any:
         """Return the send_message tool as a LangChain StructuredTool."""
 
-        def send_message_sync(content: str) -> str:
+        # Capture self so closures can access instance attributes without
+        # relying on contextvars (which are invisible across LangGraph threads).
+        tool_instance = self
+
+        def send_message_sync(
+            content: str,
+            channel: str | None = None,
+            target_id: int | None = None,
+        ) -> str:
             """Sync wrapper for send_message (for LangChain compatibility).
 
             Args:
                 content: The message text to send.
+                channel: Optional target channel name for cross-channel send.
+                target_id: Optional target ID on the remote channel.
 
             Returns:
                 Confirmation message or error.
             """
-            channel, session_key = get_channel_context()
+            if channel is not None:
+                # Cross-channel path
+                registry = tool_instance._channel_registry
+                if not registry:
+                    return "[Error: Cross-channel messaging is not available in this context]"
 
-            if not channel or not session_key:
+                target_channel = registry.get(channel)
+                if target_channel is None:
+                    available = ", ".join(sorted(registry.keys()))
+                    return (
+                        f"[Error: Unknown channel '{channel}'. "
+                        f"Available channels: {available}]"
+                    )
+
+                resolved_target = next(
+                        (v for v in (target_id, tool_instance._channel_targets.get(channel)) if v is not None),
+                        None,
+                    )
+                if resolved_target is None:
+                    return (
+                        f"[Error: No target_id for channel '{channel}'. "
+                        f"Provide target_id explicitly.]"
+                    )
+
+                session_key = target_channel.build_session_key(str(resolved_target))
+
+                try:
+                    try:
+                        loop = asyncio.get_running_loop()
+                        future = asyncio.run_coroutine_threadsafe(
+                            target_channel.send_message(session_key, content),
+                            loop,
+                        )
+                        future.result(timeout=30.0)
+                    except RuntimeError:
+                        asyncio.run(target_channel.send_message(session_key, content))
+
+                    # Inject a [SYSTEM] event into the target session if callback available
+                    if tool_instance._system_event_callback is not None:
+                        source_channel_name = _extract_channel_name_from_context()
+                        system_content = _build_cross_channel_system_event(
+                            source_channel_name, content
+                        )
+                        try:
+                            loop = asyncio.get_running_loop()
+                            future = asyncio.run_coroutine_threadsafe(
+                                tool_instance._system_event_callback(
+                                    session_key, system_content
+                                ),
+                                loop,
+                            )
+                            future.result(timeout=10.0)
+                        except RuntimeError:
+                            asyncio.run(
+                                tool_instance._system_event_callback(
+                                    session_key, system_content
+                                )
+                            )
+                        except Exception as e:
+                            logger.warning(f"Failed to inject cross-channel system event: {e}")
+
+                    return f"Message sent to {channel}: {content[:50]}{'...' if len(content) > 50 else ''}"
+                except Exception as e:
+                    logger.error(f"Failed to send cross-channel message: {e}")
+                    return f"[Error: Failed to send message to channel '{channel}': {e}]"
+
+            # Default path — current session via contextvars
+            ctx_channel, ctx_session_key = get_channel_context()
+
+            if not ctx_channel or not ctx_session_key:
                 return "[Error: send_message not available in this context (no active session)]"
 
             try:
                 try:
                     loop = asyncio.get_running_loop()
                     future = asyncio.run_coroutine_threadsafe(
-                        channel.send_message(session_key, content),
+                        ctx_channel.send_message(ctx_session_key, content),
                         loop
                     )
                     future.result(timeout=30.0)
                 except RuntimeError:
                     # No running loop - safe to use asyncio.run
-                    asyncio.run(channel.send_message(session_key, content))
+                    asyncio.run(ctx_channel.send_message(ctx_session_key, content))
 
                 return f"Message sent: {content[:50]}{'...' if len(content) > 50 else ''}"
             except Exception as e:
                 logger.error(f"Failed to send message: {e}")
                 return f"[Error: Failed to send message: {e}]"
 
-        async def send_message_async(content: str) -> str:
+        async def send_message_async(
+            content: str,
+            channel: str | None = None,
+            target_id: int | None = None,
+        ) -> str:
             """Send a message to the user mid-execution.
 
             Args:
                 content: The message text to send.
+                channel: Optional target channel name for cross-channel send.
+                target_id: Optional target ID on the remote channel.
 
             Returns:
                 Confirmation message or error.
             """
-            channel, session_key = get_channel_context()
+            if channel is not None:
+                # Cross-channel path
+                registry = tool_instance._channel_registry
+                if not registry:
+                    return "[Error: Cross-channel messaging is not available in this context]"
 
-            if not channel or not session_key:
+                target_channel = registry.get(channel)
+                if target_channel is None:
+                    available = ", ".join(sorted(registry.keys()))
+                    return (
+                        f"[Error: Unknown channel '{channel}'. "
+                        f"Available channels: {available}]"
+                    )
+
+                resolved_target = next(
+                        (v for v in (target_id, tool_instance._channel_targets.get(channel)) if v is not None),
+                        None,
+                    )
+                if resolved_target is None:
+                    return (
+                        f"[Error: No target_id for channel '{channel}'. "
+                        f"Provide target_id explicitly.]"
+                    )
+
+                session_key = target_channel.build_session_key(str(resolved_target))
+
+                try:
+                    await target_channel.send_message(session_key, content)
+                    logger.info(
+                        f"Sent cross-channel message to {channel}:{resolved_target}"
+                    )
+
+                    # Inject [SYSTEM] event into the target session if callback available
+                    if tool_instance._system_event_callback is not None:
+                        source_channel_name = _extract_channel_name_from_context()
+                        system_content = _build_cross_channel_system_event(
+                            source_channel_name, content
+                        )
+                        try:
+                            await tool_instance._system_event_callback(
+                                session_key, system_content
+                            )
+                        except Exception as e:
+                            logger.warning(f"Failed to inject cross-channel system event: {e}")
+
+                    return (
+                        f"Message sent to {channel}: "
+                        f"{content[:50]}{'...' if len(content) > 50 else ''}"
+                    )
+                except Exception as e:
+                    logger.error(f"Failed to send cross-channel message: {e}")
+                    return f"[Error: Failed to send message to channel '{channel}': {e}]"
+
+            # Default path — current session via contextvars
+            ctx_channel, ctx_session_key = get_channel_context()
+
+            if not ctx_channel or not ctx_session_key:
                 return "[Error: send_message not available in this context (no active session)]"
 
             try:
-                await channel.send_message(session_key, content)
-                logger.info(f"Sent mid-execution message to {session_key}")
+                await ctx_channel.send_message(ctx_session_key, content)
+                logger.info(f"Sent mid-execution message to {ctx_session_key}")
                 return f"Message sent: {content[:50]}{'...' if len(content) > 50 else ''}"
             except Exception as e:
                 logger.error(f"Failed to send message: {e}")
@@ -140,7 +318,38 @@ class SendMessageTool(BaseBuiltinTool):
                 "Send a message to the user while you continue working. "
                 "Use this for status updates, progress reports, or partial results "
                 "during long-running operations. The user will receive the message "
-                "immediately, and you can continue with additional tool calls or work."
+                "immediately, and you can continue with additional tool calls or work. "
+                "Specify the optional channel parameter to send to a different channel."
             ),
             args_schema=SendMessageInput,
         )
+
+
+def _extract_channel_name_from_context() -> str:
+    """Extract the source channel name from the current session context.
+
+    Returns:
+        Channel name string, or 'unknown' if no session context is set.
+    """
+    _, session_key = get_channel_context()
+    if session_key:
+        # Session key format: "{channel_name}:{id}" or "{channel_name}:{id}:{conv_id}"
+        return session_key.split(":")[0]
+    return "unknown"
+
+
+def _build_cross_channel_system_event(source_channel: str, content: str) -> str:
+    """Build the [SYSTEM] event content for cross-channel escalation injection.
+
+    Args:
+        source_channel: Name of the originating channel.
+        content: The message that was sent cross-channel.
+
+    Returns:
+        Formatted system event string.
+    """
+    return (
+        f"[SYSTEM] Cross-channel escalation from '{source_channel}':\n\n"
+        f"{content}\n\n"
+        f"Source channel logs: memory/logs/channel/ (use grep_files to search)"
+    )

--- a/openpaw/core/config/models.py
+++ b/openpaw/core/config/models.py
@@ -143,6 +143,22 @@ class WorkspaceChannelConfig(BaseModel):
         default_factory=ChannelLogConfig,
         description="Persistent channel message logging configuration",
     )
+    primary: bool = Field(
+        default=False,
+        description=(
+            "Mark this channel as the primary (preferred) channel for the workspace owner. "
+            "Cross-channel escalations route detailed briefings here. "
+            "Exactly one channel must be primary when 2+ channels are configured."
+        ),
+    )
+    default_target_id: int | None = Field(
+        default=None,
+        description=(
+            "Default target ID for cross-channel messaging. "
+            "When another channel sends a message here without an explicit target_id, "
+            "this value is used. Falls back to first allowed_users entry if not set."
+        ),
+    )
 
     @field_validator("context_messages")
     @classmethod
@@ -659,6 +675,24 @@ class WorkspaceConfig(BaseModel):
         default_factory=StatusReminderConfig,
         description="Status reminder middleware configuration",
     )
+
+    @model_validator(mode="after")
+    def validate_primary_channel(self) -> "WorkspaceConfig":
+        """Validate exactly one channel is marked primary when 2+ channels configured."""
+        if len(self.channels) >= 2:
+            primary_count = sum(1 for ch in self.channels if ch.primary)
+            if primary_count == 0:
+                raise ValueError(
+                    "Exactly one channel must be marked 'primary: true' when multiple "
+                    "channels are configured. The primary channel receives cross-channel "
+                    "escalations and detailed briefings."
+                )
+            if primary_count > 1:
+                raise ValueError(
+                    f"Only one channel can be marked 'primary: true', but {primary_count} "
+                    f"channels have primary set."
+                )
+        return self
 
     @field_validator("session_ttl_minutes")
     @classmethod

--- a/openpaw/core/prompts/framework.py
+++ b/openpaw/core/prompts/framework.py
@@ -292,6 +292,89 @@ SECTION_SYSTEM_EVENTS = (
     "channel delivery for system-originated events — it has no effect on user messages."
 )
 
+# Cross-channel communication - conditional on 2+ channels configured
+SECTION_CHANNELS_HEADER = (
+    "\n\n## Connected Channels\n\n"
+    "You are connected to multiple communication channels. You can send messages "
+    "and files to any channel using the optional `channel` parameter on "
+    "`send_message` and `send_file`.\n\n"
+)
+
+SECTION_CHANNELS_ETIQUETTE = (
+    "\n### Cross-Channel Escalation Rule\n\n"
+    "**IMPORTANT: When you receive a message on a public channel (Discord server, "
+    "group chat), you MUST escalate to the primary channel.** Follow this pattern:\n\n"
+    "1. Send a brief acknowledgment on the public channel (your normal response)\n"
+    "2. Send a detailed briefing to the primary channel using "
+    "`send_message(content='...', channel='<primary_channel_name>')`\n\n"
+    "**Public channels** — Keep responses short and professional. Acknowledge, "
+    "confirm you're investigating, report outcomes. Never share verbose details, "
+    "investigation results, or request permissions in public.\n\n"
+    "**Primary channel** — This is where you send detailed briefings, "
+    "investigation results, request user decisions, and share sensitive information.\n\n"
+    "When you omit the `channel` parameter, messages go to the channel that "
+    "triggered the current interaction. Use the `channel` parameter to target "
+    "a different channel.\n"
+)
+
+SECTION_CHANNELS_CONTEXT_RECOVERY = (
+    "\n### Cross-Channel Context Recovery\n\n"
+    "When you receive a `[SYSTEM]` escalation event referencing another channel, "
+    "you can review the source channel's logs for full context:\n\n"
+    "- Channel logs are at: `memory/logs/channel/{server}/{channel}/{YYYY-MM-DD}.jsonl`\n"
+    "- Use `grep_files('memory/logs/channel', 'search term')` to find relevant messages\n"
+    "- Use `read_file()` on specific log files for chronological context\n"
+    "- Sub-agent investigation logs referenced in the escalation event contain "
+    "tool calls, responses, and metrics from the investigation\n\n"
+    "Review these logs before responding to the user about an escalation — they "
+    "contain the full picture that the summary may not capture.\n"
+)
+
+
+def build_channels_section(channels_config: list) -> str:
+    """Build the channels section for the framework prompt.
+
+    Args:
+        channels_config: List of WorkspaceChannelConfig objects.
+
+    Returns:
+        Formatted channels section with listing table and etiquette guidance,
+        or empty string if fewer than 2 channels.
+    """
+    if len(channels_config) < 2:
+        return ""
+
+    parts = [SECTION_CHANNELS_HEADER.strip()]
+
+    # Build channel listing table
+    parts.append("")
+    parts.append("| Channel | Type | Role | Default Target |")
+    parts.append("|---------|------|------|----------------|")
+    for ch in channels_config:
+        ch_name = ch.name or ch.type or "unknown"
+        ch_type = ch.type or "unknown"
+        role = "**primary**" if ch.primary else "public"
+
+        # Resolve display target
+        target = ch.default_target_id
+        if target is None and ch.allowed_users:
+            target = ch.allowed_users[0]
+        target_str = str(target) if target is not None else "—"
+
+        parts.append(f"| `{ch_name}` | {ch_type} | {role} | {target_str} |")
+
+    # Find the primary channel name for concrete examples in the prompt
+    primary_name = next(
+        ((ch.name or ch.type or "unknown") for ch in channels_config if ch.primary),
+        "primary",
+    )
+    etiquette = SECTION_CHANNELS_ETIQUETTE.replace("<primary_channel_name>", primary_name)
+    parts.append(etiquette)
+    parts.append(SECTION_CHANNELS_CONTEXT_RECOVERY)
+
+    return "\n".join(parts)
+
+
 # Channel context - always included (group messages prepend recent history)
 SECTION_CHANNEL_CONTEXT = (
     "\n\n## Channel Context\n\n"

--- a/openpaw/core/workspace.py
+++ b/openpaw/core/workspace.py
@@ -33,6 +33,7 @@ from openpaw.core.prompts.framework import (
     SECTION_WORK_ETHIC,
     SECTION_WORKSPACE_FILESYSTEM,
     build_capability_summary,
+    build_channels_section,
     build_cron_context,
     build_framework_orientation,
 )
@@ -330,7 +331,12 @@ class AgentWorkspace:
             if cron.output is not None
         )
         has_spawn = enabled_builtins is None or "spawn" in enabled_builtins
-        if heartbeat_agent_delivery or cron_agent_delivery or has_spawn:
+        has_cross_channel = (
+            self.config is not None
+            and self.config.channels is not None
+            and len(self.config.channels) >= 2
+        )
+        if heartbeat_agent_delivery or cron_agent_delivery or has_spawn or has_cross_channel:
             sections.append(SECTION_SYSTEM_EVENTS)
 
         # Memory search - include if memory_search is enabled
@@ -344,6 +350,12 @@ class AgentWorkspace:
         # Channel logs - include when persistent channel logging is active
         if channel_logging_enabled:
             sections.append(SECTION_CHANNEL_LOGS)
+
+        # Cross-channel communication - include when 2+ channels configured
+        if self.config and self.config.channels and len(self.config.channels) >= 2:
+            channels_section = build_channels_section(self.config.channels)
+            if channels_section:
+                sections.append(channels_section)
 
         # Channel context is always available (group messages prepend recent history)
         sections.append(SECTION_CHANNEL_CONTEXT)

--- a/openpaw/workspace/runner.py
+++ b/openpaw/workspace/runner.py
@@ -794,6 +794,7 @@ class WorkspaceRunner:
         )
         self._connect_spawn_tool_to_runner()
         self._connect_channel_history_tool()
+        self._connect_cross_channel_registry()
 
         self._running = True
         self._queue_processor_task = asyncio.create_task(self._queue_processor())
@@ -861,6 +862,44 @@ class WorkspaceRunner:
             )
         except Exception as e:
             self.logger.warning(f"Failed to connect ChannelHistoryTool: {e}")
+
+    def _connect_cross_channel_registry(self) -> None:
+        """Wire channel registry into send_message and send_file for cross-channel messaging.
+
+        Only wires when two or more channels are present — single-channel workspaces
+        have no need for cross-channel routing.
+        """
+        if len(self._channels) < 2:
+            return
+
+        # Build default target map from merged config.
+        # Priority: explicit default_target_id > first entry in allowed_users.
+        channel_targets: dict[str, int] = {}
+        for ch_cfg in self._merged_config.get("channels", []):
+            ch_name = ch_cfg.get("name") or ch_cfg.get("type", "telegram")
+            default_target = ch_cfg.get("default_target_id")
+            if default_target is not None:
+                channel_targets[ch_name] = default_target
+            elif ch_cfg.get("allowed_users"):
+                channel_targets[ch_name] = ch_cfg["allowed_users"][0]
+
+        send_msg = self._builtin_loader.get_tool_instance("send_message")
+        if send_msg and hasattr(send_msg, "set_channel_registry"):
+            send_msg.set_channel_registry(
+                self._channels, channel_targets, self._inject_system_event
+            )
+            self.logger.info(
+                "Connected cross-channel registry to send_message (%d channels)",
+                len(self._channels),
+            )
+
+        send_file = self._builtin_loader.get_tool_instance("send_file")
+        if send_file and hasattr(send_file, "set_channel_registry"):
+            send_file.set_channel_registry(self._channels, channel_targets)
+            self.logger.info(
+                "Connected cross-channel registry to send_file (%d channels)",
+                len(self._channels),
+            )
 
     def _connect_memory_search_tool(self) -> None:
         """Connect MemorySearchTool builtin to vector store and embedding provider.

--- a/tests/test_cross_channel.py
+++ b/tests/test_cross_channel.py
@@ -1,0 +1,362 @@
+"""Tests for cross-channel messaging feature.
+
+Covers:
+- WorkspaceConfig.validate_primary_channel validator
+- WorkspaceChannelConfig new fields (primary, default_target_id)
+- build_channels_section prompt builder
+- SendMessageTool cross-channel registry wiring
+- _extract_channel_name_from_context and _build_cross_channel_system_event helpers
+- SendFileTool cross-channel registry wiring
+"""
+
+import pytest
+
+from openpaw.builtins.tools.send_file import SendFileTool
+from openpaw.builtins.tools.send_message import (
+    SendMessageTool,
+    _build_cross_channel_system_event,
+    _extract_channel_name_from_context,
+)
+from openpaw.core.config.models import WorkspaceChannelConfig, WorkspaceConfig
+from openpaw.core.prompts.framework import build_channels_section
+
+
+# ---------------------------------------------------------------------------
+# WorkspaceConfig.validate_primary_channel validator
+# ---------------------------------------------------------------------------
+
+
+def test_multi_channel_with_one_primary_passes() -> None:
+    """Multi-channel config with exactly one primary channel is valid."""
+    config = WorkspaceConfig.model_validate(
+        {
+            "channels": [
+                {"name": "telegram", "type": "telegram", "primary": True},
+                {"name": "discord", "type": "discord"},
+            ]
+        }
+    )
+    assert len(config.channels) == 2
+    primary_channels = [ch for ch in config.channels if ch.primary]
+    assert len(primary_channels) == 1
+    assert primary_channels[0].name == "telegram"
+
+
+def test_multi_channel_no_primary_raises() -> None:
+    """Multi-channel config with no primary channel raises ValueError."""
+    with pytest.raises(ValueError, match="must be marked 'primary: true'"):
+        WorkspaceConfig.model_validate(
+            {
+                "channels": [
+                    {"name": "telegram", "type": "telegram"},
+                    {"name": "discord", "type": "discord"},
+                ]
+            }
+        )
+
+
+def test_multi_channel_two_primary_raises() -> None:
+    """Multi-channel config with two primary channels raises ValueError."""
+    with pytest.raises(ValueError, match="Only one channel"):
+        WorkspaceConfig.model_validate(
+            {
+                "channels": [
+                    {"name": "telegram", "type": "telegram", "primary": True},
+                    {"name": "discord", "type": "discord", "primary": True},
+                ]
+            }
+        )
+
+
+def test_single_channel_no_primary_passes() -> None:
+    """Single-channel config with no primary field does not require primary."""
+    config = WorkspaceConfig.model_validate(
+        {"channels": [{"name": "telegram", "type": "telegram"}]}
+    )
+    assert len(config.channels) == 1
+    assert config.channels[0].primary is False
+
+
+def test_single_channel_with_primary_passes() -> None:
+    """Single-channel config with primary=True is valid (no multi-channel constraint)."""
+    config = WorkspaceConfig.model_validate(
+        {"channels": [{"name": "telegram", "type": "telegram", "primary": True}]}
+    )
+    assert len(config.channels) == 1
+    assert config.channels[0].primary is True
+
+
+def test_empty_channels_passes() -> None:
+    """Empty channel list requires no primary (validator only fires for 2+ channels)."""
+    config = WorkspaceConfig.model_validate({})
+    assert config.channels == []
+
+
+# ---------------------------------------------------------------------------
+# WorkspaceChannelConfig new fields
+# ---------------------------------------------------------------------------
+
+
+def test_channel_config_default_target_id() -> None:
+    """WorkspaceChannelConfig accepts and stores default_target_id."""
+    ch = WorkspaceChannelConfig(type="telegram", default_target_id=123456)
+    assert ch.default_target_id == 123456
+
+
+def test_channel_config_default_target_id_defaults_none() -> None:
+    """default_target_id defaults to None when not set."""
+    ch = WorkspaceChannelConfig(type="telegram")
+    assert ch.default_target_id is None
+
+
+def test_channel_config_primary_default_false() -> None:
+    """primary field defaults to False."""
+    ch = WorkspaceChannelConfig(type="telegram")
+    assert ch.primary is False
+
+
+def test_channel_config_primary_set_true() -> None:
+    """primary field can be set to True."""
+    ch = WorkspaceChannelConfig(type="telegram", primary=True)
+    assert ch.primary is True
+
+
+def test_channel_config_both_new_fields() -> None:
+    """Both primary and default_target_id can be set together."""
+    ch = WorkspaceChannelConfig(type="discord", primary=True, default_target_id=99999)
+    assert ch.primary is True
+    assert ch.default_target_id == 99999
+
+
+# ---------------------------------------------------------------------------
+# build_channels_section
+# ---------------------------------------------------------------------------
+
+
+def test_build_channels_section_empty_list_returns_empty() -> None:
+    """Empty channel list returns empty string."""
+    assert build_channels_section([]) == ""
+
+
+def test_build_channels_section_single_channel_returns_empty() -> None:
+    """Single channel list returns empty string (no cross-channel needed)."""
+    channels = [WorkspaceChannelConfig(type="telegram")]
+    assert build_channels_section(channels) == ""
+
+
+def test_build_channels_section_two_channels_returns_content() -> None:
+    """Two channels produce a non-empty channels section."""
+    channels = [
+        WorkspaceChannelConfig(name="telegram", type="telegram", primary=True, default_target_id=123),
+        WorkspaceChannelConfig(name="discord", type="discord"),
+    ]
+    result = build_channels_section(channels)
+    assert result != ""
+
+
+def test_build_channels_section_includes_channel_names() -> None:
+    """Channel names appear in the generated section."""
+    channels = [
+        WorkspaceChannelConfig(name="telegram", type="telegram", primary=True, default_target_id=123),
+        WorkspaceChannelConfig(name="discord-alerts", type="discord"),
+    ]
+    result = build_channels_section(channels)
+    assert "telegram" in result
+    assert "discord-alerts" in result
+
+
+def test_build_channels_section_marks_primary_role() -> None:
+    """Primary channel is labelled with '**primary**' role."""
+    channels = [
+        WorkspaceChannelConfig(name="telegram", type="telegram", primary=True, default_target_id=123),
+        WorkspaceChannelConfig(name="discord", type="discord"),
+    ]
+    result = build_channels_section(channels)
+    assert "**primary**" in result
+
+
+def test_build_channels_section_marks_public_role() -> None:
+    """Non-primary channels are labelled as 'public'."""
+    channels = [
+        WorkspaceChannelConfig(name="telegram", type="telegram", primary=True, default_target_id=123),
+        WorkspaceChannelConfig(name="discord", type="discord"),
+    ]
+    result = build_channels_section(channels)
+    assert "public" in result
+
+
+def test_build_channels_section_includes_channel_types() -> None:
+    """Channel types appear in the generated table."""
+    channels = [
+        WorkspaceChannelConfig(name="tg", type="telegram", primary=True, default_target_id=1),
+        WorkspaceChannelConfig(name="dc", type="discord"),
+    ]
+    result = build_channels_section(channels)
+    assert "telegram" in result
+    assert "discord" in result
+
+
+def test_build_channels_section_shows_default_target_id() -> None:
+    """default_target_id appears in the channel table row."""
+    channels = [
+        WorkspaceChannelConfig(name="telegram", type="telegram", primary=True, default_target_id=987654),
+        WorkspaceChannelConfig(name="discord", type="discord"),
+    ]
+    result = build_channels_section(channels)
+    assert "987654" in result
+
+
+def test_build_channels_section_falls_back_to_allowed_users() -> None:
+    """Falls back to first allowed_users entry when default_target_id is not set."""
+    channels = [
+        WorkspaceChannelConfig(
+            name="telegram",
+            type="telegram",
+            primary=True,
+            allowed_users=[555444],
+        ),
+        WorkspaceChannelConfig(name="discord", type="discord"),
+    ]
+    result = build_channels_section(channels)
+    assert "555444" in result
+
+
+def test_build_channels_section_uses_type_as_name_fallback() -> None:
+    """When name is None, the channel type is used as the display name."""
+    channels = [
+        WorkspaceChannelConfig(type="telegram", primary=True, default_target_id=1),
+        WorkspaceChannelConfig(type="discord"),
+    ]
+    result = build_channels_section(channels)
+    # type should appear as the name in the table row
+    assert "telegram" in result
+    assert "discord" in result
+
+
+# ---------------------------------------------------------------------------
+# SendMessageTool cross-channel registry
+# ---------------------------------------------------------------------------
+
+
+def test_send_message_tool_set_channel_registry() -> None:
+    """set_channel_registry stores channels and targets on the tool instance."""
+    tool = SendMessageTool()
+    channels = {"telegram": object(), "discord": object()}
+    targets = {"telegram": 123}
+
+    tool.set_channel_registry(channels, targets)
+
+    assert tool._channel_registry == channels
+    assert tool._channel_targets == targets
+
+
+def test_send_message_tool_registry_defaults_empty() -> None:
+    """Channel registry defaults to empty dicts before wiring."""
+    tool = SendMessageTool()
+    assert tool._channel_registry == {}
+    assert tool._channel_targets == {}
+
+
+def test_send_message_tool_set_channel_registry_with_callback() -> None:
+    """set_channel_registry accepts an optional system_event_callback."""
+    tool = SendMessageTool()
+    channels = {"telegram": object()}
+    targets = {"telegram": 111}
+    callback = object()
+
+    tool.set_channel_registry(channels, targets, system_event_callback=callback)
+
+    assert tool._channel_registry == channels
+    assert tool._channel_targets == targets
+    assert tool._system_event_callback is callback
+
+
+def test_send_message_tool_callback_defaults_none() -> None:
+    """System event callback defaults to None before wiring."""
+    tool = SendMessageTool()
+    assert tool._system_event_callback is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_channel_name_from_context helper
+# ---------------------------------------------------------------------------
+
+
+def test_extract_channel_name_from_context_no_session_returns_unknown() -> None:
+    """Returns 'unknown' when no session context is active."""
+    # No context set — should safely return "unknown"
+    result = _extract_channel_name_from_context()
+    assert result == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# _build_cross_channel_system_event helper
+# ---------------------------------------------------------------------------
+
+
+def test_build_cross_channel_system_event_contains_system_marker() -> None:
+    """Result includes the [SYSTEM] marker."""
+    result = _build_cross_channel_system_event("discord-alerts", "Server is down!")
+    assert "[SYSTEM]" in result
+
+
+def test_build_cross_channel_system_event_contains_source_channel() -> None:
+    """Result includes the source channel name."""
+    result = _build_cross_channel_system_event("discord-alerts", "Server is down!")
+    assert "discord-alerts" in result
+
+
+def test_build_cross_channel_system_event_contains_message_content() -> None:
+    """Result includes the original message content."""
+    result = _build_cross_channel_system_event("discord-alerts", "Server is down!")
+    assert "Server is down!" in result
+
+
+def test_build_cross_channel_system_event_contains_log_path_hint() -> None:
+    """Result includes reference to channel logs for context recovery."""
+    result = _build_cross_channel_system_event("discord-alerts", "Server is down!")
+    assert "memory/logs/channel/" in result
+
+
+def test_build_cross_channel_system_event_various_inputs() -> None:
+    """Helper works with different channel names and message contents."""
+    result = _build_cross_channel_system_event("telegram-personal", "Deploy complete.")
+    assert "telegram-personal" in result
+    assert "Deploy complete." in result
+
+
+# ---------------------------------------------------------------------------
+# SendFileTool cross-channel registry
+# ---------------------------------------------------------------------------
+
+
+def test_send_file_tool_set_channel_registry() -> None:
+    """set_channel_registry stores channels and targets on SendFileTool."""
+    tool = SendFileTool(config={"workspace_path": "/tmp"})
+    channels = {"telegram": object(), "discord": object()}
+    targets = {"telegram": 123}
+
+    tool.set_channel_registry(channels, targets)
+
+    assert tool._channel_registry == channels
+    assert tool._channel_targets == targets
+
+
+def test_send_file_tool_registry_defaults_empty() -> None:
+    """SendFileTool channel registry defaults to empty dicts before wiring."""
+    tool = SendFileTool(config={"workspace_path": "/tmp"})
+    assert tool._channel_registry == {}
+    assert tool._channel_targets == {}
+
+
+def test_send_file_tool_registry_overwrite() -> None:
+    """Calling set_channel_registry twice replaces the previous registry."""
+    tool = SendFileTool(config={"workspace_path": "/tmp"})
+    first_channels = {"telegram": object()}
+    second_channels = {"discord": object()}
+
+    tool.set_channel_registry(first_channels, {})
+    tool.set_channel_registry(second_channels, {"discord": 999})
+
+    assert tool._channel_registry == second_channels
+    assert tool._channel_targets == {"discord": 999}

--- a/tests/test_multi_channel_config.py
+++ b/tests/test_multi_channel_config.py
@@ -30,7 +30,7 @@ def test_channels_list_parses() -> None:
     """A 'channels:' list with multiple entries loads correctly."""
     data = {
         "channels": [
-            {"type": "telegram", "token": "tg-token"},
+            {"type": "telegram", "token": "tg-token", "primary": True},
             {"type": "discord", "token": "dc-token"},
         ]
     }
@@ -126,7 +126,7 @@ def test_channels_with_same_type_different_names() -> None:
     """Two channels sharing the same type but with different names parse without error."""
     data = {
         "channels": [
-            {"name": "tg-primary", "type": "telegram", "token": "token-a"},
+            {"name": "tg-primary", "type": "telegram", "token": "token-a", "primary": True},
             {"name": "tg-secondary", "type": "telegram", "token": "token-b"},
         ]
     }


### PR DESCRIPTION
## Summary

- Add optional `channel` and `target_id` params to `send_message` and `send_file` for cross-channel messaging
- New `primary` and `default_target_id` fields on `WorkspaceChannelConfig` with strict validation
- Channel registry wired via instance attributes (avoids LangGraph contextvars pitfall)
- Cross-channel sends inject `[SYSTEM]` context events into target session with summary + log pointers
- Framework prompt teaches escalation rules with concrete channel names
- Devin workspace updated to multi-channel (telegram primary + discord)
- `discord_test` workspace archived
- 34 new tests, 2404 total passing

## Known Issues / Follow-up Needed

**Agent escalation behavior is broken with Kimi K2.5.** The framework plumbing works correctly but the model does not follow the cross-channel escalation prompt:

- When receiving a Discord message, the agent calls `send_message(channel="discord")` instead of `send_message(channel="telegram")` — sending TO the channel it's already on
- The prompt explicitly says `send_message(content='...', channel='telegram')` but Kimi K2.5 ignores it
- The agent's text response claims it escalated to Telegram but the logs show it never did

**Proposed fixes (not yet implemented):**
1. Remove non-primary channel target IDs from the prompt table — eliminates the "temptation" for the model to use wrong targets
2. Add corrective error messages — when cross-channel send fails, suggest "Did you mean the primary channel 'telegram'?"
3. Test with Claude or other models that follow instructions more reliably
4. Consider removing `default_target_id` fallback for non-primary channels entirely

**Architecture doc:** `llm_memory/cross-channel-escalation-architecture.md`

## Test plan

- [x] Config validation: primary channel enforcement (exactly one when 2+ channels)
- [x] Cross-channel target resolution: explicit > default_target_id > allowed_users
- [x] Prompt section injection: only when 2+ channels configured
- [x] Backward compat: single-channel workspaces unaffected
- [x] Lint + full test suite passing (2404 tests)
- [ ] E2E: Discord alert → Telegram escalation (blocked by model behavior)
- [ ] E2E: Telegram reply with cross-channel context recovery