### PR TITLE
feat: add GPT-Researcher builtin for deep research via WebSocket API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -902,6 +902,50 @@ poetry run playwright install chromium
 - Agent calls `browser_click(42)` to click the "Schedule" button (element #42)
 - Agent fills in meeting details and confirms booking
 
+### GPT-Researcher
+
+Agents can conduct deep research via a self-hosted GPT-Researcher instance. The builtin communicates over WebSocket for streaming research reports and REST for document uploads.
+
+**Available Tools**:
+- `research` - Submit a research query and receive a comprehensive report with citations (1-5 min)
+- `upload_research_document` - Upload a workspace file for local document research (only available when `upload_endpoint` is configured)
+
+**Report Types**:
+- `research_report` (default) - Comprehensive research with citations
+- `outline_report` - Structured outline of the topic
+- `detailed_report` - In-depth analysis
+- `resource_report` - Curated list of resources
+
+**Configuration** (in `agent.yaml` or global config):
+
+```yaml
+builtins:
+  gpt_researcher:
+    enabled: true
+    config:
+      endpoint: "wss://researcher.example.com/ws"           # WebSocket endpoint (required)
+      upload_endpoint: "https://researcher.example.com/upload/"  # REST upload endpoint (optional)
+      timeout_seconds: 300            # Max seconds to wait for research (default: 300)
+      default_report_type: "research_report"   # Default report type
+      default_report_source: "web"             # Default source: web or local
+      default_tone: "Objective"                # Default writing tone
+```
+
+**Prerequisites**: Requires optional `websockets` package:
+
+```bash
+poetry install --extras researcher
+```
+
+**Protocol**: Connects to GPT-Researcher WebSocket API, sends `"start " + JSON payload`, and streams back JSON messages: `logs` (progress), `report` (content chunks), `path` (completion signal). Report chunks are concatenated into the final markdown report.
+
+**Document Upload**: Upload workspace files via REST (`POST /upload/` with multipart form), then use `report_source='local'` in research queries to analyze uploaded documents. File paths are validated through the sandbox to prevent path traversal.
+
+**Example Usage** (by agent):
+- User: "Research the current state of WebAssembly adoption in server-side applications"
+- Agent calls `research(query="WebAssembly adoption in server-side applications", report_type="detailed_report")`
+- GPT-Researcher streams progress logs, then returns full report with citations
+
 ### Sub-Agent Spawning
 
 Agents can spawn background workers for concurrent task execution using the `spawn` builtin. Sub-agents run in isolated contexts with filtered tools to prevent recursion and unsolicited messaging.
@@ -1318,6 +1362,7 @@ OpenPaw provides optional built-in capabilities that are conditionally available
 - `spawn` - Sub-agent spawning for background tasks (no API key required, see "Sub-Agent Spawning" section)
 - `plan` - Session-scoped planning tool for multi-step work externalization (no API key required)
 - `browser` - Web automation via Playwright with accessibility tree navigation (requires `playwright` package, see "Web Browsing" section)
+- `gpt_researcher` - Deep research via self-hosted GPT-Researcher instance (requires `websockets` package, see "GPT-Researcher" section)
 
 **Processors** - Channel-layer message transformers:
 - `file_persistence` - Saves all uploaded files to workspace uploads/ directory (no API key required)
@@ -1337,6 +1382,7 @@ builtins/
 │   ├── cron_manager.py  # Persistent YAML cron management (create/list/update/delete)
 │   ├── spawn.py      # Sub-agent spawning (spawn_agent, list, get_result, cancel)
 │   ├── browser.py    # Web automation with Playwright + accessibility tree
+│   ├── gpt_researcher.py  # Deep research via GPT-Researcher WebSocket API
 │   ├── _channel_context.py # Shared contextvars for channel/session state
 │   ├── send_message.py  # Mid-execution messaging
 │   ├── send_file.py     # Send workspace files to users

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Agents can ingest documents, browse the web, search the internet, and manage the
 
 **Browser automation** -- Playwright-driven web interaction via accessibility tree. Agents reference page elements by number, not CSS selectors.
 
+**Deep research** -- Integrate with a self-hosted GPT-Researcher instance for multi-source research reports with citations. Agents submit queries via WebSocket and receive comprehensive markdown reports.
+
 **Approval gates** -- Human-in-the-loop authorization for dangerous operations, with configurable timeouts and channel-native UI.
 
 **Multi-channel support** -- Connect agents to Telegram, Discord, or both simultaneously. Trigger-based activation lets agents respond to @mentions, keyword triggers, or both in group chats. On-demand context fetch gives agents awareness of recent channel history when triggered.

--- a/openpaw/builtins/loader.py
+++ b/openpaw/builtins/loader.py
@@ -40,6 +40,10 @@ class BuiltinLoader:
         "file_persistence": ["max_file_size", "clear_data_after_save"],
         "channel_history": ["max_messages_per_request", "content_truncation"],
         "md2pdf": ["theme", "max_diagram_width", "self_heal", "self_heal_model", "max_heal_iterations"],
+        "gpt_researcher": [
+            "endpoint", "upload_endpoint", "timeout_seconds",
+            "default_report_type", "default_report_source", "default_tone",
+        ],
     }
 
     def __init__(

--- a/openpaw/builtins/registry.py
+++ b/openpaw/builtins/registry.py
@@ -160,6 +160,13 @@ class BuiltinRegistry:
         except ImportError as e:
             logger.debug(f"Acknowledge tool not available: {e}")
 
+        try:
+            from openpaw.builtins.tools.gpt_researcher import GptResearcherTool
+
+            self.register_tool(GptResearcherTool)
+        except ImportError as e:
+            logger.debug(f"GPT-Researcher not available: {e}")
+
         # Processors (sorted by metadata.priority in BuiltinLoader.load_processors)
         try:
             from openpaw.builtins.processors.file_persistence import FilePersistenceProcessor

--- a/openpaw/builtins/tools/gpt_researcher.py
+++ b/openpaw/builtins/tools/gpt_researcher.py
@@ -1,0 +1,255 @@
+"""GPT-Researcher integration builtin.
+
+Provides agents with deep research capabilities via a self-hosted
+GPT-Researcher instance. Communicates over WebSocket for streaming
+research reports and REST for document uploads.
+"""
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import Any, Literal
+
+from langchain_core.tools import StructuredTool
+
+from openpaw.builtins.base import (
+    BaseBuiltinTool,
+    BuiltinMetadata,
+    BuiltinPrerequisite,
+    BuiltinType,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GptResearcherTool(BaseBuiltinTool):
+    """Deep research via a self-hosted GPT-Researcher instance.
+
+    Connects to a GPT-Researcher WebSocket API to submit research queries
+    and stream back full reports. Optionally supports uploading documents
+    for local-source research.
+
+    Config options:
+        endpoint: WebSocket endpoint URL (required)
+        upload_endpoint: REST upload endpoint URL (optional)
+        timeout_seconds: Max seconds to wait for research (default: 300)
+        default_report_type: Default report type (default: research_report)
+        default_report_source: Default report source (default: web)
+        default_tone: Default research tone (default: Objective)
+    """
+
+    metadata = BuiltinMetadata(
+        name="gpt_researcher",
+        display_name="GPT-Researcher",
+        description="Deep research via self-hosted GPT-Researcher instance",
+        builtin_type=BuiltinType.TOOL,
+        group="research",
+        prerequisites=BuiltinPrerequisite(packages=["websockets", "httpx"]),
+    )
+
+    def __init__(self, config: dict[str, Any] | None = None):
+        super().__init__(config)
+        self._endpoint: str = self.config.get("endpoint", "")
+        self._upload_endpoint: str = self.config.get("upload_endpoint", "")
+        self._timeout: int = self.config.get("timeout_seconds", 300)
+        self._default_report_type: str = self.config.get(
+            "default_report_type", "research_report"
+        )
+        self._default_report_source: str = self.config.get(
+            "default_report_source", "web"
+        )
+        self._default_tone: str = self.config.get("default_tone", "Objective")
+        self._workspace_path: Path | None = (
+            Path(self.config["workspace_path"])
+            if "workspace_path" in self.config
+            else None
+        )
+
+    async def _run_research(
+        self,
+        query: str,
+        report_type: Literal[
+            "research_report",
+            "outline_report",
+            "detailed_report",
+            "resource_report",
+        ] | None = None,
+        report_source: Literal["web", "local"] | None = None,
+        tone: Literal[
+            "Objective",
+            "Formal",
+            "Analytical",
+            "Persuasive",
+            "Informative",
+            "Explanatory",
+            "Descriptive",
+            "Critical",
+            "Comparative",
+            "Speculative",
+            "Reflective",
+            "Narrative",
+            "Humorous",
+            "Optimistic",
+            "Pessimistic",
+        ] | None = None,
+        source_urls: list[str] | None = None,
+        query_domains: list[str] | None = None,
+    ) -> str:
+        """Execute a research query via GPT-Researcher WebSocket API.
+
+        Args:
+            query: The research question or topic.
+            report_type: Type of report to generate.
+            report_source: Source for research. 'web' for internet, 'local' for uploaded docs.
+            tone: Writing tone for the report.
+            source_urls: Restrict research to these specific URLs.
+            query_domains: Restrict research to these domains.
+
+        Returns:
+            The full research report as markdown text.
+        """
+        import websockets
+
+        if not self._endpoint:
+            return "Error: GPT-Researcher endpoint not configured. Set endpoint in builtins.gpt_researcher.config."
+
+        payload = {
+            "task": query,
+            "report_type": report_type or self._default_report_type,
+            "report_source": report_source or self._default_report_source,
+            "tone": tone or self._default_tone,
+            "headers": {},
+            "source_urls": source_urls or [],
+            "document_urls": [],
+            "query_domains": query_domains or [],
+        }
+
+        report_chunks: list[str] = []
+
+        try:
+            async with websockets.connect(
+                self._endpoint, ping_interval=None
+            ) as ws:
+                await ws.send("start " + json.dumps(payload))
+
+                while True:
+                    try:
+                        msg = await asyncio.wait_for(
+                            ws.recv(), timeout=self._timeout
+                        )
+                        data = json.loads(msg)
+                        msg_type = data.get("type", "")
+
+                        if msg_type == "report":
+                            report_chunks.append(data.get("output", ""))
+                        elif msg_type == "path":
+                            break
+                        elif msg_type == "logs":
+                            log_msg = data.get("output", "")
+                            if log_msg:
+                                logger.debug(
+                                    f"GPT-Researcher progress: {log_msg}"
+                                )
+                    except TimeoutError:
+                        logger.warning(
+                            f"GPT-Researcher timed out after {self._timeout}s"
+                        )
+                        break
+        except websockets.exceptions.ConnectionClosedOK:
+            pass  # Server closed cleanly — return whatever was accumulated
+        except Exception as e:
+            logger.error(f"GPT-Researcher connection error: {e}")
+            return f"Error connecting to GPT-Researcher: {e}"
+
+        report = "".join(report_chunks)
+        if not report:
+            return "GPT-Researcher returned an empty report. Check the server logs for details."
+
+        return report
+
+    async def _upload_document(
+        self,
+        file_path: str,
+    ) -> str:
+        """Upload a workspace file to GPT-Researcher for local research.
+
+        After uploading, use the research tool with report_source='local'
+        to research against the uploaded document.
+
+        Args:
+            file_path: Path to the file within the workspace to upload.
+
+        Returns:
+            Upload status message.
+        """
+        import httpx
+
+        if not self._upload_endpoint:
+            return (
+                "Error: GPT-Researcher upload endpoint not configured. "
+                "Set upload_endpoint in builtins.gpt_researcher.config."
+            )
+
+        if not self._workspace_path:
+            return "Error: Workspace path not available."
+
+        from openpaw.agent.tools.sandbox import resolve_sandboxed_path
+
+        try:
+            resolved = resolve_sandboxed_path(self._workspace_path, file_path)
+        except ValueError as e:
+            return f"Error: {e}"
+
+        if not resolved.exists():
+            return f"Error: File not found: {file_path}"
+
+        try:
+            async with httpx.AsyncClient(timeout=60) as client:
+                with open(resolved, "rb") as f:
+                    response = await client.post(
+                        self._upload_endpoint,
+                        files={"file": (resolved.name, f)},
+                    )
+                response.raise_for_status()
+                return (
+                    f"Successfully uploaded '{resolved.name}' to GPT-Researcher. "
+                    "Use report_source='local' to research against uploaded documents."
+                )
+        except Exception as e:
+            logger.error(f"GPT-Researcher upload error: {e}")
+            return f"Error uploading file: {e}"
+
+    def get_langchain_tool(self) -> list[StructuredTool]:
+        """Return GPT-Researcher tools."""
+        tools: list[StructuredTool] = []
+
+        tools.append(
+            StructuredTool.from_function(
+                coroutine=self._run_research,
+                name="research",
+                description=(
+                    "Submit a deep research query to GPT-Researcher. "
+                    "Returns a comprehensive research report with citations. "
+                    "Use for questions that need thorough web research, "
+                    "literature review, or multi-source analysis. "
+                    "Reports take 1-5 minutes to generate."
+                ),
+            )
+        )
+
+        if self._upload_endpoint:
+            tools.append(
+                StructuredTool.from_function(
+                    coroutine=self._upload_document,
+                    name="upload_research_document",
+                    description=(
+                        "Upload a workspace file to GPT-Researcher for "
+                        "local document research. After uploading, call "
+                        "the research tool with report_source='local' to "
+                        "analyze the uploaded document(s)."
+                    ),
+                )
+            )
+
+        return tools

--- a/openpaw/core/config/models.py
+++ b/openpaw/core/config/models.py
@@ -283,6 +283,20 @@ class ChannelHistoryBuiltinConfig(BuiltinItemConfig):
     )
 
 
+class GptResearcherBuiltinConfig(BuiltinItemConfig):
+    """Configuration for the GPT-Researcher integration tool."""
+
+    endpoint: str = Field(default="", description="WebSocket endpoint URL (e.g., wss://researcher.example.com/ws)")
+    upload_endpoint: str = Field(default="", description="REST upload endpoint URL (e.g., https://researcher.example.com/upload/)")
+    timeout_seconds: int = Field(default=300, description="Max seconds to wait for research completion")
+    default_report_type: str = Field(
+        default="research_report",
+        description="Default report type: research_report, outline_report, detailed_report, resource_report",
+    )
+    default_report_source: str = Field(default="web", description="Default report source: web or local")
+    default_tone: str = Field(default="Objective", description="Default writing tone for reports")
+
+
 class FilePersistenceBuiltinConfig(BuiltinItemConfig):
     """Configuration for the file persistence processor."""
 
@@ -324,6 +338,7 @@ class BuiltinsConfig(BaseModel):
     file_persistence: FilePersistenceBuiltinConfig = Field(default_factory=FilePersistenceBuiltinConfig)
     md2pdf: Md2pdfBuiltinConfig = Field(default_factory=Md2pdfBuiltinConfig)
     channel_history: ChannelHistoryBuiltinConfig = Field(default_factory=ChannelHistoryBuiltinConfig)
+    gpt_researcher: GptResearcherBuiltinConfig = Field(default_factory=GptResearcherBuiltinConfig)
 
     model_config = {"extra": "allow"}
 
@@ -355,6 +370,7 @@ class WorkspaceBuiltinsConfig(BaseModel):
     file_persistence: FilePersistenceBuiltinConfig | None = None
     md2pdf: Md2pdfBuiltinConfig | None = None
     channel_history: ChannelHistoryBuiltinConfig | None = None
+    gpt_researcher: GptResearcherBuiltinConfig | None = None
 
     model_config = {"extra": "allow"}
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -7185,7 +7185,7 @@ description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"voice\" or extra == \"all-builtins\""
+markers = "extra == \"voice\" or extra == \"all-builtins\" or extra == \"researcher\""
 files = [
     {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b"},
     {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205"},
@@ -7724,12 +7724,13 @@ files = [
 cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and python_version < \"3.14\"", "cffi (>=2.0.0b) ; platform_python_implementation != \"PyPy\" and python_version >= \"3.14\""]
 
 [extras]
-all-builtins = ["elevenlabs", "langchain-community", "openai", "sqlite-vec"]
+all-builtins = ["elevenlabs", "httpx", "langchain-community", "openai", "sqlite-vec", "websockets"]
 memory = ["sqlite-vec"]
+researcher = ["httpx", "websockets"]
 voice = ["elevenlabs", "openai"]
 web = ["langchain-community"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "ab63be92f36a29c586bd77f00f22209f883f8046e23b6ffc2fd298b5865b2623"
+content-hash = "a2045244d211e4694222eb9c3937056212be21458bd804f0797ed507770432c9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,11 +45,17 @@ web = [
 memory = [
     "sqlite-vec (>=0.1.6)",  # Semantic search over conversation archives
 ]
+researcher = [
+    "websockets (>=12.0)",  # GPT-Researcher WebSocket streaming
+    "httpx (>=0.27.0)",     # GPT-Researcher file upload
+]
 all-builtins = [
     "openai (>=1.0.0)",
     "elevenlabs (>=1.0.0)",
     "langchain-community (>=0.4.0)",
     "sqlite-vec (>=0.1.6)",
+    "websockets (>=12.0)",
+    "httpx (>=0.27.0)",
 ]
 
 

--- a/tests/test_gpt_researcher.py
+++ b/tests/test_gpt_researcher.py
@@ -1,0 +1,710 @@
+"""Tests for GptResearcherTool builtin.
+
+Covers metadata, config extraction, tool creation, research execution (mocked
+WebSocket), and document upload (mocked httpx).
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from openpaw.builtins.base import BuiltinType
+from openpaw.builtins.tools.gpt_researcher import GptResearcherTool
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ws_messages(*payloads: dict) -> list[str]:
+    """Serialise a sequence of dicts to JSON strings (WebSocket message bodies)."""
+    return [json.dumps(p) for p in payloads]
+
+
+def _ws_mock(messages: list[str]) -> MagicMock:
+    """Return an async-context-manager mock that yields a WebSocket mock.
+
+    The WebSocket's ``recv()`` iterates through *messages* then raises
+    ``StopAsyncIteration`` (simulating connection close).
+    """
+    ws = AsyncMock()
+    ws.send = AsyncMock()
+
+    # Each call to recv() returns the next message, then ConnectionClosedOK.
+    recv_side_effects = list(messages)
+    import websockets.exceptions
+
+    recv_side_effects.append(
+        websockets.exceptions.ConnectionClosedOK(None, None)
+    )
+    ws.recv = AsyncMock(side_effect=recv_side_effects)
+
+    # Async context manager protocol.
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=ws)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def minimal_config() -> dict:
+    """Config with only the required endpoint set."""
+    return {"endpoint": "ws://localhost:8765"}
+
+
+@pytest.fixture
+def full_config(tmp_path: Path) -> dict:
+    """Config with all optional fields set, including upload endpoint."""
+    return {
+        "endpoint": "ws://localhost:8765",
+        "upload_endpoint": "http://localhost:8765/upload",
+        "timeout_seconds": 60,
+        "default_report_type": "detailed_report",
+        "default_report_source": "local",
+        "default_tone": "Analytical",
+        "workspace_path": str(tmp_path),
+    }
+
+
+@pytest.fixture
+def tool_minimal(minimal_config: dict) -> GptResearcherTool:
+    return GptResearcherTool(config=minimal_config)
+
+
+@pytest.fixture
+def tool_full(full_config: dict) -> GptResearcherTool:
+    return GptResearcherTool(config=full_config)
+
+
+# ---------------------------------------------------------------------------
+# TestMetadata
+# ---------------------------------------------------------------------------
+
+
+class TestMetadata:
+    """Verify the class-level metadata is correct."""
+
+    def test_name(self) -> None:
+        assert GptResearcherTool.metadata.name == "gpt_researcher"
+
+    def test_display_name(self) -> None:
+        assert GptResearcherTool.metadata.display_name == "GPT-Researcher"
+
+    def test_builtin_type_is_tool(self) -> None:
+        assert GptResearcherTool.metadata.builtin_type == BuiltinType.TOOL
+
+    def test_group_is_research(self) -> None:
+        assert GptResearcherTool.metadata.group == "research"
+
+    def test_prerequisite_package_is_websockets(self) -> None:
+        assert "websockets" in GptResearcherTool.metadata.prerequisites.packages
+
+    def test_no_env_var_prerequisites(self) -> None:
+        """No API key should be required."""
+        assert GptResearcherTool.metadata.prerequisites.env_vars == []
+
+
+# ---------------------------------------------------------------------------
+# TestConfig
+# ---------------------------------------------------------------------------
+
+
+class TestConfig:
+    """Verify config values are correctly extracted during __init__."""
+
+    def test_endpoint_extracted(self, tool_minimal: GptResearcherTool) -> None:
+        assert tool_minimal._endpoint == "ws://localhost:8765"
+
+    def test_upload_endpoint_defaults_to_empty_string(
+        self, tool_minimal: GptResearcherTool
+    ) -> None:
+        assert tool_minimal._upload_endpoint == ""
+
+    def test_upload_endpoint_extracted(self, tool_full: GptResearcherTool) -> None:
+        assert tool_full._upload_endpoint == "http://localhost:8765/upload"
+
+    def test_timeout_defaults_to_300(self, tool_minimal: GptResearcherTool) -> None:
+        assert tool_minimal._timeout == 300
+
+    def test_timeout_overridden(self, tool_full: GptResearcherTool) -> None:
+        assert tool_full._timeout == 60
+
+    def test_default_report_type_defaults(self, tool_minimal: GptResearcherTool) -> None:
+        assert tool_minimal._default_report_type == "research_report"
+
+    def test_default_report_type_overridden(self, tool_full: GptResearcherTool) -> None:
+        assert tool_full._default_report_type == "detailed_report"
+
+    def test_default_report_source_defaults(self, tool_minimal: GptResearcherTool) -> None:
+        assert tool_minimal._default_report_source == "web"
+
+    def test_default_report_source_overridden(self, tool_full: GptResearcherTool) -> None:
+        assert tool_full._default_report_source == "local"
+
+    def test_default_tone_defaults(self, tool_minimal: GptResearcherTool) -> None:
+        assert tool_minimal._default_tone == "Objective"
+
+    def test_default_tone_overridden(self, tool_full: GptResearcherTool) -> None:
+        assert tool_full._default_tone == "Analytical"
+
+    def test_workspace_path_none_when_absent(self, tool_minimal: GptResearcherTool) -> None:
+        assert tool_minimal._workspace_path is None
+
+    def test_workspace_path_extracted_as_path(
+        self, tool_full: GptResearcherTool, full_config: dict
+    ) -> None:
+        assert tool_full._workspace_path == Path(full_config["workspace_path"])
+
+    def test_no_config_uses_all_defaults(self) -> None:
+        tool = GptResearcherTool()
+        assert tool._endpoint == ""
+        assert tool._upload_endpoint == ""
+        assert tool._timeout == 300
+        assert tool._default_report_type == "research_report"
+        assert tool._default_report_source == "web"
+        assert tool._default_tone == "Objective"
+        assert tool._workspace_path is None
+
+
+# ---------------------------------------------------------------------------
+# TestToolCreation
+# ---------------------------------------------------------------------------
+
+
+class TestToolCreation:
+    """Verify get_langchain_tool() returns the right structure."""
+
+    def test_returns_list(self, tool_minimal: GptResearcherTool) -> None:
+        tools = tool_minimal.get_langchain_tool()
+        assert isinstance(tools, list)
+
+    def test_one_tool_without_upload_endpoint(
+        self, tool_minimal: GptResearcherTool
+    ) -> None:
+        tools = tool_minimal.get_langchain_tool()
+        assert len(tools) == 1
+
+    def test_two_tools_with_upload_endpoint(
+        self, tool_full: GptResearcherTool
+    ) -> None:
+        tools = tool_full.get_langchain_tool()
+        assert len(tools) == 2
+
+    def test_research_tool_name(self, tool_minimal: GptResearcherTool) -> None:
+        tools = tool_minimal.get_langchain_tool()
+        assert tools[0].name == "research"
+
+    def test_upload_tool_name(self, tool_full: GptResearcherTool) -> None:
+        tools = tool_full.get_langchain_tool()
+        names = {t.name for t in tools}
+        assert "upload_research_document" in names
+
+    def test_research_tool_has_description(self, tool_minimal: GptResearcherTool) -> None:
+        tools = tool_minimal.get_langchain_tool()
+        research_tool = tools[0]
+        assert research_tool.description
+        assert len(research_tool.description) > 20
+
+    def test_upload_tool_has_description(self, tool_full: GptResearcherTool) -> None:
+        tools = tool_full.get_langchain_tool()
+        upload_tool = next(t for t in tools if t.name == "upload_research_document")
+        assert upload_tool.description
+        assert len(upload_tool.description) > 20
+
+    def test_upload_tool_absent_without_endpoint(
+        self, tool_minimal: GptResearcherTool
+    ) -> None:
+        tools = tool_minimal.get_langchain_tool()
+        names = {t.name for t in tools}
+        assert "upload_research_document" not in names
+
+
+# ---------------------------------------------------------------------------
+# TestResearchExecution
+# ---------------------------------------------------------------------------
+
+
+class TestResearchExecution:
+    """Test _run_research via mocked WebSocket connection."""
+
+    @pytest.mark.asyncio
+    async def test_successful_research_returns_report(
+        self, tool_minimal: GptResearcherTool
+    ) -> None:
+        messages = _make_ws_messages(
+            {"type": "logs", "output": "Searching the web..."},
+            {"type": "report", "output": "# AI Landscape\n\n"},
+            {"type": "report", "output": "Big models are everywhere."},
+            {"type": "path", "output": "/tmp/report.pdf"},
+        )
+
+        with patch(
+            "websockets.connect", return_value=_ws_mock(messages)
+        ):
+            result = await tool_minimal._run_research("AI landscape 2025")
+
+        assert "AI Landscape" in result
+        assert "Big models are everywhere." in result
+
+    @pytest.mark.asyncio
+    async def test_report_chunks_are_concatenated(
+        self, tool_minimal: GptResearcherTool
+    ) -> None:
+        messages = _make_ws_messages(
+            {"type": "report", "output": "Part one. "},
+            {"type": "report", "output": "Part two. "},
+            {"type": "report", "output": "Part three."},
+            {"type": "path", "output": "/tmp/report.pdf"},
+        )
+
+        with patch(
+            "websockets.connect", return_value=_ws_mock(messages)
+        ):
+            result = await tool_minimal._run_research("Some query")
+
+        assert result == "Part one. Part two. Part three."
+
+    @pytest.mark.asyncio
+    async def test_path_message_stops_iteration(
+        self, tool_minimal: GptResearcherTool
+    ) -> None:
+        """Messages after 'path' should not be processed."""
+        messages = _make_ws_messages(
+            {"type": "report", "output": "Final report."},
+            {"type": "path", "output": "/tmp/report.pdf"},
+            # This message arrives after path — should be ignored.
+            {"type": "report", "output": "SHOULD NOT APPEAR"},
+        )
+
+        with patch(
+            "websockets.connect", return_value=_ws_mock(messages)
+        ):
+            result = await tool_minimal._run_research("query")
+
+        assert "SHOULD NOT APPEAR" not in result
+        assert "Final report." in result
+
+    @pytest.mark.asyncio
+    async def test_empty_report_returns_error_message(
+        self, tool_minimal: GptResearcherTool
+    ) -> None:
+        """A path message with no preceding report chunks should surface cleanly."""
+        messages = _make_ws_messages(
+            {"type": "logs", "output": "Starting..."},
+            {"type": "path", "output": "/tmp/report.pdf"},
+        )
+
+        with patch(
+            "websockets.connect", return_value=_ws_mock(messages)
+        ):
+            result = await tool_minimal._run_research("empty query")
+
+        assert "empty report" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_endpoint_returns_error(self) -> None:
+        """No endpoint configured should return a helpful error immediately."""
+        tool = GptResearcherTool(config={})
+
+        result = await tool._run_research("some query")
+
+        assert "Error" in result
+        assert "endpoint" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_connection_error_returns_error_string(
+        self, tool_minimal: GptResearcherTool
+    ) -> None:
+        with patch(
+            "websockets.connect",
+            side_effect=OSError("Connection refused"),
+        ):
+            result = await tool_minimal._run_research("query")
+
+        assert "Error" in result
+        assert "GPT-Researcher" in result
+
+    @pytest.mark.asyncio
+    async def test_timeout_breaks_loop_and_returns_partial_report(
+        self, tool_minimal: GptResearcherTool
+    ) -> None:
+        """asyncio.TimeoutError on recv() should break the loop; partial
+        content accumulated before the timeout is returned."""
+        ws = AsyncMock()
+        ws.send = AsyncMock()
+
+        call_count = 0
+
+        async def recv_with_timeout():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return json.dumps({"type": "report", "output": "Partial content."})
+            raise TimeoutError()
+
+        ws.recv = recv_with_timeout
+
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=ws)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("websockets.connect", return_value=cm):
+            result = await tool_minimal._run_research("slow query")
+
+        assert "Partial content." in result
+
+    @pytest.mark.asyncio
+    async def test_payload_includes_query_as_task(
+        self, tool_minimal: GptResearcherTool
+    ) -> None:
+        """Verify the WebSocket send payload contains the query as 'task'."""
+        captured_payload: dict = {}
+
+        ws = AsyncMock()
+
+        async def capture_send(data: str) -> None:
+            prefix, payload_json = data.split(" ", 1)
+            captured_payload.update(json.loads(payload_json))
+
+        ws.send = capture_send
+        ws.recv = AsyncMock(
+            side_effect=[
+                json.dumps({"type": "path", "output": "/tmp/r.pdf"}),
+            ]
+        )
+
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=ws)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("websockets.connect", return_value=cm):
+            await tool_minimal._run_research("quantum computing")
+
+        assert captured_payload.get("task") == "quantum computing"
+
+    @pytest.mark.asyncio
+    async def test_payload_uses_default_report_type(
+        self, tool_minimal: GptResearcherTool
+    ) -> None:
+        captured_payload: dict = {}
+
+        ws = AsyncMock()
+
+        async def capture_send(data: str) -> None:
+            _, payload_json = data.split(" ", 1)
+            captured_payload.update(json.loads(payload_json))
+
+        ws.send = capture_send
+        ws.recv = AsyncMock(
+            side_effect=[json.dumps({"type": "path", "output": "/tmp/r.pdf"})]
+        )
+
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=ws)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("websockets.connect", return_value=cm):
+            await tool_minimal._run_research("query")
+
+        assert captured_payload.get("report_type") == "research_report"
+
+    @pytest.mark.asyncio
+    async def test_explicit_report_type_overrides_default(
+        self, tool_minimal: GptResearcherTool
+    ) -> None:
+        captured_payload: dict = {}
+
+        ws = AsyncMock()
+
+        async def capture_send(data: str) -> None:
+            _, payload_json = data.split(" ", 1)
+            captured_payload.update(json.loads(payload_json))
+
+        ws.send = capture_send
+        ws.recv = AsyncMock(
+            side_effect=[json.dumps({"type": "path", "output": "/tmp/r.pdf"})]
+        )
+
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=ws)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("websockets.connect", return_value=cm):
+            await tool_minimal._run_research(
+                "query", report_type="outline_report"
+            )
+
+        assert captured_payload.get("report_type") == "outline_report"
+
+    @pytest.mark.asyncio
+    async def test_source_urls_included_in_payload(
+        self, tool_minimal: GptResearcherTool
+    ) -> None:
+        captured_payload: dict = {}
+
+        ws = AsyncMock()
+
+        async def capture_send(data: str) -> None:
+            _, payload_json = data.split(" ", 1)
+            captured_payload.update(json.loads(payload_json))
+
+        ws.send = capture_send
+        ws.recv = AsyncMock(
+            side_effect=[json.dumps({"type": "path", "output": "/tmp/r.pdf"})]
+        )
+
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=ws)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        urls = ["https://example.com", "https://docs.python.org"]
+        with patch("websockets.connect", return_value=cm):
+            await tool_minimal._run_research("query", source_urls=urls)
+
+        assert captured_payload.get("source_urls") == urls
+
+    @pytest.mark.asyncio
+    async def test_logs_messages_do_not_appear_in_report(
+        self, tool_minimal: GptResearcherTool
+    ) -> None:
+        messages = _make_ws_messages(
+            {"type": "logs", "output": "DEBUG: internal log detail"},
+            {"type": "report", "output": "Clean report text."},
+            {"type": "path", "output": "/tmp/report.pdf"},
+        )
+
+        with patch(
+            "websockets.connect", return_value=_ws_mock(messages)
+        ):
+            result = await tool_minimal._run_research("query")
+
+        assert "DEBUG: internal log detail" not in result
+        assert "Clean report text." in result
+
+
+# ---------------------------------------------------------------------------
+# TestDocumentUpload
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentUpload:
+    """Test _upload_document via mocked httpx."""
+
+    @pytest.mark.asyncio
+    async def test_missing_upload_endpoint_returns_error(
+        self, tool_minimal: GptResearcherTool
+    ) -> None:
+        """Tool without upload_endpoint should return a config error."""
+        result = await tool_minimal._upload_document("report.pdf")
+
+        assert "Error" in result
+        assert "upload_endpoint" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_workspace_path_returns_error(self) -> None:
+        """upload_endpoint present but no workspace_path should error."""
+        tool = GptResearcherTool(
+            config={"upload_endpoint": "http://localhost/upload"}
+        )
+        result = await tool._upload_document("file.pdf")
+
+        assert "Error" in result
+        assert "workspace" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_successful_upload(self, tmp_path: Path) -> None:
+        """Happy path: file exists, HTTP 200 → success message."""
+        sample_file = tmp_path / "paper.pdf"
+        sample_file.write_bytes(b"%PDF-1.4 content")
+
+        tool = GptResearcherTool(
+            config={
+                "upload_endpoint": "http://localhost:8765/upload",
+                "workspace_path": str(tmp_path),
+            }
+        )
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await tool._upload_document("paper.pdf")
+
+        assert "Successfully uploaded" in result
+        assert "paper.pdf" in result
+        assert "local" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_file_not_found_returns_error(self, tmp_path: Path) -> None:
+        tool = GptResearcherTool(
+            config={
+                "upload_endpoint": "http://localhost/upload",
+                "workspace_path": str(tmp_path),
+            }
+        )
+
+        result = await tool._upload_document("nonexistent.pdf")
+
+        assert "Error" in result
+        assert "not found" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_http_error_returns_error_string(self, tmp_path: Path) -> None:
+        """HTTP errors from the server should surface as user-friendly strings."""
+        sample_file = tmp_path / "report.pdf"
+        sample_file.write_bytes(b"content")
+
+        tool = GptResearcherTool(
+            config={
+                "upload_endpoint": "http://localhost/upload",
+                "workspace_path": str(tmp_path),
+            }
+        )
+
+        import httpx
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        http_error = httpx.HTTPStatusError(
+            "500 Internal Server Error",
+            request=MagicMock(),
+            response=mock_response,
+        )
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=http_error)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await tool._upload_document("report.pdf")
+
+        assert "Error" in result
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_rejected(self, tmp_path: Path) -> None:
+        """Path traversal attempts must be caught by sandbox validation."""
+        tool = GptResearcherTool(
+            config={
+                "upload_endpoint": "http://localhost/upload",
+                "workspace_path": str(tmp_path),
+            }
+        )
+
+        result = await tool._upload_document("../etc/passwd")
+
+        assert "Error" in result
+
+    @pytest.mark.asyncio
+    async def test_absolute_path_rejected(self, tmp_path: Path) -> None:
+        """Absolute paths must be rejected by sandbox validation."""
+        tool = GptResearcherTool(
+            config={
+                "upload_endpoint": "http://localhost/upload",
+                "workspace_path": str(tmp_path),
+            }
+        )
+
+        result = await tool._upload_document("/etc/passwd")
+
+        assert "Error" in result
+
+    @pytest.mark.asyncio
+    async def test_upload_sends_file_to_correct_endpoint(
+        self, tmp_path: Path
+    ) -> None:
+        """Verify the POST goes to the configured upload_endpoint."""
+        sample_file = tmp_path / "data.txt"
+        sample_file.write_text("data content")
+
+        upload_url = "http://myresearcher.internal/v1/upload"
+        tool = GptResearcherTool(
+            config={
+                "upload_endpoint": upload_url,
+                "workspace_path": str(tmp_path),
+            }
+        )
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            await tool._upload_document("data.txt")
+
+        mock_client.post.assert_called_once()
+        call_args = mock_client.post.call_args
+        assert call_args[0][0] == upload_url
+
+    @pytest.mark.asyncio
+    async def test_upload_uses_filename_as_form_key(self, tmp_path: Path) -> None:
+        """The multipart POST should use ``file`` as the form field name."""
+        sample_file = tmp_path / "notes.txt"
+        sample_file.write_text("notes")
+
+        tool = GptResearcherTool(
+            config={
+                "upload_endpoint": "http://localhost/upload",
+                "workspace_path": str(tmp_path),
+            }
+        )
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            await tool._upload_document("notes.txt")
+
+        call_kwargs = mock_client.post.call_args[1]
+        assert "files" in call_kwargs
+        assert "file" in call_kwargs["files"]
+
+    @pytest.mark.asyncio
+    async def test_upload_from_subdirectory(self, tmp_path: Path) -> None:
+        """Files nested in workspace subdirectories should be uploadable."""
+        subdir = tmp_path / "reports"
+        subdir.mkdir()
+        sample_file = subdir / "q4.pdf"
+        sample_file.write_bytes(b"%PDF content")
+
+        tool = GptResearcherTool(
+            config={
+                "upload_endpoint": "http://localhost/upload",
+                "workspace_path": str(tmp_path),
+            }
+        )
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await tool._upload_document("reports/q4.pdf")
+
+        assert "Error" not in result
+        assert "q4.pdf" in result

--- a/tests/test_gpt_researcher.py
+++ b/tests/test_gpt_researcher.py
@@ -13,6 +13,20 @@ import pytest
 from openpaw.builtins.base import BuiltinType
 from openpaw.builtins.tools.gpt_researcher import GptResearcherTool
 
+try:
+    import websockets.exceptions as _ws_exc
+
+    _has_websockets = True
+except ImportError:
+    _has_websockets = False
+
+try:
+    import httpx as _httpx  # noqa: F401
+
+    _has_httpx = True
+except ImportError:
+    _has_httpx = False
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -34,10 +48,8 @@ def _ws_mock(messages: list[str]) -> MagicMock:
 
     # Each call to recv() returns the next message, then ConnectionClosedOK.
     recv_side_effects = list(messages)
-    import websockets.exceptions
-
     recv_side_effects.append(
-        websockets.exceptions.ConnectionClosedOK(None, None)
+        _ws_exc.ConnectionClosedOK(None, None)  # type: ignore[union-attr]
     )
     ws.recv = AsyncMock(side_effect=recv_side_effects)
 
@@ -231,6 +243,7 @@ class TestToolCreation:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(not _has_websockets, reason="websockets not installed")
 class TestResearchExecution:
     """Test _run_research via mocked WebSocket connection."""
 
@@ -494,6 +507,7 @@ class TestResearchExecution:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(not _has_httpx, reason="httpx not installed")
 class TestDocumentUpload:
     """Test _upload_document via mocked httpx."""
 


### PR DESCRIPTION
New optional builtin tool integrating with self-hosted GPT-Researcher instances. Provides research and upload_research_document tools with Literal-typed parameters for report_type, report_source, and tone to ensure valid values in tool schemas.

- WebSocket streaming with ConnectionClosedOK graceful handling
- REST file upload with sandbox path validation
- Configurable endpoint, timeout, defaults via GptResearcherBuiltinConfig
- Optional deps: websockets, httpx (poetry install --extras researcher)
- 50 unit tests covering metadata, config, execution, and upload paths