### PR TITLE
fix: include FireworksError in tenacity retry exception list

### DIFF
--- a/openpaw/agent/runner.py
+++ b/openpaw/agent/runner.py
@@ -151,6 +151,7 @@ def create_chat_model(
     if provider == "fireworks":
         import httpx
         import tenacity
+        from fireworks.client.error import FireworksError
         from langchain_fireworks import ChatFireworks
 
         if api_key:
@@ -172,6 +173,7 @@ def create_chat_model(
                     httpx.ReadTimeout,
                     ConnectionError,
                     TimeoutError,
+                    FireworksError,
                 )),
                 stop=tenacity.stop_after_attempt(effective_retries + 1),
                 wait=tenacity.wait_exponential_jitter(initial=1, max=60),


### PR DESCRIPTION
## Summary
- Fireworks SDK raises `fireworks.client.error.RateLimitError` (inherits from `FireworksError`) which is not an `httpx` exception
- The tenacity retry patch only caught httpx errors, so Fireworks rate limits/overload errors exhausted all attempts without actually retrying
- Added `FireworksError` to the retry exception tuple so all transient Fireworks errors (rate limits, server overload) are properly retried with exponential backoff

## Test plan
- [ ] Run krieger workspace against Fireworks under load and verify retry logs appear on transient errors
- [ ] Confirm `poetry run ruff check openpaw/agent/runner.py` passes
- [ ] Confirm `poetry run python -c "from openpaw.agent.runner import create_chat_model"` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)