### PR TITLE
feat: email builtin with Gmail provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -946,6 +946,61 @@ poetry install --extras researcher
 - Agent calls `research(query="WebAssembly adoption in server-side applications", report_type="detailed_report")`
 - GPT-Researcher streams progress logs, then returns full report with citations
 
+### Email Integration
+
+Agents can send and receive email via the `email` builtin. All 8 tools cover the full email workflow — from listing inbox messages to replying and downloading attachments. Only Gmail (via Google service account + domain-wide delegation) is supported in this release.
+
+**Available Tools**:
+- `send_email` - Send an email to one or more recipients with optional file attachments
+- `check_email` - List recent messages from a Gmail label (default: INBOX)
+- `get_email` - Retrieve the full content of a message by ID (body, headers, attachment metadata)
+- `search_email` - Search messages using Gmail search syntax (`from:`, `subject:`, `is:unread`, etc.)
+- `reply_email` - Reply to an existing thread (automatically sets In-Reply-To and References headers)
+- `download_attachment` - Download an email attachment and save it to `downloads/email/` in the workspace
+- `mark_as_read` - Remove the UNREAD label from a message
+- `mark_as_unread` - Add the UNREAD label to a message
+
+**Security Model**: `RecipientPolicy` validates all outbound recipients (to, cc, bcc) against a glob allowlist before any email is sent. An **empty `allowed_recipients` list blocks ALL outbound email** — this is the safe default. Configure the allowlist explicitly before agents can send. `max_recipients` caps the number of addresses per message (default: 10).
+
+**Configuration** (in `agent.yaml` or global config):
+
+```yaml
+builtins:
+  email:
+    enabled: true
+    config:
+      provider: gmail                                    # Only "gmail" is supported
+      service_account_file: config/service-account.json # Relative to workspace root
+      delegated_user: agent@yourdomain.com               # Email to impersonate via domain-wide delegation
+      allowed_recipients:                                # Empty = block all sends (safe default)
+        - "*@yourdomain.com"
+        - "partner@external.com"
+      max_recipients: 10                                 # Max recipients per outbound message
+```
+
+**Prerequisites**: Requires optional Google API packages:
+
+```bash
+poetry install --extras email
+```
+
+**Provider Setup**:
+1. Create a Google Cloud service account with a JSON key file
+2. Enable the Gmail API in your Google Cloud project
+3. Configure domain-wide delegation on the service account
+4. Grant the service account the `https://www.googleapis.com/auth/gmail.modify` OAuth scope
+5. Set `service_account_file` (workspace-relative path) and `delegated_user` in config
+
+**Attachment Handling**: `send_email` and `reply_email` accept `attachment_paths` — workspace-relative file paths validated through the sandbox. Downloaded attachments are saved to `downloads/email/` with deduplicated filenames. The workspace-relative path is returned for immediate `read_file()` access.
+
+**Example Usage** (by agent):
+- User: "Check my inbox and summarize the unread messages"
+- Agent calls `check_email(label="INBOX", max_results=20)`
+- Agent calls `search_email(query="is:unread")` to narrow to unread
+- Agent calls `get_email(message_id="...")` to read a specific message
+- User: "Reply to that invoice email and attach the signed PDF"
+- Agent calls `reply_email(message_id="...", body="...", attachment_paths=["uploads/invoice-signed.pdf"])`
+
 ### Sub-Agent Spawning
 
 Agents can spawn background workers for concurrent task execution using the `spawn` builtin. Sub-agents run in isolated contexts with filtered tools to prevent recursion and unsolicited messaging.
@@ -1363,6 +1418,7 @@ OpenPaw provides optional built-in capabilities that are conditionally available
 - `plan` - Session-scoped planning tool for multi-step work externalization (no API key required)
 - `browser` - Web automation via Playwright with accessibility tree navigation (requires `playwright` package, see "Web Browsing" section)
 - `gpt_researcher` - Deep research via self-hosted GPT-Researcher instance (requires `websockets` package, see "GPT-Researcher" section)
+- `email` - Send and receive email via Gmail service account (requires `email` extras, see "Email Integration" section)
 
 **Processors** - Channel-layer message transformers:
 - `file_persistence` - Saves all uploaded files to workspace uploads/ directory (no API key required)
@@ -1383,6 +1439,10 @@ builtins/
 │   ├── spawn.py      # Sub-agent spawning (spawn_agent, list, get_result, cancel)
 │   ├── browser.py    # Web automation with Playwright + accessibility tree
 │   ├── gpt_researcher.py  # Deep research via GPT-Researcher WebSocket API
+│   ├── email/        # Email integration (send/receive via Gmail service account)
+│   │   ├── __init__.py    # EmailToolBuiltin + 8 tools
+│   │   ├── base.py        # EmailProvider ABC, EmailMessage, RecipientPolicy
+│   │   └── gmail.py       # GmailProvider (service account + domain-wide delegation)
 │   ├── _channel_context.py # Shared contextvars for channel/session state
 │   ├── send_message.py  # Mid-execution messaging
 │   ├── send_file.py     # Send workspace files to users

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Agents can ingest documents, browse the web, search the internet, and manage the
 
 **Browser automation** -- Playwright-driven web interaction via accessibility tree. Agents reference page elements by number, not CSS selectors.
 
+**Email integration** -- Send and receive email via Gmail with safe-by-default recipient policies. Read inbox, search, reply with threading, and manage attachments.
+
 **Deep research** -- Integrate with a self-hosted GPT-Researcher instance for multi-source research reports with citations. Agents submit queries via WebSocket and receive comprehensive markdown reports.
 
 **Approval gates** -- Human-in-the-loop authorization for dangerous operations, with configurable timeouts and channel-native UI.
@@ -153,7 +155,7 @@ Once running, agents respond to framework commands in chat:
 - [Configuration](docs/configuration.md) -- Global and per-workspace configuration reference
 - [Workspaces](docs/workspaces.md) -- Workspace structure, identity files, and custom tools
 - [Scheduling](docs/scheduling.md) -- Cron jobs, heartbeats, and dynamic scheduling
-- [Built-ins](docs/builtins.md) -- Web search, browser automation, voice, sub-agents, and more
+- [Built-ins](docs/builtins.md) -- Web search, browser automation, email, voice, sub-agents, and more
 - [Channels](docs/channels.md) -- Channel adapters and access control
 - [Queue System](docs/queue-system.md) -- Queue modes and message handling
 - [Architecture](docs/architecture.md) -- System design, data flows, and architectural decisions

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -118,6 +118,19 @@ builtins:
   #     max_concurrent: 8           # Maximum simultaneous sub-agents
   #     default_progress_interval: 0  # Minutes between progress updates (0 = disabled)
 
+  # Email integration — send and receive email via Gmail service account
+  # (requires: poetry install --extras email)
+  # email:
+  #   enabled: true
+  #   config:
+  #     provider: gmail
+  #     service_account_file: config/service-account.json  # Relative to workspace root
+  #     delegated_user: agent@yourdomain.com               # Email to impersonate (domain-wide delegation)
+  #     allowed_recipients:                                 # Empty = block all sends (safe default)
+  #       - "*@yourdomain.com"
+  #       - "partner@external.com"
+  #     max_recipients: 10                                  # Max recipients per outbound message
+
   # Browser automation via Playwright with accessibility tree navigation
   # (requires: poetry add playwright && poetry run playwright install chromium)
   # browser:

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -8,14 +8,15 @@ Builtins are optional capabilities conditionally loaded based on API key availab
 
 ## Overview
 
-OpenPaw ships with 15 built-in tools and 4 message processors. Builtins are discovered at runtime — if prerequisites (API keys, packages) are missing, the builtin is unavailable. The allow/deny system provides fine-grained control over which capabilities are active in each workspace.
+OpenPaw ships with 16 built-in tools and 4 message processors. Builtins are discovered at runtime — if prerequisites (API keys, packages) are missing, the builtin is unavailable. The allow/deny system provides fine-grained control over which capabilities are active in each workspace.
 
 **Architecture:**
 
 ```
 BuiltinRegistry
-├─ Tools (15)
+├─ Tools (16)
 │  ├─ browser          Web automation via Playwright
+│  ├─ email            Email send/receive via Gmail
 │  ├─ brave_search     Web search
 │  ├─ spawn            Sub-agent spawning
 │  ├─ cron             Agent self-scheduling
@@ -664,6 +665,78 @@ To find voice IDs, visit the [ElevenLabs Voice Library](https://elevenlabs.io/vo
 
 ---
 
+### email
+
+**Group:** `communication`
+**Type:** Tool (8 functions)
+**Prerequisites:** `poetry install --extras email` (google-auth, google-api-python-client)
+
+Send and receive email via Google service account with domain-wide delegation. Designed with an abstract provider interface for future SMTP/SES support.
+
+**Security Model:**
+
+The email builtin enforces a **safe-by-default** outbound policy via `RecipientPolicy`:
+- An **empty `allowed_recipients` list blocks ALL outbound email** — sending must be explicitly enabled
+- Recipient patterns use fnmatch glob syntax (e.g., `*@company.com`)
+- All recipients (to, cc, bcc) are validated before sending
+- Max recipients per message is configurable (default: 10)
+
+**Available Functions:**
+- `send_email` — Send email with recipient policy validation and optional file attachments
+- `check_email` — List recent messages from a Gmail label (default: INBOX)
+- `get_email` — Retrieve full content of a specific email by message ID
+- `search_email` — Search using Gmail query syntax (from:, subject:, is:unread, etc.)
+- `reply_email` — Reply to an email thread with proper In-Reply-To/References headers
+- `download_attachment` — Download email attachment to workspace `downloads/email/`
+- `mark_as_read` — Remove UNREAD label from a message
+- `mark_as_unread` — Add UNREAD label to a message
+
+**Configuration:**
+
+```yaml
+builtins:
+  email:
+    enabled: true
+    config:
+      provider: gmail
+      service_account_file: config/service-account.json  # Relative to workspace root
+      delegated_user: agent@yourdomain.com
+      allowed_recipients:                     # Empty = block all sends (safe default)
+        - "*@yourdomain.com"
+        - "partner@external.com"
+      max_recipients: 10
+```
+
+**Provider Setup (Gmail):**
+
+1. Create a Google Cloud project with Gmail API enabled
+2. Create a service account and download the JSON key file
+3. Enable domain-wide delegation on the service account
+4. In Google Workspace Admin, authorize the service account with scopes:
+   - `https://www.googleapis.com/auth/gmail.readonly`
+   - `https://www.googleapis.com/auth/gmail.send`
+   - `https://www.googleapis.com/auth/gmail.modify`
+5. Place the JSON key file in your workspace (e.g., `config/service-account.json`)
+6. Set `delegated_user` to the email address the agent should impersonate
+
+**Usage Example:**
+
+```
+User: "Check my email for anything from Alice"
+Agent: [Calls search_email(query="from:alice@example.com")]
+Agent: "Found 3 emails from Alice. The most recent is about the Q4 report..."
+
+User: "Download the PDF attachment from that email"
+Agent: [Calls download_attachment(message_id="...", attachment_id="...", filename="q4-report.pdf")]
+Agent: "Saved to downloads/email/q4-report.pdf"
+
+User: "Reply and tell her I'll review it by Friday"
+Agent: [Calls reply_email(message_id="...", body="Thanks Alice, I'll review the Q4 report by Friday.")]
+Agent: "Reply sent to alice@example.com"
+```
+
+---
+
 ### status_reminder
 
 **Group:** `agent`
@@ -974,6 +1047,7 @@ builtins:
 | `agent` | spawn, cron, task_tracker, send_message, followup, send_file |
 | `automation` | cron_manager, acknowledge |
 | `browser` | browser |
+| `communication` | email |
 | `memory` | memory_search |
 | `document` | md2pdf |
 
@@ -1010,6 +1084,12 @@ Installs: `langchain-community`
 poetry install -E memory
 ```
 Installs: `sqlite-vec`
+
+**Email capabilities:**
+```bash
+poetry install -E email
+```
+Installs: `google-auth`, `google-api-python-client`
 
 **All optional builtins:**
 ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,6 +88,16 @@ builtins:
     config:
       max_file_size: 52428800  # 50 MB
       clear_data_after_save: false
+
+  # email:
+  #   enabled: true
+  #   config:
+  #     provider: gmail
+  #     service_account_file: config/service-account.json
+  #     delegated_user: agent@yourdomain.com
+  #     allowed_recipients:
+  #       - "*@yourdomain.com"
+  #     max_recipients: 10
 ```
 
 ### Configuration Sections
@@ -609,6 +619,7 @@ These are automatically loaded via `python-dotenv` when the workspace starts.
 - `BRAVE_API_KEY` — Web search capability
 - `OPENAI_API_KEY` — Whisper audio transcription (also used for GPT models)
 - `ELEVENLABS_API_KEY` — Text-to-speech
+- Google service account JSON file — Email integration (see [Builtins - Email](builtins.md#email))
 
 ---
 

--- a/openpaw/builtins/loader.py
+++ b/openpaw/builtins/loader.py
@@ -206,12 +206,6 @@ class BuiltinLoader:
                 if allowed_users:
                     config["default_target_id"] = allowed_users[0]
 
-        # Resolve service_account_file relative to workspace for email tool
-        if name == "email":
-            sa_file = config.get("service_account_file")
-            if sa_file and self.workspace_path and not Path(sa_file).is_absolute():
-                config["service_account_file"] = str(self.workspace_path / sa_file)
-
         # Inject channel routing config for send_message tool
         if name == "send_message" and self.channel_config:
             channel_type = self.channel_config.get("type", "telegram")
@@ -233,6 +227,12 @@ class BuiltinLoader:
             cfg_dict = self._get_field(workspace_cfg, "config")
             if cfg_dict:
                 config.update(cfg_dict)
+
+        # Post-merge: resolve service_account_file relative to workspace
+        if name == "email":
+            sa_file = config.get("service_account_file")
+            if sa_file and self.workspace_path and not Path(sa_file).is_absolute():
+                config["service_account_file"] = str(self.workspace_path / sa_file)
 
         return config
 

--- a/openpaw/builtins/loader.py
+++ b/openpaw/builtins/loader.py
@@ -44,6 +44,10 @@ class BuiltinLoader:
             "endpoint", "upload_endpoint", "timeout_seconds",
             "default_report_type", "default_report_source", "default_tone",
         ],
+        "email": [
+            "provider", "service_account_file", "delegated_user",
+            "allowed_recipients", "max_recipients",
+        ],
     }
 
     def __init__(
@@ -201,6 +205,12 @@ class BuiltinLoader:
                 allowed_users = self.channel_config.get("allowed_users", [])
                 if allowed_users:
                     config["default_target_id"] = allowed_users[0]
+
+        # Resolve service_account_file relative to workspace for email tool
+        if name == "email":
+            sa_file = config.get("service_account_file")
+            if sa_file and self.workspace_path and not Path(sa_file).is_absolute():
+                config["service_account_file"] = str(self.workspace_path / sa_file)
 
         # Inject channel routing config for send_message tool
         if name == "send_message" and self.channel_config:

--- a/openpaw/builtins/registry.py
+++ b/openpaw/builtins/registry.py
@@ -167,6 +167,13 @@ class BuiltinRegistry:
         except ImportError as e:
             logger.debug(f"GPT-Researcher not available: {e}")
 
+        try:
+            from openpaw.builtins.tools.email import EmailToolBuiltin
+
+            self.register_tool(EmailToolBuiltin)
+        except ImportError as e:
+            logger.debug(f"Email tool not available: {e}")
+
         # Processors (sorted by metadata.priority in BuiltinLoader.load_processors)
         try:
             from openpaw.builtins.processors.file_persistence import FilePersistenceProcessor

--- a/openpaw/builtins/tools/email/__init__.py
+++ b/openpaw/builtins/tools/email/__init__.py
@@ -1,0 +1,601 @@
+"""Email builtin — send and receive email via a configured provider.
+
+Returns 8 LangChain tools covering the full email workflow:
+send, check, get, search, reply, download attachment, mark read/unread.
+
+Only Gmail (via Google service account + domain-wide delegation) is
+supported in this release.  Additional providers can be added by
+implementing the ``EmailProvider`` ABC in ``base.py`` and registering
+them in ``__init__`` of this module.
+"""
+
+import logging
+import mimetypes
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from openpaw.agent.tools.sandbox import resolve_sandboxed_path
+from openpaw.builtins.base import (
+    BaseBuiltinTool,
+    BuiltinMetadata,
+    BuiltinPrerequisite,
+    BuiltinType,
+)
+from openpaw.builtins.tools.email.base import EmailProvider, RecipientPolicy
+from openpaw.core.utils import deduplicate_path, sanitize_filename
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Input schemas
+# ---------------------------------------------------------------------------
+
+
+class SendEmailInput(BaseModel):
+    """Input schema for send_email."""
+
+    to: list[str] = Field(description="Primary recipient email addresses.")
+    subject: str = Field(description="Email subject line.")
+    body: str = Field(description="Plain-text email body.")
+    cc: list[str] | None = Field(default=None, description="CC recipient email addresses.")
+    bcc: list[str] | None = Field(default=None, description="BCC recipient email addresses.")
+    attachment_paths: list[str] | None = Field(
+        default=None,
+        description=(
+            "Workspace-relative paths to files to attach. "
+            "Each path is resolved against the workspace sandbox."
+        ),
+    )
+
+
+class CheckEmailInput(BaseModel):
+    """Input schema for check_email."""
+
+    max_results: int = Field(
+        default=10,
+        ge=1,
+        le=50,
+        description="Maximum number of messages to return (1–50).",
+    )
+    label: str = Field(
+        default="INBOX",
+        description="Gmail label/folder to list from (e.g. 'INBOX', 'SENT', 'SPAM').",
+    )
+
+
+class GetEmailInput(BaseModel):
+    """Input schema for get_email."""
+
+    message_id: str = Field(description="The Gmail message ID to retrieve.")
+
+
+class SearchEmailInput(BaseModel):
+    """Input schema for search_email."""
+
+    query: str = Field(
+        description=(
+            "Gmail search query using Gmail search syntax. "
+            "Examples: 'from:alice@example.com', 'subject:invoice', 'is:unread'."
+        )
+    )
+    max_results: int = Field(
+        default=10,
+        ge=1,
+        le=50,
+        description="Maximum number of results to return (1–50).",
+    )
+
+
+class ReplyEmailInput(BaseModel):
+    """Input schema for reply_email."""
+
+    message_id: str = Field(description="The Gmail message ID to reply to.")
+    body: str = Field(description="Plain-text body of the reply.")
+    attachment_paths: list[str] | None = Field(
+        default=None,
+        description="Workspace-relative paths to files to attach to the reply.",
+    )
+
+
+class DownloadAttachmentInput(BaseModel):
+    """Input schema for download_attachment."""
+
+    message_id: str = Field(description="The Gmail message ID containing the attachment.")
+    attachment_id: str = Field(description="The attachment ID from get_email output.")
+    filename: str = Field(
+        description="The attachment filename from get_email output (e.g., 'report.pdf').",
+    )
+    save_as: str | None = Field(
+        default=None,
+        description=(
+            "Optional filename override. "
+            "If omitted, uses the filename parameter. "
+            "Saved to downloads/email/ in the workspace."
+        ),
+    )
+
+
+class MarkAsReadInput(BaseModel):
+    """Input schema for mark_as_read."""
+
+    message_id: str = Field(description="The Gmail message ID to mark as read.")
+
+
+class MarkAsUnreadInput(BaseModel):
+    """Input schema for mark_as_unread."""
+
+    message_id: str = Field(description="The Gmail message ID to mark as unread.")
+
+
+# ---------------------------------------------------------------------------
+# Builtin
+# ---------------------------------------------------------------------------
+
+_PROVIDER_NOT_CONFIGURED = (
+    "[Error: Email provider is not configured. "
+    "Contact the workspace administrator to set up email credentials.]"
+)
+
+
+class EmailToolBuiltin(BaseBuiltinTool):
+    """Multi-tool email builtin providing send/receive capabilities.
+
+    Backed by a Gmail service-account provider.  The provider is constructed
+    lazily from the workspace config injected by ``BuiltinLoader``.
+
+    Config options (all injected by the loader or agent.yaml):
+        provider: Provider name — only "gmail" is supported (default: "gmail").
+        service_account_file: Absolute path to the Google service account JSON.
+        delegated_user: Email address to impersonate via domain-wide delegation.
+        allowed_recipients: List of glob patterns for outbound recipient validation.
+        max_recipients: Maximum number of recipients per outbound message (default: 10).
+        workspace_path: Absolute path to the workspace root (injected by loader).
+    """
+
+    metadata = BuiltinMetadata(
+        name="email",
+        display_name="Email",
+        description="Send and receive email via configured provider",
+        builtin_type=BuiltinType.TOOL,
+        group="communication",
+        prerequisites=BuiltinPrerequisite(packages=["google.oauth2", "googleapiclient"]),
+    )
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        super().__init__(config)
+
+        provider_name: str = self.config.get("provider", "gmail")
+        service_account_file: str | None = self.config.get("service_account_file")
+        delegated_user: str | None = self.config.get("delegated_user")
+
+        workspace_path_raw = self.config.get("workspace_path")
+        self._workspace_root: Path | None = (
+            Path(workspace_path_raw).resolve() if workspace_path_raw else None
+        )
+
+        allowed_recipients: list[str] = self.config.get("allowed_recipients", [])
+        max_recipients: int = self.config.get("max_recipients", 10)
+        self._policy = RecipientPolicy(allowed_recipients, max_recipients)
+
+        # Build provider — store None if config is incomplete so that all tools
+        # can return a clean error string rather than crashing at call time.
+        self._provider: EmailProvider | None = None
+        if not service_account_file or not delegated_user:
+            logger.warning(
+                "EmailToolBuiltin: 'service_account_file' or 'delegated_user' not set — "
+                "email tools will return an error until the config is corrected."
+            )
+            return
+
+        if provider_name != "gmail":
+            logger.warning(
+                f"EmailToolBuiltin: unsupported provider '{provider_name}'. "
+                "Only 'gmail' is supported. Email tools will be unavailable."
+            )
+            return
+
+        if not Path(service_account_file).exists():
+            logger.warning(
+                f"EmailToolBuiltin: service_account_file not found at "
+                f"'{service_account_file}' — email tools will fail on first use."
+            )
+
+        try:
+            from openpaw.builtins.tools.email.gmail import GmailProvider
+
+            self._provider = GmailProvider(
+                service_account_file=service_account_file,
+                delegated_user=delegated_user,
+            )
+            logger.info(
+                f"EmailToolBuiltin initialized (provider=gmail, delegated_user={delegated_user})"
+            )
+        except Exception as exc:
+            logger.error(f"EmailToolBuiltin: failed to initialize GmailProvider: {exc}")
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def get_langchain_tool(self) -> list[Any]:
+        """Return the full list of email tools."""
+        return [
+            self._create_send_email_tool(),
+            self._create_check_email_tool(),
+            self._create_get_email_tool(),
+            self._create_search_email_tool(),
+            self._create_reply_email_tool(),
+            self._create_download_attachment_tool(),
+            self._create_mark_as_read_tool(),
+            self._create_mark_as_unread_tool(),
+        ]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_attachments(
+        self, paths: list[str]
+    ) -> tuple[list[tuple[str, bytes, str]], str | None]:
+        """Resolve a list of workspace-relative attachment paths to (name, bytes, mime) tuples.
+
+        Returns:
+            A tuple of (attachments, error_string).  If any path fails to
+            resolve or read, error_string is set and attachments is empty.
+        """
+        if not paths:
+            return [], None
+
+        if not self._workspace_root:
+            return [], "[Error: workspace_path not configured — cannot resolve attachment paths]"
+
+        attachments: list[tuple[str, bytes, str]] = []
+        for raw_path in paths:
+            try:
+                resolved = resolve_sandboxed_path(self._workspace_root, raw_path)
+            except ValueError as exc:
+                return [], f"[Error: Invalid attachment path '{raw_path}': {exc}]"
+
+            if not resolved.exists():
+                return [], f"[Error: Attachment not found: {raw_path}]"
+
+            if not resolved.is_file():
+                return [], f"[Error: Attachment path is not a file: {raw_path}]"
+
+            try:
+                content = resolved.read_bytes()
+            except OSError as exc:
+                return [], f"[Error: Could not read attachment '{raw_path}': {exc}]"
+
+            mime_type, _ = mimetypes.guess_type(resolved.name)
+            attachments.append((resolved.name, content, mime_type or "application/octet-stream"))
+
+        return attachments, None
+
+    # ------------------------------------------------------------------
+    # Tool factories
+    # ------------------------------------------------------------------
+
+    def _create_send_email_tool(self) -> Any:
+        from langchain_core.tools import StructuredTool
+
+        async def send_email_async(
+            to: list[str],
+            subject: str,
+            body: str,
+            cc: list[str] | None = None,
+            bcc: list[str] | None = None,
+            attachment_paths: list[str] | None = None,
+        ) -> str:
+            if not self._provider:
+                return _PROVIDER_NOT_CONFIGURED
+
+            cc = cc or []
+            bcc = bcc or []
+            attachment_paths = attachment_paths or []
+
+            all_recipients = to + cc + bcc
+            policy_error = self._policy.validate(all_recipients)
+            if policy_error:
+                return f"[Error: Recipient policy violation — {policy_error}]"
+
+            attachments, att_error = self._resolve_attachments(attachment_paths)
+            if att_error:
+                return att_error
+
+            try:
+                message_id = await self._provider.send(
+                    to=to,
+                    subject=subject,
+                    body=body,
+                    cc=cc or None,
+                    bcc=bcc or None,
+                    attachments=attachments or None,
+                )
+                att_note = f" with {len(attachments)} attachment(s)" if attachments else ""
+                return f"Email sent{att_note}. Message ID: {message_id}"
+            except Exception as exc:
+                logger.error(f"send_email failed: {exc}")
+                return f"[Error: Failed to send email: {exc}]"
+
+        return StructuredTool.from_function(
+            coroutine=send_email_async,
+            name="send_email",
+            description=(
+                "Send an email to one or more recipients. "
+                "All recipients (to, cc, bcc) must match the configured allowed_recipients "
+                "patterns — email sending is disabled by default for safety. "
+                "Optionally attach workspace files by providing their relative paths."
+            ),
+            args_schema=SendEmailInput,
+        )
+
+    def _create_check_email_tool(self) -> Any:
+        from langchain_core.tools import StructuredTool
+
+        async def check_email_async(max_results: int = 10, label: str = "INBOX") -> str:
+            if not self._provider:
+                return _PROVIDER_NOT_CONFIGURED
+
+            try:
+                messages = await self._provider.list_messages(
+                    max_results=max_results, label=label
+                )
+            except Exception as exc:
+                logger.error(f"check_email failed: {exc}")
+                return f"[Error: Failed to check email: {exc}]"
+
+            if not messages:
+                return f"No messages found in {label}."
+
+            summaries = "\n\n---\n\n".join(msg.format_summary() for msg in messages)
+            return f"{len(messages)} message(s) in {label}:\n\n{summaries}"
+
+        return StructuredTool.from_function(
+            coroutine=check_email_async,
+            name="check_email",
+            description=(
+                "List recent email messages from a Gmail label (default: INBOX). "
+                "Returns message summaries including ID, date, sender, subject, and snippet. "
+                "Use get_email with the message ID to retrieve the full body."
+            ),
+            args_schema=CheckEmailInput,
+        )
+
+    def _create_get_email_tool(self) -> Any:
+        from langchain_core.tools import StructuredTool
+
+        async def get_email_async(message_id: str) -> str:
+            if not self._provider:
+                return _PROVIDER_NOT_CONFIGURED
+
+            try:
+                message = await self._provider.get_message(message_id)
+            except Exception as exc:
+                logger.error(f"get_email failed for id={message_id}: {exc}")
+                return f"[Error: Failed to retrieve email {message_id}: {exc}]"
+
+            return message.format_full()
+
+        return StructuredTool.from_function(
+            coroutine=get_email_async,
+            name="get_email",
+            description=(
+                "Retrieve the full content of a specific email by its message ID. "
+                "Returns the complete body, headers, and attachment metadata. "
+                "Attachment IDs in the output can be used with download_attachment."
+            ),
+            args_schema=GetEmailInput,
+        )
+
+    def _create_search_email_tool(self) -> Any:
+        from langchain_core.tools import StructuredTool
+
+        async def search_email_async(query: str, max_results: int = 10) -> str:
+            if not self._provider:
+                return _PROVIDER_NOT_CONFIGURED
+
+            try:
+                messages = await self._provider.search(query=query, max_results=max_results)
+            except Exception as exc:
+                logger.error(f"search_email failed (query={query!r}): {exc}")
+                return f"[Error: Email search failed: {exc}]"
+
+            if not messages:
+                return f"No messages matched query: {query}"
+
+            summaries = "\n\n---\n\n".join(msg.format_summary() for msg in messages)
+            return f"{len(messages)} result(s) for '{query}':\n\n{summaries}"
+
+        return StructuredTool.from_function(
+            coroutine=search_email_async,
+            name="search_email",
+            description=(
+                "Search email using Gmail query syntax. "
+                "Supports operators like 'from:', 'to:', 'subject:', 'is:unread', "
+                "'has:attachment', 'after:2024/01/01', and free-text search. "
+                "Returns message summaries; use get_email for full content."
+            ),
+            args_schema=SearchEmailInput,
+        )
+
+    def _create_reply_email_tool(self) -> Any:
+        from langchain_core.tools import StructuredTool
+
+        async def reply_email_async(
+            message_id: str,
+            body: str,
+            attachment_paths: list[str] | None = None,
+        ) -> str:
+            if not self._provider:
+                return _PROVIDER_NOT_CONFIGURED
+
+            attachment_paths = attachment_paths or []
+
+            # Fetch the original message to extract threading info and sender.
+            try:
+                original = await self._provider.get_message(message_id)
+            except Exception as exc:
+                logger.error(f"reply_email: failed to fetch original message {message_id}: {exc}")
+                return f"[Error: Could not retrieve original message {message_id}: {exc}]"
+
+            # Validate original sender against recipient policy.
+            # NOTE: reply_email currently only sends to original.sender. If cc/bcc
+            # fields are added in a future iteration, validate ALL recipients here.
+            policy_error = self._policy.validate([original.sender])
+            if policy_error:
+                return (
+                    f"[Error: Cannot reply — original sender '{original.sender}' "
+                    f"is not in the allowed_recipients list: {policy_error}]"
+                )
+
+            attachments, att_error = self._resolve_attachments(attachment_paths)
+            if att_error:
+                return att_error
+
+            # Avoid stacking "Re: Re: Re: ..." on chain replies.
+            subject = original.subject
+            if not subject.startswith("Re: "):
+                subject = f"Re: {subject}"
+
+            try:
+                sent_id = await self._provider.send(
+                    to=[original.sender],
+                    subject=subject,
+                    body=body,
+                    reply_to_message_id=original.id,
+                    thread_id=original.thread_id,
+                    attachments=attachments or None,
+                )
+                att_note = f" with {len(attachments)} attachment(s)" if attachments else ""
+                return (
+                    f"Reply sent{att_note} to {original.sender}. "
+                    f"Message ID: {sent_id} (thread: {original.thread_id})"
+                )
+            except Exception as exc:
+                logger.error(f"reply_email failed for message_id={message_id}: {exc}")
+                return f"[Error: Failed to send reply: {exc}]"
+
+        return StructuredTool.from_function(
+            coroutine=reply_email_async,
+            name="reply_email",
+            description=(
+                "Reply to an existing email thread. "
+                "Automatically sets threading headers (In-Reply-To, References) "
+                "so the reply appears in the same thread. "
+                "The original sender must match the allowed_recipients policy."
+            ),
+            args_schema=ReplyEmailInput,
+        )
+
+    def _create_download_attachment_tool(self) -> Any:
+        from langchain_core.tools import StructuredTool
+
+        async def download_attachment_async(
+            message_id: str,
+            attachment_id: str,
+            filename: str,
+            save_as: str | None = None,
+        ) -> str:
+            if not self._provider:
+                return _PROVIDER_NOT_CONFIGURED
+
+            if not self._workspace_root:
+                return "[Error: workspace_path not configured — cannot save attachments]"
+
+            try:
+                attachment = await self._provider.download_attachment(
+                    message_id=message_id,
+                    attachment_id=attachment_id,
+                    filename_hint=filename,
+                )
+            except Exception as exc:
+                logger.error(
+                    f"download_attachment failed (msg={message_id}, att={attachment_id}): {exc}"
+                )
+                return f"[Error: Failed to download attachment: {exc}]"
+
+            if attachment.content is None:
+                return "[Error: Provider returned attachment with no content]"
+
+            # Determine filename — caller override takes priority.
+            raw_filename = save_as or attachment.filename or "attachment"
+            safe_name = sanitize_filename(raw_filename)
+
+            # Ensure target directory exists.
+            save_dir = self._workspace_root / "downloads" / "email"
+            save_dir.mkdir(parents=True, exist_ok=True)
+
+            # Deduplicate if a file with that name already exists.
+            target_path = deduplicate_path(save_dir / safe_name)
+
+            try:
+                target_path.write_bytes(attachment.content)
+            except OSError as exc:
+                logger.error(f"download_attachment: failed to write {target_path}: {exc}")
+                return f"[Error: Failed to save attachment to disk: {exc}]"
+
+            # Return workspace-relative path for easy reference in subsequent tools.
+            relative = target_path.relative_to(self._workspace_root)
+            size_kb = len(attachment.content) / 1024
+            return (
+                f"Attachment saved: {relative} ({size_kb:.1f} KB)\n"
+                f"MIME type: {attachment.mime_type}"
+            )
+
+        return StructuredTool.from_function(
+            coroutine=download_attachment_async,
+            name="download_attachment",
+            description=(
+                "Download an email attachment and save it to downloads/email/ "
+                "in the workspace. "
+                "Requires the message ID and attachment ID from get_email output. "
+                "Returns the workspace-relative path of the saved file."
+            ),
+            args_schema=DownloadAttachmentInput,
+        )
+
+    def _create_mark_as_read_tool(self) -> Any:
+        from langchain_core.tools import StructuredTool
+
+        async def mark_as_read_async(message_id: str) -> str:
+            if not self._provider:
+                return _PROVIDER_NOT_CONFIGURED
+
+            try:
+                await self._provider.mark_as_read(message_id)
+                return f"Message {message_id} marked as read."
+            except Exception as exc:
+                logger.error(f"mark_as_read failed for id={message_id}: {exc}")
+                return f"[Error: Failed to mark message as read: {exc}]"
+
+        return StructuredTool.from_function(
+            coroutine=mark_as_read_async,
+            name="mark_as_read",
+            description="Mark an email message as read (removes the UNREAD label).",
+            args_schema=MarkAsReadInput,
+        )
+
+    def _create_mark_as_unread_tool(self) -> Any:
+        from langchain_core.tools import StructuredTool
+
+        async def mark_as_unread_async(message_id: str) -> str:
+            if not self._provider:
+                return _PROVIDER_NOT_CONFIGURED
+
+            try:
+                await self._provider.mark_as_unread(message_id)
+                return f"Message {message_id} marked as unread."
+            except Exception as exc:
+                logger.error(f"mark_as_unread failed for id={message_id}: {exc}")
+                return f"[Error: Failed to mark message as unread: {exc}]"
+
+        return StructuredTool.from_function(
+            coroutine=mark_as_unread_async,
+            name="mark_as_unread",
+            description="Mark an email message as unread (adds the UNREAD label).",
+            args_schema=MarkAsUnreadInput,
+        )

--- a/openpaw/builtins/tools/email/base.py
+++ b/openpaw/builtins/tools/email/base.py
@@ -1,0 +1,258 @@
+"""Email provider abstraction and data models.
+
+Defines the EmailProvider ABC that concrete implementations (Gmail, SMTP, SES, etc.)
+must implement, along with shared data models and the RecipientPolicy safety gate.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from fnmatch import fnmatch
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EmailAttachment:
+    """Email attachment metadata and optional content.
+
+    Content is populated only when explicitly downloaded via download_attachment().
+    List/get operations return metadata only (content=None).
+    """
+
+    filename: str
+    mime_type: str
+    size_bytes: int
+    attachment_id: str = ""
+    content: bytes | None = None
+
+
+@dataclass
+class EmailMessage:
+    """A single email message."""
+
+    id: str
+    thread_id: str
+    subject: str
+    sender: str
+    recipients: list[str]
+    body: str
+    date: datetime
+    snippet: str
+    cc: list[str] = field(default_factory=list)
+    labels: list[str] = field(default_factory=list)
+    attachments: list[EmailAttachment] = field(default_factory=list)
+
+    def format_summary(self) -> str:
+        """Format a concise summary for tool output."""
+        att_info = f" [{len(self.attachments)} attachment(s)]" if self.attachments else ""
+        cc_info = f", CC: {', '.join(self.cc)}" if self.cc else ""
+        return (
+            f"ID: {self.id}\n"
+            f"Date: {self.date.strftime('%Y-%m-%d %H:%M')}\n"
+            f"From: {self.sender}\n"
+            f"To: {', '.join(self.recipients)}{cc_info}\n"
+            f"Subject: {self.subject}{att_info}\n"
+            f"Snippet: {self.snippet}"
+        )
+
+    def format_full(self) -> str:
+        """Format full message content for tool output."""
+        att_section = ""
+        if self.attachments:
+            att_lines = []
+            for att in self.attachments:
+                size_kb = att.size_bytes / 1024
+                att_lines.append(
+                    f"  - {att.filename} ({att.mime_type}, {size_kb:.1f} KB, id: {att.attachment_id})"
+                )
+            att_section = "\nAttachments:\n" + "\n".join(att_lines)
+
+        cc_info = f"\nCC: {', '.join(self.cc)}" if self.cc else ""
+        labels_info = f"\nLabels: {', '.join(self.labels)}" if self.labels else ""
+
+        return (
+            f"ID: {self.id}\n"
+            f"Thread: {self.thread_id}\n"
+            f"Date: {self.date.strftime('%Y-%m-%d %H:%M:%S %Z')}\n"
+            f"From: {self.sender}\n"
+            f"To: {', '.join(self.recipients)}{cc_info}{labels_info}\n"
+            f"Subject: {self.subject}\n"
+            f"---\n"
+            f"{self.body}"
+            f"{att_section}"
+        )
+
+
+class RecipientPolicy:
+    """Validates email recipients against an allowlist.
+
+    Safety-first design: an empty allowlist blocks ALL outbound email.
+    This is intentional — email is an externally-visible side effect and
+    must be explicitly configured before agents can send.
+    """
+
+    def __init__(self, allowed_patterns: list[str], max_recipients: int = 10) -> None:
+        self.allowed_patterns = [p.lower() for p in allowed_patterns]
+        self.max_recipients = max_recipients
+
+    def validate(self, recipients: list[str]) -> str | None:
+        """Validate a list of recipients against the policy.
+
+        Returns:
+            None if all recipients pass, or an error message string.
+        """
+        if not recipients:
+            return "No recipients specified"
+
+        total = len(recipients)
+        if total > self.max_recipients:
+            return f"Too many recipients ({total}). Maximum allowed: {self.max_recipients}"
+
+        if not self.allowed_patterns:
+            return (
+                "No allowed_recipients configured. "
+                "Email sending is disabled by default for safety. "
+                "Configure allowed_recipients in the email builtin config."
+            )
+
+        blocked: list[str] = []
+        for addr in recipients:
+            if not self._matches(addr):
+                blocked.append(addr)
+
+        if blocked:
+            return (
+                f"Recipient(s) not in allowlist: {', '.join(blocked)}. "
+                f"Allowed patterns: {', '.join(self.allowed_patterns)}"
+            )
+
+        return None
+
+    def _matches(self, email: str) -> bool:
+        """Check if an email address matches any allowed pattern."""
+        email_lower = email.lower().strip()
+        for pattern in self.allowed_patterns:
+            if fnmatch(email_lower, pattern):
+                return True
+        return False
+
+
+class EmailProvider(ABC):
+    """Abstract base class for email provider implementations.
+
+    Concrete providers (Gmail, SMTP, SES) implement these methods to handle
+    the transport-level details of sending and retrieving email.
+    """
+
+    @abstractmethod
+    async def send(
+        self,
+        to: list[str],
+        subject: str,
+        body: str,
+        cc: list[str] | None = None,
+        bcc: list[str] | None = None,
+        reply_to_message_id: str | None = None,
+        thread_id: str | None = None,
+        attachments: list[tuple[str, bytes, str]] | None = None,
+    ) -> str:
+        """Send an email.
+
+        Args:
+            to: Recipient email addresses.
+            subject: Email subject line.
+            body: Plain text email body.
+            cc: CC recipients.
+            bcc: BCC recipients.
+            reply_to_message_id: Message-ID header for threading replies.
+            thread_id: Provider-specific thread identifier for reply grouping.
+            attachments: List of (filename, content_bytes, mime_type) tuples.
+
+        Returns:
+            The sent message ID.
+
+        Raises:
+            Exception: On transport failure. The tool layer catches all
+                exceptions and converts them to ``[Error: ...]`` strings.
+        """
+
+    @abstractmethod
+    async def list_messages(
+        self,
+        max_results: int = 10,
+        label: str = "INBOX",
+    ) -> list[EmailMessage]:
+        """List recent messages.
+
+        Args:
+            max_results: Maximum messages to return.
+            label: Label/folder to list from.
+
+        Returns:
+            List of EmailMessage with metadata (body may be truncated).
+        """
+
+    @abstractmethod
+    async def get_message(self, message_id: str) -> EmailMessage:
+        """Get a single message with full content.
+
+        Args:
+            message_id: The provider-specific message ID.
+
+        Returns:
+            Full EmailMessage including body and attachment metadata.
+        """
+
+    @abstractmethod
+    async def search(
+        self,
+        query: str,
+        max_results: int = 10,
+    ) -> list[EmailMessage]:
+        """Search messages using provider-native query syntax.
+
+        Args:
+            query: Provider-specific search query (e.g., Gmail search syntax).
+            max_results: Maximum messages to return.
+
+        Returns:
+            List of matching EmailMessage objects.
+        """
+
+    @abstractmethod
+    async def download_attachment(
+        self,
+        message_id: str,
+        attachment_id: str,
+        filename_hint: str = "",
+    ) -> EmailAttachment:
+        """Download an attachment's content.
+
+        Args:
+            message_id: The message containing the attachment.
+            attachment_id: The provider-specific attachment ID.
+            filename_hint: Original filename from message metadata. Providers
+                that cannot recover the filename from the download API should
+                use this as a fallback.
+
+        Returns:
+            EmailAttachment with content populated.
+        """
+
+    @abstractmethod
+    async def mark_as_read(self, message_id: str) -> None:
+        """Mark a message as read.
+
+        Args:
+            message_id: The message to mark as read.
+        """
+
+    @abstractmethod
+    async def mark_as_unread(self, message_id: str) -> None:
+        """Mark a message as unread.
+
+        Args:
+            message_id: The message to mark as unread.
+        """

--- a/openpaw/builtins/tools/email/gmail.py
+++ b/openpaw/builtins/tools/email/gmail.py
@@ -1,0 +1,775 @@
+"""Gmail provider implementation using Google service account + domain-wide delegation.
+
+All blocking googleapiclient calls are dispatched via asyncio.to_thread() to keep
+the event loop free. Errors from the Google API are caught and returned as
+user-friendly strings — exceptions never bubble up to callers.
+"""
+
+import asyncio
+import base64
+import logging
+import threading
+from datetime import UTC, datetime
+from email.mime.application import MIMEApplication
+from email.mime.base import MIMEBase
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import Any
+
+from openpaw.builtins.tools.email.base import (
+    EmailAttachment,
+    EmailMessage,
+    EmailProvider,
+)
+
+logger = logging.getLogger(__name__)
+
+# Gmail OAuth2 scopes required for read, send, and label modification.
+_SCOPES = [
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/gmail.modify",
+]
+
+# Safety valve: cap body text to avoid flooding the agent's context window.
+_MAX_BODY_CHARS = 50_000
+
+
+class GmailProvider(EmailProvider):
+    """Email provider backed by the Gmail API via service account delegation.
+
+    Uses a Google Workspace service account with domain-wide delegation enabled
+    so the agent can act on behalf of any user in the organization.
+
+    Args:
+        service_account_file: Absolute path to the service account JSON key file.
+        delegated_user: The email address of the user to impersonate
+            (e.g., "agent@yourdomain.com").
+    """
+
+    def __init__(self, service_account_file: str, delegated_user: str) -> None:
+        self._service_account_file = service_account_file
+        self._delegated_user = delegated_user
+        self._service: Any = None
+        self._service_lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Lazy client initialization
+    # ------------------------------------------------------------------
+
+    def _get_service(self) -> Any:
+        """Return the Gmail API service, building it on first call.
+
+        Thread-safe via double-checked locking. This is intentionally
+        synchronous — it is always called from within asyncio.to_thread().
+        """
+        if self._service is not None:
+            return self._service
+
+        with self._service_lock:
+            if self._service is not None:
+                return self._service
+
+            from google.oauth2 import service_account
+            from googleapiclient.discovery import build
+
+            credentials = service_account.Credentials.from_service_account_file(  # type: ignore[no-untyped-call]
+                self._service_account_file,
+                scopes=_SCOPES,
+                subject=self._delegated_user,
+            )
+            self._service = build("gmail", "v1", credentials=credentials)
+            logger.info(f"Gmail API service initialized for {self._delegated_user}")
+
+        return self._service
+
+    # ------------------------------------------------------------------
+    # EmailProvider interface
+    # ------------------------------------------------------------------
+
+    async def send(
+        self,
+        to: list[str],
+        subject: str,
+        body: str,
+        cc: list[str] | None = None,
+        bcc: list[str] | None = None,
+        reply_to_message_id: str | None = None,
+        thread_id: str | None = None,
+        attachments: list[tuple[str, bytes, str]] | None = None,
+    ) -> str:
+        """Send an email and return the sent message ID.
+
+        Constructs a proper RFC 2822 / MIME message. When replying, sets the
+        In-Reply-To and References headers so Gmail threads the message correctly.
+
+        Args:
+            to: Primary recipient addresses.
+            subject: Email subject line.
+            body: Plain text body.
+            cc: CC recipient addresses.
+            bcc: BCC recipient addresses.
+            reply_to_message_id: RFC 2822 Message-ID of the message being replied to.
+            thread_id: Gmail thread ID to attach this message to.
+            attachments: Sequence of (filename, content_bytes, mime_type) tuples.
+
+        Returns:
+            The sent message ID.
+
+        Raises:
+            RuntimeError: On MIME construction or API failure.
+        """
+        mime_message = _build_mime_message(
+            sender=self._delegated_user,
+            to=to,
+            subject=subject,
+            body=body,
+            cc=cc,
+            bcc=bcc,
+            reply_to_message_id=reply_to_message_id,
+            attachments=attachments,
+        )
+
+        raw = base64.urlsafe_b64encode(mime_message.as_bytes()).decode("utf-8")
+        payload: dict[str, Any] = {"raw": raw}
+        if thread_id:
+            payload["threadId"] = thread_id
+
+        def _do_send() -> Any:
+            service = self._get_service()
+            return (
+                service.users()
+                .messages()
+                .send(userId="me", body=payload)
+                .execute()
+            )
+
+        try:
+            result = await asyncio.to_thread(_do_send)
+            message_id: str = result.get("id", "unknown")
+            logger.info(f"Email sent successfully (message_id={message_id})")
+            return message_id
+        except Exception as exc:
+            raise RuntimeError(_format_api_error("send email", exc)) from exc
+
+    async def list_messages(
+        self,
+        max_results: int = 10,
+        label: str = "INBOX",
+    ) -> list[EmailMessage]:
+        """List recent messages from the given label/folder.
+
+        Performs two round-trips: one to list message IDs, one batch of individual
+        fetches (format=metadata) for headers + snippet.
+
+        Args:
+            max_results: Maximum number of messages to return (capped at 100).
+            label: Gmail label to list from (e.g., "INBOX", "SENT", "SPAM").
+
+        Returns:
+            List of EmailMessage objects with metadata. Body is empty for list results;
+            call get_message() for the full body.
+        """
+        max_results = min(max_results, 100)
+
+        def _list_ids() -> list[str]:
+            service = self._get_service()
+            resp = (
+                service.users()
+                .messages()
+                .list(userId="me", labelIds=[label], maxResults=max_results)
+                .execute()
+            )
+            return [m["id"] for m in resp.get("messages", [])]
+
+        try:
+            message_ids = await asyncio.to_thread(_list_ids)
+        except Exception as exc:
+            logger.error(f"Failed to list messages: {exc}")
+            return []
+
+        if not message_ids:
+            return []
+
+        # Fetch metadata for each message concurrently.
+        tasks = [self._fetch_message(mid, full=False) for mid in message_ids]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        messages: list[EmailMessage] = []
+        for item in results:
+            if isinstance(item, EmailMessage):
+                messages.append(item)
+            else:
+                logger.warning(f"Skipping failed message fetch: {item}")
+
+        return messages
+
+    async def get_message(self, message_id: str) -> EmailMessage:
+        """Retrieve a single message with full body content.
+
+        Args:
+            message_id: The Gmail message ID.
+
+        Returns:
+            Full EmailMessage including body text and attachment metadata.
+
+        Raises:
+            RuntimeError: If the message cannot be fetched (wraps the underlying error).
+        """
+        result = await self._fetch_message(message_id, full=True)
+        if isinstance(result, Exception):
+            raise RuntimeError(f"Failed to retrieve message {message_id}: {result}") from result
+        return result
+
+    async def search(
+        self,
+        query: str,
+        max_results: int = 10,
+    ) -> list[EmailMessage]:
+        """Search messages using Gmail query syntax.
+
+        Supports the full Gmail search language (e.g., ``from:alice@example.com``,
+        ``subject:invoice``, ``has:attachment``, ``after:2024/01/01``).
+
+        Args:
+            query: Gmail search query string.
+            max_results: Maximum results to return (capped at 100).
+
+        Returns:
+            List of matching EmailMessage objects with metadata.
+        """
+        max_results = min(max_results, 100)
+
+        def _search() -> list[str]:
+            service = self._get_service()
+            resp = (
+                service.users()
+                .messages()
+                .list(userId="me", q=query, maxResults=max_results)
+                .execute()
+            )
+            return [m["id"] for m in resp.get("messages", [])]
+
+        try:
+            message_ids = await asyncio.to_thread(_search)
+        except Exception as exc:
+            logger.error(f"Search failed (query={query!r}): {exc}")
+            return []
+
+        if not message_ids:
+            return []
+
+        tasks = [self._fetch_message(mid, full=False) for mid in message_ids]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        messages: list[EmailMessage] = []
+        for item in results:
+            if isinstance(item, EmailMessage):
+                messages.append(item)
+            else:
+                logger.warning(f"Skipping failed message fetch during search: {item}")
+
+        return messages
+
+    async def download_attachment(
+        self,
+        message_id: str,
+        attachment_id: str,
+        filename_hint: str = "",
+    ) -> EmailAttachment:
+        """Download an attachment's raw bytes from Gmail.
+
+        Args:
+            message_id: The Gmail message that contains the attachment.
+            attachment_id: The Gmail attachment ID (from EmailAttachment.attachment_id).
+            filename_hint: Original filename from message metadata (the Gmail
+                attachments API does not return the filename in the download response).
+
+        Returns:
+            EmailAttachment with content populated.
+
+        Raises:
+            RuntimeError: If the download fails.
+        """
+
+        def _download() -> Any:
+            service = self._get_service()
+            return (
+                service.users()
+                .messages()
+                .attachments()
+                .get(userId="me", messageId=message_id, id=attachment_id)
+                .execute()
+            )
+
+        try:
+            result = await asyncio.to_thread(_download)
+        except Exception as exc:
+            raise RuntimeError(
+                _format_api_error(f"download attachment {attachment_id}", exc)
+            ) from exc
+
+        raw_data = result.get("data", "")
+        content = base64.urlsafe_b64decode(_pad_base64(raw_data))
+        size = result.get("size", len(content))
+
+        return EmailAttachment(
+            filename=filename_hint,
+            mime_type="application/octet-stream",
+            size_bytes=size,
+            attachment_id=attachment_id,
+            content=content,
+        )
+
+    async def mark_as_read(self, message_id: str) -> None:
+        """Remove the UNREAD label from a message.
+
+        Args:
+            message_id: The Gmail message ID to mark as read.
+
+        Raises:
+            RuntimeError: If the API call fails.
+        """
+
+        def _modify() -> None:
+            service = self._get_service()
+            service.users().messages().modify(
+                userId="me",
+                id=message_id,
+                body={"removeLabelIds": ["UNREAD"]},
+            ).execute()
+
+        try:
+            await asyncio.to_thread(_modify)
+            logger.debug(f"Marked message {message_id} as read")
+        except Exception as exc:
+            raise RuntimeError(
+                _format_api_error(f"mark message {message_id} as read", exc)
+            ) from exc
+
+    async def mark_as_unread(self, message_id: str) -> None:
+        """Add the UNREAD label to a message.
+
+        Args:
+            message_id: The Gmail message ID to mark as unread.
+
+        Raises:
+            RuntimeError: If the API call fails.
+        """
+
+        def _modify() -> None:
+            service = self._get_service()
+            service.users().messages().modify(
+                userId="me",
+                id=message_id,
+                body={"addLabelIds": ["UNREAD"]},
+            ).execute()
+
+        try:
+            await asyncio.to_thread(_modify)
+            logger.debug(f"Marked message {message_id} as unread")
+        except Exception as exc:
+            raise RuntimeError(
+                _format_api_error(f"mark message {message_id} as unread", exc)
+            ) from exc
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _fetch_message(
+        self, message_id: str, full: bool
+    ) -> EmailMessage | Exception:
+        """Fetch a single Gmail message and parse it into an EmailMessage.
+
+        Args:
+            message_id: The Gmail message ID.
+            full: When True, fetches the full payload (body + attachments).
+                  When False, fetches only metadata and snippet.
+
+        Returns:
+            An EmailMessage on success, or the Exception on failure.
+        """
+        msg_format = "full" if full else "metadata"
+
+        def _get() -> Any:
+            service = self._get_service()
+            return (
+                service.users()
+                .messages()
+                .get(userId="me", id=message_id, format=msg_format)
+                .execute()
+            )
+
+        try:
+            raw = await asyncio.to_thread(_get)
+        except Exception as exc:
+            logger.warning(f"Failed to fetch message {message_id}: {exc}")
+            return exc
+
+        try:
+            return _parse_gmail_message(raw, include_body=full)
+        except Exception as exc:
+            logger.warning(f"Failed to parse message {message_id}: {exc}")
+            return exc
+
+
+# ------------------------------------------------------------------
+# Pure parsing helpers (no I/O)
+# ------------------------------------------------------------------
+
+
+def _parse_gmail_message(raw: dict[str, Any], include_body: bool) -> EmailMessage:
+    """Parse a raw Gmail API message dict into an EmailMessage.
+
+    Args:
+        raw: The dict returned by messages.get().
+        include_body: Whether to extract and decode the body text.
+
+    Returns:
+        Populated EmailMessage.
+    """
+    headers = _extract_headers(raw.get("payload", {}).get("headers", []))
+
+    date = _parse_date(headers.get("date", ""))
+    recipients = _split_addresses(headers.get("to", ""))
+    cc = _split_addresses(headers.get("cc", ""))
+    labels: list[str] = raw.get("labelIds", [])
+    snippet: str = raw.get("snippet", "")
+
+    body = ""
+    attachments: list[EmailAttachment] = []
+
+    if include_body:
+        payload = raw.get("payload", {})
+        body, attachments = _extract_body_and_attachments(payload)
+        body = body[:_MAX_BODY_CHARS]
+
+    return EmailMessage(
+        id=raw.get("id", ""),
+        thread_id=raw.get("threadId", ""),
+        subject=headers.get("subject", "(no subject)"),
+        sender=headers.get("from", ""),
+        recipients=recipients,
+        body=body,
+        date=date,
+        snippet=snippet,
+        cc=cc,
+        labels=labels,
+        attachments=attachments,
+    )
+
+
+def _extract_headers(header_list: list[dict[str, str]]) -> dict[str, str]:
+    """Flatten a Gmail headers list into a lowercase-keyed dict.
+
+    When a header appears multiple times, the last value wins.
+
+    Args:
+        header_list: List of {"name": ..., "value": ...} dicts from Gmail API.
+
+    Returns:
+        Dict mapping lowercase header name → value.
+    """
+    result: dict[str, str] = {}
+    for h in header_list:
+        name = h.get("name", "").lower()
+        value = h.get("value", "")
+        if name:
+            result[name] = value
+    return result
+
+
+def _parse_date(date_str: str) -> datetime:
+    """Parse a RFC 2822 date string into an aware datetime (UTC fallback).
+
+    Args:
+        date_str: Date header value from the Gmail message.
+
+    Returns:
+        Timezone-aware datetime. Returns epoch UTC if parsing fails.
+    """
+    if not date_str:
+        return datetime.fromtimestamp(0, tz=UTC)
+
+    from email.utils import parsedate_to_datetime
+
+    try:
+        dt = parsedate_to_datetime(date_str)
+        # Ensure tz-aware; naive dates are treated as UTC.
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt
+    except Exception:
+        logger.debug(f"Could not parse date header: {date_str!r}")
+        return datetime.fromtimestamp(0, tz=UTC)
+
+
+def _split_addresses(header_value: str) -> list[str]:
+    """Split a comma-separated address header into individual addresses.
+
+    Args:
+        header_value: Raw header value (e.g., "Alice <a@b.com>, Bob <b@c.com>").
+
+    Returns:
+        List of address strings. Empty list if the header is blank.
+    """
+    if not header_value.strip():
+        return []
+    return [addr.strip() for addr in header_value.split(",") if addr.strip()]
+
+
+def _extract_body_and_attachments(
+    payload: dict[str, Any],
+) -> tuple[str, list[EmailAttachment]]:
+    """Walk the MIME payload tree and extract plain text body + attachment metadata.
+
+    Gmail stores messages as a recursive tree of parts. This function does a
+    depth-first walk, collecting:
+    - The first ``text/plain`` part it finds as the body.
+    - Any parts with a Content-Disposition of "attachment" as EmailAttachment entries.
+
+    Args:
+        payload: The ``payload`` dict from a Gmail message (format=full).
+
+    Returns:
+        Tuple of (body_text, list_of_attachments).
+    """
+    body_parts: list[str] = []
+    attachments: list[EmailAttachment] = []
+
+    _walk_payload(payload, body_parts, attachments)
+
+    body = "\n".join(body_parts)
+    return body, attachments
+
+
+def _walk_payload(
+    part: dict[str, Any],
+    body_parts: list[str],
+    attachments: list[EmailAttachment],
+) -> None:
+    """Recursively walk a Gmail payload part, filling body_parts and attachments.
+
+    Args:
+        part: A single MIME part dict from the Gmail API.
+        body_parts: Accumulator list for body text segments.
+        attachments: Accumulator list for attachment metadata.
+    """
+    mime_type: str = part.get("mimeType", "")
+    filename: str = part.get("filename", "")
+    body_data: dict[str, Any] = part.get("body", {})
+    sub_parts: list[dict[str, Any]] = part.get("parts", [])
+
+    # Determine Content-Disposition from part headers.
+    part_headers = _extract_headers(part.get("headers", []))
+    disposition = part_headers.get("content-disposition", "")
+
+    # Attachment: named part or explicitly marked as attachment.
+    if filename and body_data.get("attachmentId"):
+        attachment_id = body_data["attachmentId"]
+        size = body_data.get("size", 0)
+        content_id = part_headers.get("content-id", "")
+        # Skip inline images with a content-id (embedded in HTML), keep true attachments.
+        is_inline_image = "inline" in disposition and content_id
+        if not is_inline_image:
+            attachments.append(
+                EmailAttachment(
+                    filename=filename,
+                    mime_type=mime_type,
+                    size_bytes=size,
+                    attachment_id=attachment_id,
+                    content=None,
+                )
+            )
+        return  # Do not descend into attachment parts.
+
+    # Plain text body — take the first one found in the tree.
+    if mime_type == "text/plain" and not sub_parts:
+        raw_data = body_data.get("data", "")
+        if raw_data:
+            text = base64.urlsafe_b64decode(_pad_base64(raw_data)).decode(
+                "utf-8", errors="replace"
+            )
+            body_parts.append(text)
+        return
+
+    # HTML fallback: if we have no plain text yet and this is text/html, convert.
+    if mime_type == "text/html" and not sub_parts and not body_parts:
+        raw_data = body_data.get("data", "")
+        if raw_data:
+            html = base64.urlsafe_b64decode(_pad_base64(raw_data)).decode(
+                "utf-8", errors="replace"
+            )
+            body_parts.append(_strip_html(html))
+        return
+
+    # Multipart container — recurse into sub-parts.
+    for sub_part in sub_parts:
+        _walk_payload(sub_part, body_parts, attachments)
+
+
+def _strip_html(html: str) -> str:
+    """Remove HTML tags from a string, leaving readable plain text.
+
+    A lightweight fallback for when no text/plain part is available. Uses the
+    stdlib ``email`` + ``html.parser`` to avoid external dependencies.
+
+    Args:
+        html: Raw HTML string.
+
+    Returns:
+        Plain text with tags stripped. Whitespace is normalized.
+    """
+    from html.parser import HTMLParser
+
+    class _Stripper(HTMLParser):
+        def __init__(self) -> None:
+            super().__init__()
+            self._chunks: list[str] = []
+
+        def handle_data(self, data: str) -> None:
+            self._chunks.append(data)
+
+        def get_text(self) -> str:
+            return " ".join(self._chunks)
+
+    stripper = _Stripper()
+    try:
+        stripper.feed(html)
+        return stripper.get_text()
+    except Exception:
+        return html  # Return raw HTML as fallback if parsing fails.
+
+
+def _pad_base64(data: str) -> str:
+    """Add missing base64 padding characters.
+
+    Gmail uses base64url without padding. Python's base64.urlsafe_b64decode
+    requires correct padding.
+
+    Args:
+        data: Potentially unpadded base64url string.
+
+    Returns:
+        Properly padded base64url string.
+    """
+    remainder = len(data) % 4
+    if remainder:
+        data += "=" * (4 - remainder)
+    return data
+
+
+def _build_mime_message(
+    sender: str,
+    to: list[str],
+    subject: str,
+    body: str,
+    cc: list[str] | None,
+    bcc: list[str] | None,
+    reply_to_message_id: str | None,
+    attachments: list[tuple[str, bytes, str]] | None,
+) -> MIMEMultipart | MIMEText:
+    """Construct a RFC 2822 MIME message ready for base64url encoding.
+
+    Uses MIMEMultipart when attachments are present, otherwise falls back to a
+    simple MIMEText to keep the message compact.
+
+    Args:
+        sender: From address.
+        to: Primary recipient list.
+        subject: Subject line.
+        body: Plain text body.
+        cc: CC recipients.
+        bcc: BCC recipients (included in headers; Gmail handles actual delivery).
+        reply_to_message_id: RFC 2822 Message-ID for threading.
+        attachments: List of (filename, content_bytes, mime_type) tuples.
+
+    Returns:
+        Assembled MIME message object.
+    """
+    if attachments:
+        msg: MIMEMultipart | MIMEText = MIMEMultipart()
+        msg.attach(MIMEText(body, "plain", "utf-8"))
+    else:
+        msg = MIMEText(body, "plain", "utf-8")
+
+    msg["From"] = sender
+    msg["To"] = ", ".join(to)
+    msg["Subject"] = subject
+
+    if cc:
+        msg["Cc"] = ", ".join(cc)
+    if bcc:
+        msg["Bcc"] = ", ".join(bcc)
+
+    if reply_to_message_id:
+        # Strip any surrounding angle brackets before adding them back, to be safe.
+        clean_id = reply_to_message_id.strip().strip("<>")
+        msg["In-Reply-To"] = f"<{clean_id}>"
+        msg["References"] = f"<{clean_id}>"
+
+    if attachments and isinstance(msg, MIMEMultipart):
+        for filename, content_bytes, mime_type in attachments:
+            main_type, _, sub_type = mime_type.partition("/")
+            if main_type and sub_type:
+                part: MIMEBase = MIMEBase(main_type, sub_type)
+                part.set_payload(content_bytes)
+                from email import encoders
+
+                encoders.encode_base64(part)
+            else:
+                # Fallback for unrecognised or missing MIME types.
+                part = MIMEApplication(content_bytes)
+
+            part.add_header("Content-Disposition", "attachment", filename=filename)
+            msg.attach(part)
+
+    return msg
+
+
+def _format_api_error(action: str, exc: Exception) -> str:
+    """Return a user-friendly error string for a Gmail API exception.
+
+    Attempts to extract a meaningful message from HttpError responses.
+    Falls back to a generic message for unexpected exception types.
+
+    Args:
+        action: Short description of what was being attempted (e.g., "send email").
+        exc: The caught exception.
+
+    Returns:
+        A formatted "[Error: ...]" string safe to return to the agent.
+    """
+    # googleapiclient.errors.HttpError exposes .status_code (int) directly,
+    # or .resp.status on the underlying httplib2 response object.
+    status_code: int | None = None
+    try:
+        status_code = getattr(exc, "status_code", None)
+        if status_code is None:
+            resp = getattr(exc, "resp", None)
+            if resp is not None:
+                status_code = getattr(resp, "status", None)
+        if status_code is not None:
+            status_code = int(status_code)
+    except (ValueError, TypeError):
+        pass
+
+    if status_code == 429:
+        return "[Error: Gmail API rate limit reached. Please wait a moment and try again.]"
+    if status_code == 401:
+        return "[Error: Gmail authentication failed. Check the service account credentials.]"
+    if status_code == 403:
+        return (
+            "[Error: Gmail API access denied. "
+            "Verify that domain-wide delegation is enabled for this service account "
+            "and that the correct scopes have been granted.]"
+        )
+    if status_code == 404:
+        return "[Error: Requested Gmail resource not found. Check the message or attachment ID.]"
+    if status_code is not None and status_code >= 500:
+        return f"[Error: Gmail API server error ({status_code}). Please try again later.]"
+
+    # Generic fallback — include the exception message but avoid raw tracebacks.
+    logger.error(f"Unexpected error during '{action}': {exc}", exc_info=True)
+    return f"[Error: Failed to {action}: {exc}]"

--- a/openpaw/core/config/models.py
+++ b/openpaw/core/config/models.py
@@ -297,6 +297,28 @@ class GptResearcherBuiltinConfig(BuiltinItemConfig):
     default_tone: str = Field(default="Objective", description="Default writing tone for reports")
 
 
+class EmailBuiltinConfig(BuiltinItemConfig):
+    """Configuration for the email integration tool."""
+
+    provider: str = Field(default="gmail", description="Email provider: gmail")
+    service_account_file: str | None = Field(
+        default=None,
+        description="Path to Google service account JSON (absolute or relative to workspace)",
+    )
+    delegated_user: str | None = Field(
+        default=None,
+        description="Email address to impersonate via domain-wide delegation",
+    )
+    allowed_recipients: list[str] = Field(
+        default_factory=list,
+        description="Recipient allowlist patterns (e.g., '*@company.com'). Empty = block all sends.",
+    )
+    max_recipients: int = Field(
+        default=10,
+        description="Maximum recipients per email (to + cc + bcc combined)",
+    )
+
+
 class FilePersistenceBuiltinConfig(BuiltinItemConfig):
     """Configuration for the file persistence processor."""
 
@@ -339,6 +361,7 @@ class BuiltinsConfig(BaseModel):
     md2pdf: Md2pdfBuiltinConfig = Field(default_factory=Md2pdfBuiltinConfig)
     channel_history: ChannelHistoryBuiltinConfig = Field(default_factory=ChannelHistoryBuiltinConfig)
     gpt_researcher: GptResearcherBuiltinConfig = Field(default_factory=GptResearcherBuiltinConfig)
+    email: EmailBuiltinConfig = Field(default_factory=EmailBuiltinConfig)
 
     model_config = {"extra": "allow"}
 
@@ -371,6 +394,7 @@ class WorkspaceBuiltinsConfig(BaseModel):
     md2pdf: Md2pdfBuiltinConfig | None = None
     channel_history: ChannelHistoryBuiltinConfig | None = None
     gpt_researcher: GptResearcherBuiltinConfig | None = None
+    email: EmailBuiltinConfig | None = None
 
     model_config = {"extra": "allow"}
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -558,6 +558,104 @@ files = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+description = "Foreign Function Interface for Python calling C code."
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "(extra == \"email\" or extra == \"all-builtins\") and platform_python_implementation != \"PyPy\""
+files = [
+    {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
+    {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb"},
+    {file = "cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a"},
+    {file = "cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743"},
+    {file = "cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187"},
+    {file = "cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18"},
+    {file = "cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5"},
+    {file = "cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b"},
+    {file = "cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27"},
+    {file = "cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75"},
+    {file = "cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1"},
+    {file = "cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f"},
+    {file = "cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25"},
+    {file = "cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4"},
+    {file = "cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322"},
+    {file = "cffi-2.0.0-cp39-cp39-win32.whl", hash = "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a"},
+    {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
+    {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
+]
+
+[package.dependencies]
+pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -725,6 +823,79 @@ colorama = {version = "*", markers = "sys_platform == \"win32\""}
 
 [package.extras]
 development = ["black", "flake8", "mypy", "pytest", "types-colorama"]
+
+[[package]]
+name = "cryptography"
+version = "46.0.7"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = true
+python-versions = "!=3.9.0,!=3.9.1,>=3.8"
+groups = ["main"]
+markers = "extra == \"email\" or extra == \"all-builtins\""
+files = [
+    {file = "cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b"},
+    {file = "cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85"},
+    {file = "cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e"},
+    {file = "cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457"},
+    {file = "cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b"},
+    {file = "cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2"},
+    {file = "cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e"},
+    {file = "cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee"},
+    {file = "cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298"},
+    {file = "cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb"},
+    {file = "cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0"},
+    {file = "cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85"},
+    {file = "cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e"},
+    {file = "cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246"},
+    {file = "cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4"},
+    {file = "cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5"},
+]
+
+[package.dependencies]
+cffi = {version = ">=2.0.0", markers = "python_full_version >= \"3.9.0\" and platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs", "sphinx-rtd-theme (>=3.0.0)"]
+docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
+nox = ["nox[uv] (>=2024.4.15)"]
+pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.14)", "ruff (>=0.11.11)"]
+sdist = ["build (>=1.0.0)"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==46.0.7)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "cuda-bindings"
@@ -1355,6 +1526,118 @@ test-full = ["adlfs", "aiohttp (!=4.0.0a0,!=4.0.0a1)", "backports-zstd ; python_
 tqdm = ["tqdm"]
 
 [[package]]
+name = "google-api-core"
+version = "2.30.3"
+description = "Google API client core library"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"email\" or extra == \"all-builtins\""
+files = [
+    {file = "google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8"},
+    {file = "google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b"},
+]
+
+[package.dependencies]
+google-auth = ">=2.14.1,<3.0.0"
+googleapis-common-protos = ">=1.63.2,<2.0.0"
+proto-plus = [
+    {version = ">=1.22.3,<2.0.0"},
+    {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
+]
+protobuf = ">=4.25.8,<8.0.0"
+requests = ">=2.20.0,<3.0.0"
+
+[package.extras]
+async-rest = ["google-auth[aiohttp] (>=2.35.0,<3.0.0)"]
+grpc = ["grpcio (>=1.33.2,<2.0.0)", "grpcio (>=1.49.1,<2.0.0) ; python_version >= \"3.11\"", "grpcio (>=1.75.1,<2.0.0) ; python_version >= \"3.14\"", "grpcio-status (>=1.33.2,<2.0.0)", "grpcio-status (>=1.49.1,<2.0.0) ; python_version >= \"3.11\"", "grpcio-status (>=1.75.1,<2.0.0) ; python_version >= \"3.14\""]
+
+[[package]]
+name = "google-api-python-client"
+version = "2.194.0"
+description = "Google API Client Library for Python"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"email\" or extra == \"all-builtins\""
+files = [
+    {file = "google_api_python_client-2.194.0-py3-none-any.whl", hash = "sha256:61eaaac3b8fc8fdf11c08af87abc3d1342d1b37319cc1b57405f86ef7697e717"},
+    {file = "google_api_python_client-2.194.0.tar.gz", hash = "sha256:db92647bd1a90f40b79c9618461553c2b20b6a43ce7395fa6de07132dc14f023"},
+]
+
+[package.dependencies]
+google-api-core = ">=1.31.5,<2.0.dev0 || >2.3.0,<3.0.0"
+google-auth = ">=1.32.0,<2.24.0 || >2.24.0,<2.25.0 || >2.25.0,<3.0.0"
+google-auth-httplib2 = ">=0.2.0,<1.0.0"
+httplib2 = ">=0.19.0,<1.0.0"
+uritemplate = ">=3.0.1,<5"
+
+[[package]]
+name = "google-auth"
+version = "2.49.2"
+description = "Google Authentication Library"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"email\" or extra == \"all-builtins\""
+files = [
+    {file = "google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5"},
+    {file = "google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409"},
+]
+
+[package.dependencies]
+cryptography = ">=38.0.3"
+pyasn1-modules = ">=0.2.1"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.6.2,<4.0.0)", "requests (>=2.20.0,<3.0.0)"]
+cryptography = ["cryptography (>=38.0.3)"]
+enterprise-cert = ["pyopenssl"]
+pyjwt = ["pyjwt (>=2.0)"]
+pyopenssl = ["pyopenssl (>=20.0.0)"]
+reauth = ["pyu2f (>=0.1.5)"]
+requests = ["requests (>=2.20.0,<3.0.0)"]
+rsa = ["rsa (>=3.1.4,<5)"]
+testing = ["aiohttp (<3.10.0)", "aiohttp (>=3.6.2,<4.0.0)", "aioresponses", "flask", "freezegun", "grpcio", "packaging", "pyjwt (>=2.0)", "pyopenssl (<24.3.0)", "pyopenssl (>=20.0.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-localserver", "pyu2f (>=0.1.5)", "requests (>=2.20.0,<3.0.0)", "responses", "urllib3"]
+urllib3 = ["packaging", "urllib3"]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.3.1"
+description = "Google Authentication Library: httplib2 transport"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"email\" or extra == \"all-builtins\""
+files = [
+    {file = "google_auth_httplib2-0.3.1-py3-none-any.whl", hash = "sha256:682356a90ef4ba3d06548c37e9112eea6fc00395a11b0303a644c1a86abc275c"},
+    {file = "google_auth_httplib2-0.3.1.tar.gz", hash = "sha256:0af542e815784cb64159b4469aa5d71dd41069ba93effa006e1916b1dcd88e55"},
+]
+
+[package.dependencies]
+google-auth = ">=1.32.0,<3.0.0"
+httplib2 = ">=0.19.0,<1.0.0"
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.74.0"
+description = "Common protobufs used in Google APIs"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"email\" or extra == \"all-builtins\""
+files = [
+    {file = "googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5"},
+    {file = "googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1"},
+]
+
+[package.dependencies]
+protobuf = ">=4.25.8,<8.0.0"
+
+[package.extras]
+grpc = ["grpcio (>=1.44.0,<2.0.0)"]
+
+[[package]]
 name = "greenlet"
 version = "3.3.1"
 description = "Lightweight in-process concurrent programming"
@@ -1537,6 +1820,22 @@ asyncio = ["anyio (>=4.0,<5.0)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
 trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
+name = "httplib2"
+version = "0.31.2"
+description = "A comprehensive HTTP client library."
+optional = true
+python-versions = ">=3.6"
+groups = ["main"]
+markers = "extra == \"email\" or extra == \"all-builtins\""
+files = [
+    {file = "httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349"},
+    {file = "httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24"},
+]
+
+[package.dependencies]
+pyparsing = ">=3.1,<4"
 
 [[package]]
 name = "httpx"
@@ -4523,6 +4822,44 @@ files = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.27.2"
+description = "Beautiful, Pythonic protocol buffers"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"email\" or extra == \"all-builtins\""
+files = [
+    {file = "proto_plus-1.27.2-py3-none-any.whl", hash = "sha256:6432f75893d3b9e70b9c412f1d2f03f65b11fb164b793d14ae2ca01821d22718"},
+    {file = "proto_plus-1.27.2.tar.gz", hash = "sha256:b2adde53adadf75737c44d3dcb0104fde65250dfc83ad59168b4aa3e574b6a24"},
+]
+
+[package.dependencies]
+protobuf = ">=4.25.8,<8.0.0"
+
+[package.extras]
+testing = ["google-api-core (>=1.31.5)"]
+
+[[package]]
+name = "protobuf"
+version = "7.34.1"
+description = ""
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"email\" or extra == \"all-builtins\""
+files = [
+    {file = "protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7"},
+    {file = "protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b"},
+    {file = "protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a"},
+    {file = "protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4"},
+    {file = "protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a"},
+    {file = "protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c"},
+    {file = "protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11"},
+    {file = "protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280"},
+]
+
+[[package]]
 name = "psutil"
 version = "7.2.2"
 description = "Cross-platform lib for process and system monitoring."
@@ -4556,6 +4893,35 @@ files = [
 [package.extras]
 dev = ["abi3audit", "black", "check-manifest", "colorama ; os_name == \"nt\"", "coverage", "packaging", "psleak", "pylint", "pyperf", "pypinfo", "pyreadline3 ; os_name == \"nt\"", "pytest", "pytest-cov", "pytest-instafail", "pytest-xdist", "pywin32 ; os_name == \"nt\" and implementation_name != \"pypy\"", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "validate-pyproject[all]", "virtualenv", "vulture", "wheel", "wheel ; os_name == \"nt\" and implementation_name != \"pypy\"", "wmi ; os_name == \"nt\" and implementation_name != \"pypy\""]
 test = ["psleak", "pytest", "pytest-instafail", "pytest-xdist", "pywin32 ; os_name == \"nt\" and implementation_name != \"pypy\"", "setuptools", "wheel ; os_name == \"nt\" and implementation_name != \"pypy\"", "wmi ; os_name == \"nt\" and implementation_name != \"pypy\""]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"email\" or extra == \"all-builtins\""
+files = [
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+description = "A collection of ASN.1-based protocols modules"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"email\" or extra == \"all-builtins\""
+files = [
+    {file = "pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a"},
+    {file = "pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6"},
+]
+
+[package.dependencies]
+pyasn1 = ">=0.6.1,<0.7.0"
 
 [[package]]
 name = "pyclipper"
@@ -4601,6 +4967,19 @@ files = [
     {file = "pyclipper-1.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:29dae3e0296dff8502eeb7639fcfee794b0eec8590ba3563aee28db269da6b04"},
     {file = "pyclipper-1.4.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:98b2a40f98e1fc1b29e8a6094072e7e0c7dfe901e573bf6cfc6eb7ce84a7ae87"},
     {file = "pyclipper-1.4.0.tar.gz", hash = "sha256:9882bd889f27da78add4dd6f881d25697efc740bf840274e749988d25496c8e1"},
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+description = "C parser in Python"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "(extra == \"email\" or extra == \"all-builtins\") and implementation_name != \"PyPy\" and platform_python_implementation != \"PyPy\""
+files = [
+    {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
+    {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
 ]
 
 [[package]]
@@ -4957,6 +5336,22 @@ pyobjc-core = ">=12.1"
 pyobjc-framework-Cocoa = ">=12.1"
 pyobjc-framework-CoreML = ">=12.1"
 pyobjc-framework-Quartz = ">=12.1"
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+description = "pyparsing - Classes and methods to define and execute parsing grammars"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"email\" or extra == \"all-builtins\""
+files = [
+    {file = "pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d"},
+    {file = "pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc"},
+]
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pypdfium2"
@@ -7129,6 +7524,19 @@ tzdata = {version = "*", markers = "platform_system == \"Windows\""}
 devenv = ["check-manifest", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)", "zest.releaser"]
 
 [[package]]
+name = "uritemplate"
+version = "4.2.0"
+description = "Implementation of RFC 6570 URI Templates"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"email\" or extra == \"all-builtins\""
+files = [
+    {file = "uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686"},
+    {file = "uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -7724,7 +8132,8 @@ files = [
 cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and python_version < \"3.14\"", "cffi (>=2.0.0b) ; platform_python_implementation != \"PyPy\" and python_version >= \"3.14\""]
 
 [extras]
-all-builtins = ["elevenlabs", "httpx", "langchain-community", "openai", "sqlite-vec", "websockets"]
+all-builtins = ["elevenlabs", "google-api-python-client", "google-auth", "httpx", "langchain-community", "openai", "sqlite-vec", "websockets"]
+email = ["google-api-python-client", "google-auth"]
 memory = ["sqlite-vec"]
 researcher = ["httpx", "websockets"]
 voice = ["elevenlabs", "openai"]
@@ -7733,4 +8142,4 @@ web = ["langchain-community"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "a2045244d211e4694222eb9c3937056212be21458bd804f0797ed507770432c9"
+content-hash = "89f8a609f80ee4a6954ec82f9de1b968b3d37f9a23aa6d9c55b9efda50360d7b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,10 @@ researcher = [
     "websockets (>=12.0)",  # GPT-Researcher WebSocket streaming
     "httpx (>=0.27.0)",     # GPT-Researcher file upload
 ]
+email = [
+    "google-auth (>=2.0.0)",              # Google service account auth
+    "google-api-python-client (>=2.0.0)", # Gmail API client
+]
 all-builtins = [
     "openai (>=1.0.0)",
     "elevenlabs (>=1.0.0)",
@@ -56,6 +60,8 @@ all-builtins = [
     "sqlite-vec (>=0.1.6)",
     "websockets (>=12.0)",
     "httpx (>=0.27.0)",
+    "google-auth (>=2.0.0)",
+    "google-api-python-client (>=2.0.0)",
 ]
 
 

--- a/tests/builtins/__init__.py
+++ b/tests/builtins/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for OpenPaw builtins."""

--- a/tests/builtins/test_email_base.py
+++ b/tests/builtins/test_email_base.py
@@ -1,0 +1,482 @@
+"""Tests for email base data models and RecipientPolicy.
+
+Covers pure data model behaviour — no I/O, no API calls, no mocking needed.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from openpaw.builtins.tools.email.base import (
+    EmailAttachment,
+    EmailMessage,
+    RecipientPolicy,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_message(
+    *,
+    msg_id: str = "abc123",
+    thread_id: str = "thread_1",
+    subject: str = "Hello",
+    sender: str = "alice@example.com",
+    recipients: list[str] | None = None,
+    body: str = "Body text.",
+    date: datetime | None = None,
+    snippet: str = "Body text.",
+    cc: list[str] | None = None,
+    labels: list[str] | None = None,
+    attachments: list[EmailAttachment] | None = None,
+) -> EmailMessage:
+    return EmailMessage(
+        id=msg_id,
+        thread_id=thread_id,
+        subject=subject,
+        sender=sender,
+        recipients=recipients or ["bob@example.com"],
+        body=body,
+        date=date or datetime(2024, 3, 15, 10, 30, tzinfo=UTC),
+        snippet=snippet,
+        cc=cc or [],
+        labels=labels or [],
+        attachments=attachments or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# EmailAttachment
+# ---------------------------------------------------------------------------
+
+
+class TestEmailAttachment:
+    """Tests for the EmailAttachment dataclass."""
+
+    def test_minimal_construction(self) -> None:
+        att = EmailAttachment(
+            filename="invoice.pdf",
+            mime_type="application/pdf",
+            size_bytes=1024,
+        )
+        assert att.filename == "invoice.pdf"
+        assert att.mime_type == "application/pdf"
+        assert att.size_bytes == 1024
+        assert att.attachment_id == ""
+        assert att.content is None
+
+    def test_full_construction(self) -> None:
+        content = b"PDF content bytes"
+        att = EmailAttachment(
+            filename="report.pdf",
+            mime_type="application/pdf",
+            size_bytes=len(content),
+            attachment_id="att_abc123",
+            content=content,
+        )
+        assert att.attachment_id == "att_abc123"
+        assert att.content == content
+
+    def test_content_defaults_to_none(self) -> None:
+        att = EmailAttachment(filename="photo.jpg", mime_type="image/jpeg", size_bytes=50000)
+        assert att.content is None
+
+    def test_zero_size_is_valid(self) -> None:
+        att = EmailAttachment(filename="empty.txt", mime_type="text/plain", size_bytes=0)
+        assert att.size_bytes == 0
+
+
+# ---------------------------------------------------------------------------
+# EmailMessage.format_summary
+# ---------------------------------------------------------------------------
+
+
+class TestEmailMessageFormatSummary:
+    """Tests for EmailMessage.format_summary()."""
+
+    def test_includes_message_id(self) -> None:
+        msg = _make_message(msg_id="msg_xyz")
+        assert "msg_xyz" in msg.format_summary()
+
+    def test_includes_date_formatted_as_year_month_day(self) -> None:
+        msg = _make_message(date=datetime(2024, 7, 4, 9, 0, tzinfo=UTC))
+        assert "2024-07-04" in msg.format_summary()
+
+    def test_includes_sender(self) -> None:
+        msg = _make_message(sender="carol@example.com")
+        assert "carol@example.com" in msg.format_summary()
+
+    def test_includes_single_recipient(self) -> None:
+        msg = _make_message(recipients=["dan@example.com"])
+        assert "dan@example.com" in msg.format_summary()
+
+    def test_includes_multiple_recipients_comma_separated(self) -> None:
+        msg = _make_message(recipients=["dan@example.com", "eve@example.com"])
+        summary = msg.format_summary()
+        assert "dan@example.com" in summary
+        assert "eve@example.com" in summary
+
+    def test_includes_subject(self) -> None:
+        msg = _make_message(subject="Q4 Report")
+        assert "Q4 Report" in msg.format_summary()
+
+    def test_includes_snippet(self) -> None:
+        msg = _make_message(snippet="Please review the attached...")
+        assert "Please review the attached..." in msg.format_summary()
+
+    def test_no_attachment_note_when_empty(self) -> None:
+        msg = _make_message(attachments=[])
+        assert "attachment" not in msg.format_summary()
+
+    def test_attachment_count_shown_when_present(self) -> None:
+        atts = [
+            EmailAttachment(filename=f"file{i}.pdf", mime_type="application/pdf", size_bytes=100)
+            for i in range(3)
+        ]
+        msg = _make_message(attachments=atts)
+        summary = msg.format_summary()
+        assert "3 attachment" in summary
+
+    def test_cc_shown_when_present(self) -> None:
+        msg = _make_message(cc=["manager@example.com"])
+        assert "manager@example.com" in msg.format_summary()
+
+    def test_no_cc_section_when_empty(self) -> None:
+        msg = _make_message(cc=[])
+        assert "CC:" not in msg.format_summary()
+
+    def test_single_attachment_uses_correct_plural(self) -> None:
+        att = EmailAttachment(filename="single.pdf", mime_type="application/pdf", size_bytes=500)
+        msg = _make_message(attachments=[att])
+        assert "1 attachment" in msg.format_summary()
+
+
+# ---------------------------------------------------------------------------
+# EmailMessage.format_full
+# ---------------------------------------------------------------------------
+
+
+class TestEmailMessageFormatFull:
+    """Tests for EmailMessage.format_full()."""
+
+    def test_includes_message_id(self) -> None:
+        msg = _make_message(msg_id="full_msg_001")
+        assert "full_msg_001" in msg.format_full()
+
+    def test_includes_thread_id(self) -> None:
+        msg = _make_message(thread_id="thread_99")
+        assert "thread_99" in msg.format_full()
+
+    def test_includes_date_with_seconds(self) -> None:
+        msg = _make_message(date=datetime(2024, 12, 25, 8, 30, 45, tzinfo=UTC))
+        full = msg.format_full()
+        assert "2024-12-25" in full
+        assert "08:30:45" in full
+
+    def test_includes_subject(self) -> None:
+        msg = _make_message(subject="Important Notice")
+        assert "Important Notice" in msg.format_full()
+
+    def test_includes_body(self) -> None:
+        msg = _make_message(body="This is the full body content.")
+        assert "This is the full body content." in msg.format_full()
+
+    def test_includes_separator_before_body(self) -> None:
+        msg = _make_message()
+        assert "---" in msg.format_full()
+
+    def test_attachment_section_when_present(self) -> None:
+        att = EmailAttachment(
+            filename="report.pdf",
+            mime_type="application/pdf",
+            size_bytes=2048,
+            attachment_id="att_001",
+        )
+        msg = _make_message(attachments=[att])
+        full = msg.format_full()
+        assert "Attachments:" in full
+        assert "report.pdf" in full
+        assert "att_001" in full
+
+    def test_attachment_size_formatted_in_kb(self) -> None:
+        att = EmailAttachment(
+            filename="big.zip",
+            mime_type="application/zip",
+            size_bytes=51200,  # 50 KB
+        )
+        msg = _make_message(attachments=[att])
+        assert "50.0 KB" in msg.format_full()
+
+    def test_no_attachments_section_when_empty(self) -> None:
+        msg = _make_message(attachments=[])
+        assert "Attachments:" not in msg.format_full()
+
+    def test_cc_section_when_present(self) -> None:
+        msg = _make_message(cc=["cc1@example.com", "cc2@example.com"])
+        full = msg.format_full()
+        assert "CC:" in full
+        assert "cc1@example.com" in full
+
+    def test_no_cc_section_when_empty(self) -> None:
+        msg = _make_message(cc=[])
+        assert "CC:" not in msg.format_full()
+
+    def test_labels_section_when_present(self) -> None:
+        msg = _make_message(labels=["INBOX", "UNREAD"])
+        full = msg.format_full()
+        assert "Labels:" in full
+        assert "INBOX" in full
+
+    def test_no_labels_section_when_empty(self) -> None:
+        msg = _make_message(labels=[])
+        assert "Labels:" not in msg.format_full()
+
+    def test_multiple_attachments_all_listed(self) -> None:
+        atts = [
+            EmailAttachment(
+                filename=f"file{i}.txt",
+                mime_type="text/plain",
+                size_bytes=100 * (i + 1),
+                attachment_id=f"att_{i}",
+            )
+            for i in range(3)
+        ]
+        msg = _make_message(attachments=atts)
+        full = msg.format_full()
+        for i in range(3):
+            assert f"file{i}.txt" in full
+            assert f"att_{i}" in full
+
+
+# ---------------------------------------------------------------------------
+# RecipientPolicy.validate — empty allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestRecipientPolicyEmptyAllowlist:
+    """An empty allowed_patterns list must block ALL outbound sends."""
+
+    def test_blocks_any_single_recipient(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=[])
+        error = policy.validate(["anyone@anywhere.com"])
+        assert error is not None
+        assert "disabled" in error.lower() or "allowed_recipients" in error.lower()
+
+    def test_blocks_multiple_recipients(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=[])
+        error = policy.validate(["a@a.com", "b@b.com"])
+        assert error is not None
+
+    def test_error_mentions_configuration(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=[])
+        error = policy.validate(["x@y.com"])
+        assert "allowed_recipients" in error
+
+
+# ---------------------------------------------------------------------------
+# RecipientPolicy.validate — no recipients
+# ---------------------------------------------------------------------------
+
+
+class TestRecipientPolicyNoRecipients:
+    """Sending to an empty list must return an error."""
+
+    def test_empty_list_returns_error(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["*@example.com"])
+        error = policy.validate([])
+        assert error is not None
+        assert "no recipients" in error.lower()
+
+
+# ---------------------------------------------------------------------------
+# RecipientPolicy.validate — max recipients
+# ---------------------------------------------------------------------------
+
+
+class TestRecipientPolicyMaxRecipients:
+    """Exceeding max_recipients must return an informative error."""
+
+    def test_exactly_at_limit_is_allowed(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["*@example.com"], max_recipients=3)
+        error = policy.validate(["a@example.com", "b@example.com", "c@example.com"])
+        assert error is None
+
+    def test_one_over_limit_is_blocked(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["*@example.com"], max_recipients=2)
+        error = policy.validate(["a@example.com", "b@example.com", "c@example.com"])
+        assert error is not None
+        assert "3" in error
+        assert "2" in error
+
+    def test_error_mentions_maximum(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["*@example.com"], max_recipients=5)
+        recipients = [f"user{i}@example.com" for i in range(6)]
+        error = policy.validate(recipients)
+        assert "Maximum" in error or "maximum" in error
+
+
+# ---------------------------------------------------------------------------
+# RecipientPolicy.validate — wildcard patterns
+# ---------------------------------------------------------------------------
+
+
+class TestRecipientPolicyWildcard:
+    """Wildcard glob patterns must match correctly."""
+
+    def test_domain_wildcard_matches_any_user(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["*@company.com"])
+        assert policy.validate(["alice@company.com"]) is None
+        assert policy.validate(["bob@company.com"]) is None
+
+    def test_domain_wildcard_rejects_other_domain(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["*@company.com"])
+        error = policy.validate(["alice@other.com"])
+        assert error is not None
+
+    def test_full_wildcard_allows_anything(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["*"])
+        assert policy.validate(["anyone@anywhere.net"]) is None
+
+    def test_subdomain_pattern_matches_subdomain(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["*@*.company.com"])
+        assert policy.validate(["dev@mail.company.com"]) is None
+
+    def test_subdomain_pattern_does_not_match_root_domain(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["*@*.company.com"])
+        error = policy.validate(["dev@company.com"])
+        assert error is not None
+
+    def test_multiple_patterns_any_match_passes(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["*@company.com", "*@partner.org"])
+        assert policy.validate(["alice@company.com"]) is None
+        assert policy.validate(["bob@partner.org"]) is None
+
+    def test_multiple_patterns_no_match_blocked(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["*@company.com", "*@partner.org"])
+        error = policy.validate(["outsider@gmail.com"])
+        assert error is not None
+
+
+# ---------------------------------------------------------------------------
+# RecipientPolicy.validate — specific addresses
+# ---------------------------------------------------------------------------
+
+
+class TestRecipientPolicySpecificAddresses:
+    """Exact email address patterns must only match that address."""
+
+    def test_exact_match_passes(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["alice@example.com"])
+        assert policy.validate(["alice@example.com"]) is None
+
+    def test_different_user_blocked(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["alice@example.com"])
+        error = policy.validate(["bob@example.com"])
+        assert error is not None
+
+    def test_multiple_specific_addresses(self) -> None:
+        policy = RecipientPolicy(
+            allowed_patterns=["alice@example.com", "bob@example.com"]
+        )
+        assert policy.validate(["alice@example.com"]) is None
+        assert policy.validate(["bob@example.com"]) is None
+        assert policy.validate(["charlie@example.com"]) is not None
+
+
+# ---------------------------------------------------------------------------
+# RecipientPolicy.validate — case insensitivity
+# ---------------------------------------------------------------------------
+
+
+class TestRecipientPolicyCaseInsensitivity:
+    """Matching must be case-insensitive on both pattern and address."""
+
+    def test_uppercase_address_matches_lowercase_pattern(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["alice@example.com"])
+        assert policy.validate(["ALICE@EXAMPLE.COM"]) is None
+
+    def test_mixed_case_address_matches(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["alice@example.com"])
+        assert policy.validate(["Alice@Example.Com"]) is None
+
+    def test_uppercase_pattern_stored_lowercase(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["ALICE@EXAMPLE.COM"])
+        assert policy.validate(["alice@example.com"]) is None
+
+    def test_wildcard_pattern_case_insensitive(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["*@COMPANY.COM"])
+        assert policy.validate(["user@company.com"]) is None
+
+
+# ---------------------------------------------------------------------------
+# RecipientPolicy.validate — mixed allowed/blocked in a batch
+# ---------------------------------------------------------------------------
+
+
+class TestRecipientPolicyMixedBatch:
+    """When a batch has a mix of allowed and blocked, the whole batch is rejected."""
+
+    def test_one_blocked_in_batch_rejects_all(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["*@example.com"])
+        error = policy.validate(["alice@example.com", "outsider@gmail.com"])
+        assert error is not None
+
+    def test_error_names_the_blocked_address(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["*@example.com"])
+        error = policy.validate(["alice@example.com", "outsider@gmail.com"])
+        assert "outsider@gmail.com" in error
+
+    def test_all_allowed_passes_with_no_error(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["*@example.com"])
+        error = policy.validate(["alice@example.com", "bob@example.com"])
+        assert error is None
+
+    def test_multiple_blocked_addresses_all_named(self) -> None:
+        policy = RecipientPolicy(allowed_patterns=["*@company.com"])
+        error = policy.validate(
+            ["alice@company.com", "outsider@gmail.com", "hacker@evil.org"]
+        )
+        assert error is not None
+        assert "outsider@gmail.com" in error
+        assert "hacker@evil.org" in error
+
+
+# ---------------------------------------------------------------------------
+# RecipientPolicy — parametrize pattern matching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "pattern, address, should_pass",
+    [
+        # Exact matches
+        ("alice@example.com", "alice@example.com", True),
+        ("alice@example.com", "bob@example.com", False),
+        # Domain wildcards
+        ("*@example.com", "anyone@example.com", True),
+        ("*@example.com", "anyone@other.com", False),
+        # Full wildcard
+        ("*", "random@whatever.io", True),
+        # Case insensitivity
+        ("ALICE@EXAMPLE.COM", "alice@example.com", True),
+        ("alice@example.com", "ALICE@EXAMPLE.COM", True),
+        # Subdomain patterns
+        ("*@*.example.com", "user@mail.example.com", True),
+        ("*@*.example.com", "user@example.com", False),
+        # Prefix wildcard on user part
+        ("admin*@example.com", "admin@example.com", True),
+        ("admin*@example.com", "admintools@example.com", True),
+        ("admin*@example.com", "user@example.com", False),
+    ],
+)
+def test_recipient_policy_pattern_matching(
+    pattern: str, address: str, should_pass: bool
+) -> None:
+    policy = RecipientPolicy(allowed_patterns=[pattern])
+    error = policy.validate([address])
+    if should_pass:
+        assert error is None, f"Expected {address!r} to match {pattern!r}, but got: {error}"
+    else:
+        assert error is not None, f"Expected {address!r} to be blocked by {pattern!r}"

--- a/tests/builtins/test_email_gmail.py
+++ b/tests/builtins/test_email_gmail.py
@@ -1,0 +1,1056 @@
+"""Tests for the Gmail provider — pure parsing helpers and the GmailProvider class.
+
+All Google API calls are mocked. Pure helper functions are tested by importing
+them directly from the gmail module so there is no I/O.
+"""
+
+import base64
+import sys
+import types
+from datetime import UTC, datetime
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub out google.oauth2 / googleapiclient before importing the provider,
+# since those packages may not be installed in the test environment.
+# ---------------------------------------------------------------------------
+
+
+def _build_google_stubs() -> None:
+    """Register minimal google.* stubs in sys.modules if not already present."""
+    if "google" in sys.modules:
+        return
+
+    google = types.ModuleType("google")
+    oauth2 = types.ModuleType("google.oauth2")
+    sa = types.ModuleType("google.oauth2.service_account")
+
+    class _Credentials:
+        @classmethod
+        def from_service_account_file(cls, path: str, **kwargs: object) -> "_Credentials":
+            return cls()
+
+    sa.Credentials = _Credentials  # type: ignore[attr-defined]
+    oauth2.service_account = sa  # type: ignore[attr-defined]
+    google.oauth2 = oauth2  # type: ignore[attr-defined]
+
+    googleapiclient = types.ModuleType("googleapiclient")
+    discovery = types.ModuleType("googleapiclient.discovery")
+    discovery.build = MagicMock()  # type: ignore[attr-defined]
+    googleapiclient.discovery = discovery  # type: ignore[attr-defined]
+
+    errors_mod = types.ModuleType("googleapiclient.errors")
+
+    class HttpError(Exception):
+        def __init__(self, resp: object, content: bytes) -> None:
+            self.resp = resp
+            self.content = content
+
+    errors_mod.HttpError = HttpError  # type: ignore[attr-defined]
+    googleapiclient.errors = errors_mod  # type: ignore[attr-defined]
+
+    sys.modules["google"] = google
+    sys.modules["google.oauth2"] = oauth2
+    sys.modules["google.oauth2.service_account"] = sa
+    sys.modules["googleapiclient"] = googleapiclient
+    sys.modules["googleapiclient.discovery"] = discovery
+    sys.modules["googleapiclient.errors"] = errors_mod
+
+
+_build_google_stubs()
+
+# Now safe to import the module under test.
+from openpaw.builtins.tools.email.gmail import (  # noqa: E402
+    GmailProvider,
+    _build_mime_message,
+    _extract_body_and_attachments,
+    _extract_headers,
+    _format_api_error,
+    _pad_base64,
+    _parse_date,
+    _parse_gmail_message,
+    _split_addresses,
+    _strip_html,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _b64(text: str) -> str:
+    """Base64url-encode a string (no padding), as Gmail API does."""
+    return base64.urlsafe_b64encode(text.encode("utf-8")).decode("utf-8").rstrip("=")
+
+
+def _make_raw_message(
+    *,
+    msg_id: str = "msg001",
+    thread_id: str = "thread001",
+    snippet: str = "This is a snippet.",
+    labels: list[str] | None = None,
+    headers: list[dict] | None = None,
+    payload: dict | None = None,
+) -> dict:
+    """Build a minimal raw Gmail API message dict."""
+    default_headers = [
+        {"name": "From", "value": "alice@example.com"},
+        {"name": "To", "value": "bob@example.com"},
+        {"name": "Subject", "value": "Test Subject"},
+        {"name": "Date", "value": "Mon, 15 Jan 2024 10:30:00 +0000"},
+    ]
+    return {
+        "id": msg_id,
+        "threadId": thread_id,
+        "snippet": snippet,
+        "labelIds": labels or ["INBOX"],
+        "payload": payload or {"headers": headers or default_headers, "mimeType": "text/plain"},
+    }
+
+
+@pytest.fixture
+def provider() -> GmailProvider:
+    """Return a GmailProvider with mocked Google API service."""
+    with patch("google.oauth2.service_account.Credentials.from_service_account_file"):
+        with patch("googleapiclient.discovery.build"):
+            prov = GmailProvider(
+                service_account_file="/fake/sa.json",
+                delegated_user="agent@example.com",
+            )
+    # Inject a mock service so _get_service() returns without hitting disk/network.
+    prov._service = MagicMock()
+    return prov
+
+
+# ---------------------------------------------------------------------------
+# _extract_headers
+# ---------------------------------------------------------------------------
+
+
+class TestExtractHeaders:
+    """Tests for _extract_headers()."""
+
+    def test_empty_list_returns_empty_dict(self) -> None:
+        assert _extract_headers([]) == {}
+
+    def test_single_header_lowercased(self) -> None:
+        result = _extract_headers([{"name": "From", "value": "alice@example.com"}])
+        assert result == {"from": "alice@example.com"}
+
+    def test_multiple_headers(self) -> None:
+        headers = [
+            {"name": "From", "value": "alice@example.com"},
+            {"name": "To", "value": "bob@example.com"},
+            {"name": "Subject", "value": "Hi"},
+        ]
+        result = _extract_headers(headers)
+        assert result["from"] == "alice@example.com"
+        assert result["to"] == "bob@example.com"
+        assert result["subject"] == "Hi"
+
+    def test_duplicate_header_last_value_wins(self) -> None:
+        headers = [
+            {"name": "X-Header", "value": "first"},
+            {"name": "X-Header", "value": "second"},
+        ]
+        result = _extract_headers(headers)
+        assert result["x-header"] == "second"
+
+    def test_empty_name_entry_is_skipped(self) -> None:
+        headers = [
+            {"name": "", "value": "should-be-skipped"},
+            {"name": "Subject", "value": "Real"},
+        ]
+        result = _extract_headers(headers)
+        assert "" not in result
+        assert result["subject"] == "Real"
+
+    def test_mixed_case_header_names_normalized(self) -> None:
+        headers = [{"name": "Content-TYPE", "value": "text/plain"}]
+        assert _extract_headers(headers)["content-type"] == "text/plain"
+
+
+# ---------------------------------------------------------------------------
+# _parse_date
+# ---------------------------------------------------------------------------
+
+
+class TestParseDate:
+    """Tests for _parse_date()."""
+
+    def test_valid_rfc2822_date(self) -> None:
+        dt = _parse_date("Mon, 15 Jan 2024 10:30:00 +0000")
+        assert dt.year == 2024
+        assert dt.month == 1
+        assert dt.day == 15
+        assert dt.hour == 10
+        assert dt.tzinfo is not None
+
+    def test_empty_string_returns_epoch(self) -> None:
+        dt = _parse_date("")
+        assert dt == datetime.fromtimestamp(0, tz=UTC)
+
+    def test_invalid_string_returns_epoch(self) -> None:
+        dt = _parse_date("not-a-date-at-all")
+        assert dt == datetime.fromtimestamp(0, tz=UTC)
+
+    def test_result_is_timezone_aware(self) -> None:
+        dt = _parse_date("Fri, 01 Mar 2024 09:00:00 -0500")
+        assert dt.tzinfo is not None
+
+    def test_date_with_timezone_offset(self) -> None:
+        dt = _parse_date("Mon, 15 Jan 2024 10:30:00 +0500")
+        # Should parse successfully (tz-aware)
+        assert dt.year == 2024
+
+    def test_none_like_whitespace_returns_epoch(self) -> None:
+        dt = _parse_date("   ")
+        # " " is truthy so parsedate_to_datetime will be attempted and fail
+        assert dt.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# _split_addresses
+# ---------------------------------------------------------------------------
+
+
+class TestSplitAddresses:
+    """Tests for _split_addresses()."""
+
+    def test_empty_string_returns_empty_list(self) -> None:
+        assert _split_addresses("") == []
+
+    def test_whitespace_only_returns_empty_list(self) -> None:
+        assert _split_addresses("   ") == []
+
+    def test_single_address(self) -> None:
+        assert _split_addresses("alice@example.com") == ["alice@example.com"]
+
+    def test_multiple_comma_separated(self) -> None:
+        result = _split_addresses("alice@example.com, bob@example.com")
+        assert result == ["alice@example.com", "bob@example.com"]
+
+    def test_strips_whitespace_around_each_address(self) -> None:
+        result = _split_addresses("  alice@example.com  ,  bob@example.com  ")
+        assert result == ["alice@example.com", "bob@example.com"]
+
+    def test_display_name_format_preserved(self) -> None:
+        result = _split_addresses("Alice <alice@example.com>, Bob <bob@example.com>")
+        assert len(result) == 2
+        assert "Alice <alice@example.com>" in result
+
+    def test_empty_segments_filtered_out(self) -> None:
+        # Double commas produce empty segments.
+        result = _split_addresses("alice@example.com,,bob@example.com")
+        assert "" not in result
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# _pad_base64
+# ---------------------------------------------------------------------------
+
+
+class TestPadBase64:
+    """Tests for _pad_base64()."""
+
+    def test_no_padding_needed_when_divisible_by_four(self) -> None:
+        data = "ABCD"
+        assert _pad_base64(data) == "ABCD"
+
+    def test_adds_one_pad_char(self) -> None:
+        data = "ABC"  # length 3 → needs 1 padding
+        padded = _pad_base64(data)
+        assert padded == "ABC="
+
+    def test_adds_two_pad_chars(self) -> None:
+        data = "AB"  # length 2 → needs 2 padding
+        padded = _pad_base64(data)
+        assert padded == "AB=="
+
+    def test_adds_three_pad_chars(self) -> None:
+        data = "A"  # length 1 → needs 3 padding
+        padded = _pad_base64(data)
+        assert padded == "A==="
+
+    def test_padded_string_is_decodable(self) -> None:
+        original = "Hello, World!"
+        encoded = base64.urlsafe_b64encode(original.encode()).decode().rstrip("=")
+        decoded = base64.urlsafe_b64decode(_pad_base64(encoded)).decode()
+        assert decoded == original
+
+
+# ---------------------------------------------------------------------------
+# _strip_html
+# ---------------------------------------------------------------------------
+
+
+class TestStripHtml:
+    """Tests for _strip_html()."""
+
+    def test_plain_text_unchanged(self) -> None:
+        result = _strip_html("No tags here")
+        assert "No tags here" in result
+
+    def test_removes_simple_tags(self) -> None:
+        result = _strip_html("<p>Hello <b>World</b></p>")
+        assert "<p>" not in result
+        assert "<b>" not in result
+        assert "Hello" in result
+        assert "World" in result
+
+    def test_removes_html_and_body_tags(self) -> None:
+        html = "<html><body><p>Content</p></body></html>"
+        result = _strip_html(html)
+        assert "<html>" not in result
+        assert "Content" in result
+
+    def test_empty_string(self) -> None:
+        assert _strip_html("") == ""
+
+    def test_tags_only_returns_whitespace(self) -> None:
+        result = _strip_html("<br/><hr/>")
+        assert "<br" not in result
+
+    def test_preserves_text_content_from_nested_tags(self) -> None:
+        html = "<div><span><em>Nested</em></span></div>"
+        assert "Nested" in _strip_html(html)
+
+
+# ---------------------------------------------------------------------------
+# _format_api_error
+# ---------------------------------------------------------------------------
+
+
+class TestFormatApiError:
+    """Tests for _format_api_error()."""
+
+    def _exc_with_status(self, code: int) -> Exception:
+        """Create a minimal exception with a status_code attribute."""
+        exc = Exception("API error")
+        exc.status_code = code  # type: ignore[attr-defined]
+        return exc
+
+    def test_401_authentication_error(self) -> None:
+        result = _format_api_error("send email", self._exc_with_status(401))
+        assert "authentication" in result.lower() or "credentials" in result.lower()
+        assert "[Error:" in result
+
+    def test_403_access_denied_error(self) -> None:
+        result = _format_api_error("list messages", self._exc_with_status(403))
+        assert "access denied" in result.lower() or "delegation" in result.lower()
+        assert "[Error:" in result
+
+    def test_404_not_found_error(self) -> None:
+        result = _format_api_error("get message", self._exc_with_status(404))
+        assert "not found" in result.lower()
+        assert "[Error:" in result
+
+    def test_429_rate_limit_error(self) -> None:
+        result = _format_api_error("search", self._exc_with_status(429))
+        assert "rate limit" in result.lower()
+        assert "[Error:" in result
+
+    def test_500_server_error(self) -> None:
+        result = _format_api_error("send", self._exc_with_status(500))
+        assert "server error" in result.lower() or "500" in result
+        assert "[Error:" in result
+
+    def test_503_server_error(self) -> None:
+        result = _format_api_error("list", self._exc_with_status(503))
+        assert "[Error:" in result
+        assert "503" in result
+
+    def test_unknown_error_includes_exception_message(self) -> None:
+        exc = Exception("Something unusual happened")
+        result = _format_api_error("do something", exc)
+        assert "[Error:" in result
+
+    def test_no_status_code_falls_through_to_generic(self) -> None:
+        exc = ValueError("No status here")
+        result = _format_api_error("act", exc)
+        assert "[Error:" in result
+
+    def test_resp_dict_status_code_extracted(self) -> None:
+        """HttpError style: .resp object with 'status' attribute."""
+        exc = Exception("HttpError")
+        resp = MagicMock()
+        resp.status = "401"
+        exc.resp = resp  # type: ignore[attr-defined]
+        result = _format_api_error("fetch", exc)
+        assert "[Error:" in result
+        assert "authentication" in result.lower() or "credentials" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# _extract_body_and_attachments
+# ---------------------------------------------------------------------------
+
+
+class TestExtractBodyAndAttachments:
+    """Tests for _extract_body_and_attachments() via the payload walker."""
+
+    def test_simple_text_plain_message(self) -> None:
+        text = "Hello from plain text."
+        payload = {
+            "mimeType": "text/plain",
+            "body": {"data": _b64(text)},
+            "headers": [],
+        }
+        body, attachments = _extract_body_and_attachments(payload)
+        assert text in body
+        assert attachments == []
+
+    def test_html_only_message_strips_tags(self) -> None:
+        html = "<p>Hello from <b>HTML</b>.</p>"
+        payload = {
+            "mimeType": "text/html",
+            "body": {"data": _b64(html)},
+            "headers": [],
+        }
+        body, attachments = _extract_body_and_attachments(payload)
+        assert "<p>" not in body
+        assert "Hello" in body
+        assert "HTML" in body
+        assert attachments == []
+
+    def test_multipart_plain_and_html_prefers_plain(self) -> None:
+        plain_text = "Plain text version."
+        html_text = "<p>HTML version.</p>"
+        payload = {
+            "mimeType": "multipart/alternative",
+            "body": {},
+            "headers": [],
+            "parts": [
+                {"mimeType": "text/plain", "body": {"data": _b64(plain_text)}, "headers": []},
+                {"mimeType": "text/html", "body": {"data": _b64(html_text)}, "headers": []},
+            ],
+        }
+        body, _ = _extract_body_and_attachments(payload)
+        assert plain_text in body
+        # HTML version should not bleed through
+        assert "<p>" not in body
+
+    def test_attachment_extracted_with_metadata(self) -> None:
+        payload = {
+            "mimeType": "multipart/mixed",
+            "body": {},
+            "headers": [],
+            "parts": [
+                {
+                    "mimeType": "text/plain",
+                    "body": {"data": _b64("Body text.")},
+                    "headers": [],
+                },
+                {
+                    "mimeType": "application/pdf",
+                    "filename": "invoice.pdf",
+                    "body": {"attachmentId": "att_001", "size": 2048},
+                    "headers": [],
+                },
+            ],
+        }
+        body, attachments = _extract_body_and_attachments(payload)
+        assert "Body text." in body
+        assert len(attachments) == 1
+        assert attachments[0].filename == "invoice.pdf"
+        assert attachments[0].attachment_id == "att_001"
+        assert attachments[0].size_bytes == 2048
+        assert attachments[0].mime_type == "application/pdf"
+        assert attachments[0].content is None
+
+    def test_inline_image_skipped(self) -> None:
+        """Inline images (with Content-ID and inline disposition) should not appear as attachments."""
+        payload = {
+            "mimeType": "multipart/related",
+            "body": {},
+            "headers": [],
+            "parts": [
+                {
+                    "mimeType": "image/png",
+                    "filename": "logo.png",
+                    "body": {"attachmentId": "att_img", "size": 512},
+                    "headers": [
+                        {"name": "Content-Disposition", "value": "inline"},
+                        {"name": "Content-ID", "value": "<logo@example.com>"},
+                    ],
+                },
+            ],
+        }
+        _, attachments = _extract_body_and_attachments(payload)
+        assert attachments == []
+
+    def test_multiple_attachments(self) -> None:
+        payload = {
+            "mimeType": "multipart/mixed",
+            "body": {},
+            "headers": [],
+            "parts": [
+                {
+                    "mimeType": "application/pdf",
+                    "filename": "file1.pdf",
+                    "body": {"attachmentId": "att_1", "size": 1000},
+                    "headers": [],
+                },
+                {
+                    "mimeType": "application/zip",
+                    "filename": "file2.zip",
+                    "body": {"attachmentId": "att_2", "size": 2000},
+                    "headers": [],
+                },
+            ],
+        }
+        _, attachments = _extract_body_and_attachments(payload)
+        assert len(attachments) == 2
+        filenames = {a.filename for a in attachments}
+        assert "file1.pdf" in filenames
+        assert "file2.zip" in filenames
+
+    def test_empty_payload_returns_empty_body_and_no_attachments(self) -> None:
+        body, attachments = _extract_body_and_attachments({})
+        assert body == ""
+        assert attachments == []
+
+    def test_nested_multipart_traversal(self) -> None:
+        """Plain text buried inside nested multipart parts should still be found."""
+        inner_text = "Deep nested plain text."
+        payload = {
+            "mimeType": "multipart/mixed",
+            "body": {},
+            "headers": [],
+            "parts": [
+                {
+                    "mimeType": "multipart/alternative",
+                    "body": {},
+                    "headers": [],
+                    "parts": [
+                        {
+                            "mimeType": "text/plain",
+                            "body": {"data": _b64(inner_text)},
+                            "headers": [],
+                        }
+                    ],
+                }
+            ],
+        }
+        body, _ = _extract_body_and_attachments(payload)
+        assert inner_text in body
+
+
+# ---------------------------------------------------------------------------
+# _parse_gmail_message
+# ---------------------------------------------------------------------------
+
+
+class TestParseGmailMessage:
+    """Tests for _parse_gmail_message()."""
+
+    def test_basic_message_fields_populated(self) -> None:
+        raw = _make_raw_message(msg_id="xyz", thread_id="thr")
+        msg = _parse_gmail_message(raw, include_body=False)
+        assert msg.id == "xyz"
+        assert msg.thread_id == "thr"
+
+    def test_subject_from_headers(self) -> None:
+        raw = _make_raw_message(
+            headers=[
+                {"name": "From", "value": "a@b.com"},
+                {"name": "To", "value": "c@d.com"},
+                {"name": "Subject", "value": "My Subject"},
+                {"name": "Date", "value": "Mon, 15 Jan 2024 10:00:00 +0000"},
+            ]
+        )
+        msg = _parse_gmail_message(raw, include_body=False)
+        assert msg.subject == "My Subject"
+
+    def test_missing_subject_defaults_to_no_subject(self) -> None:
+        raw = _make_raw_message(
+            headers=[
+                {"name": "From", "value": "a@b.com"},
+                {"name": "To", "value": "c@d.com"},
+                {"name": "Date", "value": "Mon, 15 Jan 2024 10:00:00 +0000"},
+            ]
+        )
+        msg = _parse_gmail_message(raw, include_body=False)
+        assert msg.subject == "(no subject)"
+
+    def test_snippet_extracted(self) -> None:
+        raw = _make_raw_message(snippet="Quick preview here.")
+        msg = _parse_gmail_message(raw, include_body=False)
+        assert msg.snippet == "Quick preview here."
+
+    def test_labels_extracted(self) -> None:
+        raw = _make_raw_message(labels=["INBOX", "UNREAD", "IMPORTANT"])
+        msg = _parse_gmail_message(raw, include_body=False)
+        assert "INBOX" in msg.labels
+        assert "UNREAD" in msg.labels
+
+    def test_body_empty_when_include_body_false(self) -> None:
+        raw = _make_raw_message()
+        msg = _parse_gmail_message(raw, include_body=False)
+        assert msg.body == ""
+
+    def test_body_populated_when_include_body_true(self) -> None:
+        body_text = "This is the full body."
+        payload = {
+            "headers": [
+                {"name": "From", "value": "a@b.com"},
+                {"name": "To", "value": "c@d.com"},
+                {"name": "Date", "value": "Mon, 15 Jan 2024 10:00:00 +0000"},
+                {"name": "Subject", "value": "Subj"},
+            ],
+            "mimeType": "text/plain",
+            "body": {"data": _b64(body_text)},
+        }
+        raw = _make_raw_message(payload=payload)
+        msg = _parse_gmail_message(raw, include_body=True)
+        assert body_text in msg.body
+
+    def test_recipients_parsed_from_to_header(self) -> None:
+        raw = _make_raw_message(
+            headers=[
+                {"name": "From", "value": "sender@example.com"},
+                {"name": "To", "value": "r1@example.com, r2@example.com"},
+                {"name": "Date", "value": "Mon, 15 Jan 2024 10:00:00 +0000"},
+            ]
+        )
+        msg = _parse_gmail_message(raw, include_body=False)
+        assert "r1@example.com" in msg.recipients
+        assert "r2@example.com" in msg.recipients
+
+    def test_cc_parsed_from_cc_header(self) -> None:
+        raw = _make_raw_message(
+            headers=[
+                {"name": "From", "value": "a@b.com"},
+                {"name": "To", "value": "c@d.com"},
+                {"name": "Cc", "value": "cc1@example.com, cc2@example.com"},
+                {"name": "Date", "value": "Mon, 15 Jan 2024 10:00:00 +0000"},
+            ]
+        )
+        msg = _parse_gmail_message(raw, include_body=False)
+        assert "cc1@example.com" in msg.cc
+        assert "cc2@example.com" in msg.cc
+
+    def test_attachments_not_populated_when_include_body_false(self) -> None:
+        raw = _make_raw_message()
+        msg = _parse_gmail_message(raw, include_body=False)
+        assert msg.attachments == []
+
+    def test_body_truncated_at_max_chars(self) -> None:
+        """Body should be capped at _MAX_BODY_CHARS characters."""
+        from openpaw.builtins.tools.email.gmail import _MAX_BODY_CHARS
+
+        long_body = "x" * (_MAX_BODY_CHARS + 1000)
+        payload = {
+            "headers": [
+                {"name": "From", "value": "a@b.com"},
+                {"name": "To", "value": "c@d.com"},
+                {"name": "Date", "value": "Mon, 15 Jan 2024 10:00:00 +0000"},
+            ],
+            "mimeType": "text/plain",
+            "body": {"data": _b64(long_body)},
+        }
+        raw = _make_raw_message(payload=payload)
+        msg = _parse_gmail_message(raw, include_body=True)
+        assert len(msg.body) == _MAX_BODY_CHARS
+
+
+# ---------------------------------------------------------------------------
+# _build_mime_message
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMimeMessage:
+    """Tests for _build_mime_message()."""
+
+    def test_simple_message_is_mime_text(self) -> None:
+        msg = _build_mime_message(
+            sender="a@b.com",
+            to=["c@d.com"],
+            subject="Hello",
+            body="Body text.",
+            cc=None,
+            bcc=None,
+            reply_to_message_id=None,
+            attachments=None,
+        )
+        assert isinstance(msg, MIMEText)
+
+    def test_message_with_attachments_is_multipart(self) -> None:
+        atts = [("file.txt", b"content", "text/plain")]
+        msg = _build_mime_message(
+            sender="a@b.com",
+            to=["c@d.com"],
+            subject="Hello",
+            body="Body.",
+            cc=None,
+            bcc=None,
+            reply_to_message_id=None,
+            attachments=atts,
+        )
+        assert isinstance(msg, MIMEMultipart)
+
+    def test_from_header_set(self) -> None:
+        msg = _build_mime_message(
+            sender="sender@example.com",
+            to=["r@example.com"],
+            subject="S",
+            body="B",
+            cc=None,
+            bcc=None,
+            reply_to_message_id=None,
+            attachments=None,
+        )
+        assert msg["From"] == "sender@example.com"
+
+    def test_to_header_multiple_recipients_joined(self) -> None:
+        msg = _build_mime_message(
+            sender="s@example.com",
+            to=["a@example.com", "b@example.com"],
+            subject="S",
+            body="B",
+            cc=None,
+            bcc=None,
+            reply_to_message_id=None,
+            attachments=None,
+        )
+        assert "a@example.com" in msg["To"]
+        assert "b@example.com" in msg["To"]
+
+    def test_cc_header_set_when_provided(self) -> None:
+        msg = _build_mime_message(
+            sender="s@example.com",
+            to=["r@example.com"],
+            subject="S",
+            body="B",
+            cc=["cc@example.com"],
+            bcc=None,
+            reply_to_message_id=None,
+            attachments=None,
+        )
+        assert msg["Cc"] == "cc@example.com"
+
+    def test_bcc_header_set_when_provided(self) -> None:
+        msg = _build_mime_message(
+            sender="s@example.com",
+            to=["r@example.com"],
+            subject="S",
+            body="B",
+            cc=None,
+            bcc=["bcc@example.com"],
+            reply_to_message_id=None,
+            attachments=None,
+        )
+        assert msg["Bcc"] == "bcc@example.com"
+
+    def test_no_cc_header_when_none(self) -> None:
+        msg = _build_mime_message(
+            sender="s@example.com",
+            to=["r@example.com"],
+            subject="S",
+            body="B",
+            cc=None,
+            bcc=None,
+            reply_to_message_id=None,
+            attachments=None,
+        )
+        assert msg["Cc"] is None
+
+    def test_reply_sets_in_reply_to_header(self) -> None:
+        msg = _build_mime_message(
+            sender="s@example.com",
+            to=["r@example.com"],
+            subject="Re: Orig",
+            body="Reply body.",
+            cc=None,
+            bcc=None,
+            reply_to_message_id="abc123@mail.example.com",
+            attachments=None,
+        )
+        assert "<abc123@mail.example.com>" in msg["In-Reply-To"]
+
+    def test_reply_sets_references_header(self) -> None:
+        msg = _build_mime_message(
+            sender="s@example.com",
+            to=["r@example.com"],
+            subject="Re: Orig",
+            body="Reply body.",
+            cc=None,
+            bcc=None,
+            reply_to_message_id="abc123@mail.example.com",
+            attachments=None,
+        )
+        assert "<abc123@mail.example.com>" in msg["References"]
+
+    def test_reply_strips_angle_brackets_from_message_id(self) -> None:
+        """If caller already includes angle brackets, they should not be doubled."""
+        msg = _build_mime_message(
+            sender="s@example.com",
+            to=["r@example.com"],
+            subject="Re: S",
+            body="B",
+            cc=None,
+            bcc=None,
+            reply_to_message_id="<already-bracketed@example.com>",
+            attachments=None,
+        )
+        # Should appear exactly once with one pair of brackets.
+        in_reply_to = msg["In-Reply-To"]
+        assert in_reply_to.count("<") == 1
+        assert in_reply_to.count(">") == 1
+
+    def test_attachment_added_to_multipart(self) -> None:
+        content = b"Hello attachment"
+        atts = [("hello.txt", content, "text/plain")]
+        msg = _build_mime_message(
+            sender="s@example.com",
+            to=["r@example.com"],
+            subject="With attachment",
+            body="See attached.",
+            cc=None,
+            bcc=None,
+            reply_to_message_id=None,
+            attachments=atts,
+        )
+        assert isinstance(msg, MIMEMultipart)
+        # There should be at least two parts: body + attachment.
+        assert len(msg.get_payload()) >= 2
+
+    def test_attachment_with_unknown_mime_type_uses_application(self) -> None:
+        """MIME type without subtype (malformed) should fall back to MIMEApplication."""
+        atts = [("weirdfile.xyz", b"data", "application/octet-stream")]
+        msg = _build_mime_message(
+            sender="s@example.com",
+            to=["r@example.com"],
+            subject="S",
+            body="B",
+            cc=None,
+            bcc=None,
+            reply_to_message_id=None,
+            attachments=atts,
+        )
+        assert isinstance(msg, MIMEMultipart)
+
+
+# ---------------------------------------------------------------------------
+# GmailProvider — integration-style with mocked service
+# ---------------------------------------------------------------------------
+
+
+class TestGmailProviderSend:
+    """Tests for GmailProvider.send() with a mocked Gmail service."""
+
+    @pytest.mark.asyncio
+    async def test_successful_send_returns_message_id(self, provider: GmailProvider) -> None:
+        provider._service.users.return_value.messages.return_value.send.return_value.execute.return_value = {
+            "id": "sent_msg_001"
+        }
+        result = await provider.send(
+            to=["recipient@example.com"],
+            subject="Test",
+            body="Hello.",
+        )
+        assert result == "sent_msg_001"
+
+    @pytest.mark.asyncio
+    async def test_api_error_returns_error_string(self, provider: GmailProvider) -> None:
+        exc = Exception("API failure")
+        exc.status_code = 500  # type: ignore[attr-defined]
+        provider._service.users.return_value.messages.return_value.send.return_value.execute.side_effect = exc
+
+        with pytest.raises(RuntimeError):
+            await provider.send(
+                to=["recipient@example.com"],
+                subject="Test",
+                body="Hello.",
+            )
+
+    @pytest.mark.asyncio
+    async def test_send_with_thread_id_included_in_payload(
+        self, provider: GmailProvider
+    ) -> None:
+        execute_mock = MagicMock(return_value={"id": "sent_001"})
+        send_mock = MagicMock()
+        send_mock.execute = execute_mock
+
+        messages_mock = MagicMock()
+        messages_mock.send = MagicMock(return_value=send_mock)
+        provider._service.users.return_value.messages.return_value = messages_mock
+
+        await provider.send(
+            to=["r@example.com"],
+            subject="Re: Thread",
+            body="Reply.",
+            thread_id="thread_abc",
+        )
+
+        call_kwargs = messages_mock.send.call_args[1]
+        assert call_kwargs["body"].get("threadId") == "thread_abc"
+
+
+class TestGmailProviderMarkAsRead:
+    """Tests for GmailProvider.mark_as_read()."""
+
+    @pytest.mark.asyncio
+    async def test_mark_as_read_calls_modify_with_remove_unread(
+        self, provider: GmailProvider
+    ) -> None:
+        modify_mock = MagicMock()
+        modify_mock.execute = MagicMock(return_value={})
+        provider._service.users.return_value.messages.return_value.modify.return_value = (
+            modify_mock
+        )
+
+        await provider.mark_as_read("msg_001")
+
+        provider._service.users.return_value.messages.return_value.modify.assert_called_once()
+        call_kwargs = provider._service.users.return_value.messages.return_value.modify.call_args[1]
+        assert "UNREAD" in call_kwargs["body"]["removeLabelIds"]
+
+    @pytest.mark.asyncio
+    async def test_mark_as_read_raises_on_api_error(self, provider: GmailProvider) -> None:
+        provider._service.users.return_value.messages.return_value.modify.return_value.execute.side_effect = Exception(
+            "API down"
+        )
+        with pytest.raises(RuntimeError):
+            await provider.mark_as_read("msg_001")
+
+
+class TestGmailProviderMarkAsUnread:
+    """Tests for GmailProvider.mark_as_unread()."""
+
+    @pytest.mark.asyncio
+    async def test_mark_as_unread_calls_modify_with_add_unread(
+        self, provider: GmailProvider
+    ) -> None:
+        modify_mock = MagicMock()
+        modify_mock.execute = MagicMock(return_value={})
+        provider._service.users.return_value.messages.return_value.modify.return_value = (
+            modify_mock
+        )
+
+        await provider.mark_as_unread("msg_002")
+
+        call_kwargs = provider._service.users.return_value.messages.return_value.modify.call_args[1]
+        assert "UNREAD" in call_kwargs["body"]["addLabelIds"]
+
+    @pytest.mark.asyncio
+    async def test_mark_as_unread_raises_on_api_error(self, provider: GmailProvider) -> None:
+        provider._service.users.return_value.messages.return_value.modify.return_value.execute.side_effect = Exception(
+            "Network error"
+        )
+        with pytest.raises(RuntimeError):
+            await provider.mark_as_unread("msg_002")
+
+
+class TestGmailProviderDownloadAttachment:
+    """Tests for GmailProvider.download_attachment()."""
+
+    @pytest.mark.asyncio
+    async def test_successful_download_returns_attachment_with_content(
+        self, provider: GmailProvider
+    ) -> None:
+        raw_bytes = b"PDF content here"
+        encoded = base64.urlsafe_b64encode(raw_bytes).decode()
+        att_chain = provider._service.users.return_value.messages.return_value
+        att_chain.attachments.return_value.get.return_value.execute.return_value = {
+            "data": encoded,
+            "size": len(raw_bytes),
+        }
+
+        att = await provider.download_attachment("msg_001", "att_001")
+
+        assert att.content == raw_bytes
+        assert att.size_bytes == len(raw_bytes)
+        assert att.attachment_id == "att_001"
+
+    @pytest.mark.asyncio
+    async def test_download_failure_raises_runtime_error(
+        self, provider: GmailProvider
+    ) -> None:
+        att_chain = provider._service.users.return_value.messages.return_value
+        att_chain.attachments.return_value.get.return_value.execute.side_effect = Exception(
+            "Download failed"
+        )
+        with pytest.raises(RuntimeError):
+            await provider.download_attachment("msg_001", "att_bad")
+
+
+class TestGmailProviderGetMessage:
+    """Tests for GmailProvider.get_message()."""
+
+    def _make_full_raw(self) -> dict:
+        body_text = "Full body content."
+        return {
+            "id": "msg_full",
+            "threadId": "thr_full",
+            "snippet": "Full body content.",
+            "labelIds": ["INBOX"],
+            "payload": {
+                "headers": [
+                    {"name": "From", "value": "sender@example.com"},
+                    {"name": "To", "value": "recipient@example.com"},
+                    {"name": "Subject", "value": "Full Message"},
+                    {"name": "Date", "value": "Tue, 20 Feb 2024 14:00:00 +0000"},
+                ],
+                "mimeType": "text/plain",
+                "body": {"data": _b64(body_text)},
+            },
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_message_returns_email_message(self, provider: GmailProvider) -> None:
+        provider._service.users.return_value.messages.return_value.get.return_value.execute.return_value = (
+            self._make_full_raw()
+        )
+
+        msg = await provider.get_message("msg_full")
+
+        assert msg.id == "msg_full"
+        assert msg.subject == "Full Message"
+        assert "Full body content." in msg.body
+
+    @pytest.mark.asyncio
+    async def test_get_message_raises_on_api_failure(self, provider: GmailProvider) -> None:
+        provider._service.users.return_value.messages.return_value.get.return_value.execute.side_effect = Exception(
+            "Not found"
+        )
+        with pytest.raises(RuntimeError):
+            await provider.get_message("nonexistent")
+
+
+class TestGmailProviderListMessages:
+    """Tests for GmailProvider.list_messages()."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_no_messages(self, provider: GmailProvider) -> None:
+        provider._service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
+            "messages": []
+        }
+
+        result = await provider.list_messages()
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_caps_max_results_at_100(self, provider: GmailProvider) -> None:
+        list_mock = MagicMock()
+        list_mock.execute.return_value = {"messages": []}
+        provider._service.users.return_value.messages.return_value.list.return_value = list_mock
+
+        await provider.list_messages(max_results=200)
+
+        call_kwargs = provider._service.users.return_value.messages.return_value.list.call_args[1]
+        assert call_kwargs["maxResults"] <= 100
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_on_api_error(self, provider: GmailProvider) -> None:
+        provider._service.users.return_value.messages.return_value.list.return_value.execute.side_effect = Exception(
+            "Service unavailable"
+        )
+
+        result = await provider.list_messages()
+        assert result == []

--- a/tests/builtins/test_email_tools.py
+++ b/tests/builtins/test_email_tools.py
@@ -1,0 +1,1027 @@
+"""Tests for the EmailToolBuiltin tool layer.
+
+All EmailProvider calls are replaced with a MockEmailProvider to isolate
+the tool logic from transport-level concerns.
+"""
+
+import sys
+import types
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from openpaw.builtins.tools.email.base import (
+    EmailAttachment,
+    EmailMessage,
+    EmailProvider,
+)
+
+# ---------------------------------------------------------------------------
+# Stub out google packages so EmailToolBuiltin can be imported without them.
+# ---------------------------------------------------------------------------
+
+
+def _ensure_google_stubs() -> None:
+    if "google" in sys.modules:
+        return
+    google = types.ModuleType("google")
+    oauth2 = types.ModuleType("google.oauth2")
+    sa = types.ModuleType("google.oauth2.service_account")
+    sa.Credentials = MagicMock()  # type: ignore[attr-defined]
+    oauth2.service_account = sa  # type: ignore[attr-defined]
+    google.oauth2 = oauth2  # type: ignore[attr-defined]
+    googleapiclient = types.ModuleType("googleapiclient")
+    discovery = types.ModuleType("googleapiclient.discovery")
+    discovery.build = MagicMock()  # type: ignore[attr-defined]
+    googleapiclient.discovery = discovery  # type: ignore[attr-defined]
+    sys.modules["google"] = google
+    sys.modules["google.oauth2"] = oauth2
+    sys.modules["google.oauth2.service_account"] = sa
+    sys.modules["googleapiclient"] = googleapiclient
+    sys.modules["googleapiclient.discovery"] = discovery
+
+
+_ensure_google_stubs()
+
+from openpaw.builtins.tools.email import EmailToolBuiltin  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Mock provider
+# ---------------------------------------------------------------------------
+
+
+class MockEmailProvider(EmailProvider):
+    """In-memory EmailProvider for testing — no I/O, configurable return values."""
+
+    def __init__(self) -> None:
+        self.sent_messages: list[dict] = []
+        self.send_result: str = "mock_sent_id"
+        self.send_exception: Exception | None = None
+        self.list_result: list[EmailMessage] = []
+        self.get_result: EmailMessage | None = None
+        self.get_exception: Exception | None = None
+        self.search_result: list[EmailMessage] = []
+        self.download_result: EmailAttachment | None = None
+        self.download_exception: Exception | None = None
+        self.mark_read_exception: Exception | None = None
+        self.mark_unread_exception: Exception | None = None
+
+    async def send(
+        self,
+        to: list[str],
+        subject: str,
+        body: str,
+        cc: list[str] | None = None,
+        bcc: list[str] | None = None,
+        reply_to_message_id: str | None = None,
+        thread_id: str | None = None,
+        attachments: list[tuple[str, bytes, str]] | None = None,
+    ) -> str:
+        if self.send_exception:
+            raise self.send_exception
+        self.sent_messages.append(
+            {
+                "to": to,
+                "subject": subject,
+                "body": body,
+                "cc": cc,
+                "bcc": bcc,
+                "reply_to_message_id": reply_to_message_id,
+                "thread_id": thread_id,
+            }
+        )
+        return self.send_result
+
+    async def list_messages(
+        self, max_results: int = 10, label: str = "INBOX"
+    ) -> list[EmailMessage]:
+        return self.list_result
+
+    async def get_message(self, message_id: str) -> EmailMessage:
+        if self.get_exception:
+            raise self.get_exception
+        if self.get_result:
+            return self.get_result
+        raise RuntimeError(f"No mock result set for message_id={message_id}")
+
+    async def search(self, query: str, max_results: int = 10) -> list[EmailMessage]:
+        return self.search_result
+
+    async def download_attachment(
+        self,
+        message_id: str,
+        attachment_id: str,
+        filename_hint: str = "",
+    ) -> EmailAttachment:
+        if self.download_exception:
+            raise self.download_exception
+        if self.download_result:
+            return self.download_result
+        raise RuntimeError("No mock download result set")
+
+    async def mark_as_read(self, message_id: str) -> None:
+        if self.mark_read_exception:
+            raise self.mark_read_exception
+
+    async def mark_as_unread(self, message_id: str) -> None:
+        if self.mark_unread_exception:
+            raise self.mark_unread_exception
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_email_message(
+    *,
+    msg_id: str = "msg001",
+    thread_id: str = "thread001",
+    subject: str = "Test Subject",
+    sender: str = "alice@example.com",
+    recipients: list[str] | None = None,
+    body: str = "Email body.",
+    snippet: str = "Email body.",
+    cc: list[str] | None = None,
+    labels: list[str] | None = None,
+    attachments: list[EmailAttachment] | None = None,
+) -> EmailMessage:
+    return EmailMessage(
+        id=msg_id,
+        thread_id=thread_id,
+        subject=subject,
+        sender=sender,
+        recipients=recipients or ["bob@example.com"],
+        body=body,
+        date=datetime(2024, 3, 15, 10, 30, tzinfo=UTC),
+        snippet=snippet,
+        cc=cc or [],
+        labels=labels or ["INBOX"],
+        attachments=attachments or [],
+    )
+
+
+def _make_builtin(
+    *,
+    workspace_path: Path | None = None,
+    allowed_recipients: list[str] | None = None,
+    max_recipients: int = 10,
+    provider: MockEmailProvider | None = None,
+) -> EmailToolBuiltin:
+    """Construct an EmailToolBuiltin with a mock provider injected directly."""
+    config: dict = {
+        "allowed_recipients": allowed_recipients or ["*@example.com"],
+        "max_recipients": max_recipients,
+    }
+    if workspace_path:
+        config["workspace_path"] = str(workspace_path)
+    # Bypass __init__ provider construction by passing no service_account_file.
+    builtin = EmailToolBuiltin(config=config)
+    if provider is not None:
+        builtin._provider = provider
+    return builtin
+
+
+def _get_tool(builtin: EmailToolBuiltin, name: str):
+    """Extract a named tool from the builtin by name."""
+    tools = {t.name: t for t in builtin.get_langchain_tool()}
+    return tools[name]
+
+
+# ---------------------------------------------------------------------------
+# TestEmailToolBuiltinConstruction
+# ---------------------------------------------------------------------------
+
+
+class TestEmailToolBuiltinConstruction:
+    """Tests for EmailToolBuiltin.__init__() config handling."""
+
+    def test_provider_is_none_without_service_account_file(self) -> None:
+        builtin = EmailToolBuiltin(config={})
+        assert builtin._provider is None
+
+    def test_provider_is_none_without_delegated_user(self) -> None:
+        builtin = EmailToolBuiltin(config={"service_account_file": "/fake/sa.json"})
+        assert builtin._provider is None
+
+    def test_provider_is_none_for_unsupported_provider_name(self) -> None:
+        builtin = EmailToolBuiltin(
+            config={
+                "provider": "smtp",
+                "service_account_file": "/fake/sa.json",
+                "delegated_user": "agent@example.com",
+            }
+        )
+        assert builtin._provider is None
+
+    def test_workspace_root_set_from_config(self, tmp_path: Path) -> None:
+        builtin = EmailToolBuiltin(config={"workspace_path": str(tmp_path)})
+        assert builtin._workspace_root == tmp_path
+
+    def test_workspace_root_none_when_absent(self) -> None:
+        builtin = EmailToolBuiltin(config={})
+        assert builtin._workspace_root is None
+
+    def test_policy_configured_from_allowed_recipients(self) -> None:
+        builtin = EmailToolBuiltin(
+            config={"allowed_recipients": ["*@mycompany.com"], "max_recipients": 5}
+        )
+        assert builtin._policy.allowed_patterns == ["*@mycompany.com"]
+        assert builtin._policy.max_recipients == 5
+
+    def test_get_langchain_tool_returns_eight_tools(self) -> None:
+        builtin = EmailToolBuiltin(config={})
+        tools = builtin.get_langchain_tool()
+        assert len(tools) == 8
+
+    def test_tool_names(self) -> None:
+        builtin = EmailToolBuiltin(config={})
+        names = {t.name for t in builtin.get_langchain_tool()}
+        expected = {
+            "send_email",
+            "check_email",
+            "get_email",
+            "search_email",
+            "reply_email",
+            "download_attachment",
+            "mark_as_read",
+            "mark_as_unread",
+        }
+        assert names == expected
+
+
+# ---------------------------------------------------------------------------
+# TestAllToolsWhenProviderIsNone
+# ---------------------------------------------------------------------------
+
+
+class TestAllToolsWhenProviderIsNone:
+    """All 8 tools must return the _PROVIDER_NOT_CONFIGURED error string
+    when no provider has been successfully initialized."""
+
+    @pytest.fixture
+    def no_provider_builtin(self) -> EmailToolBuiltin:
+        builtin = EmailToolBuiltin(config={})
+        assert builtin._provider is None
+        return builtin
+
+    @pytest.mark.asyncio
+    async def test_send_email_no_provider(self, no_provider_builtin: EmailToolBuiltin) -> None:
+        tool = _get_tool(no_provider_builtin, "send_email")
+        result = await tool.ainvoke(
+            {"to": ["r@example.com"], "subject": "Hi", "body": "Hello."}
+        )
+        assert "[Error:" in result
+        assert "not configured" in result.lower() or "email provider" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_check_email_no_provider(self, no_provider_builtin: EmailToolBuiltin) -> None:
+        tool = _get_tool(no_provider_builtin, "check_email")
+        result = await tool.ainvoke({})
+        assert "[Error:" in result
+
+    @pytest.mark.asyncio
+    async def test_get_email_no_provider(self, no_provider_builtin: EmailToolBuiltin) -> None:
+        tool = _get_tool(no_provider_builtin, "get_email")
+        result = await tool.ainvoke({"message_id": "msg001"})
+        assert "[Error:" in result
+
+    @pytest.mark.asyncio
+    async def test_search_email_no_provider(
+        self, no_provider_builtin: EmailToolBuiltin
+    ) -> None:
+        tool = _get_tool(no_provider_builtin, "search_email")
+        result = await tool.ainvoke({"query": "from:alice"})
+        assert "[Error:" in result
+
+    @pytest.mark.asyncio
+    async def test_reply_email_no_provider(
+        self, no_provider_builtin: EmailToolBuiltin
+    ) -> None:
+        tool = _get_tool(no_provider_builtin, "reply_email")
+        result = await tool.ainvoke({"message_id": "msg001", "body": "My reply."})
+        assert "[Error:" in result
+
+    @pytest.mark.asyncio
+    async def test_download_attachment_no_provider(
+        self, no_provider_builtin: EmailToolBuiltin
+    ) -> None:
+        tool = _get_tool(no_provider_builtin, "download_attachment")
+        result = await tool.ainvoke(
+            {"message_id": "msg001", "attachment_id": "att_001", "filename": "file.pdf"}
+        )
+        assert "[Error:" in result
+
+    @pytest.mark.asyncio
+    async def test_mark_as_read_no_provider(
+        self, no_provider_builtin: EmailToolBuiltin
+    ) -> None:
+        tool = _get_tool(no_provider_builtin, "mark_as_read")
+        result = await tool.ainvoke({"message_id": "msg001"})
+        assert "[Error:" in result
+
+    @pytest.mark.asyncio
+    async def test_mark_as_unread_no_provider(
+        self, no_provider_builtin: EmailToolBuiltin
+    ) -> None:
+        tool = _get_tool(no_provider_builtin, "mark_as_unread")
+        result = await tool.ainvoke({"message_id": "msg001"})
+        assert "[Error:" in result
+
+
+# ---------------------------------------------------------------------------
+# TestResolveAttachments
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAttachments:
+    """Tests for EmailToolBuiltin._resolve_attachments()."""
+
+    def test_empty_paths_returns_empty_list_and_no_error(self, tmp_path: Path) -> None:
+        builtin = _make_builtin(workspace_path=tmp_path)
+        attachments, error = builtin._resolve_attachments([])
+        assert attachments == []
+        assert error is None
+
+    def test_valid_file_resolved_correctly(self, tmp_path: Path) -> None:
+        sample = tmp_path / "doc.txt"
+        sample.write_text("content")
+        builtin = _make_builtin(workspace_path=tmp_path)
+        attachments, error = builtin._resolve_attachments(["doc.txt"])
+        assert error is None
+        assert len(attachments) == 1
+        name, content, mime_type = attachments[0]
+        assert name == "doc.txt"
+        assert content == b"content"
+        assert "text" in mime_type
+
+    def test_nonexistent_file_returns_error(self, tmp_path: Path) -> None:
+        builtin = _make_builtin(workspace_path=tmp_path)
+        _, error = builtin._resolve_attachments(["missing.pdf"])
+        assert error is not None
+        assert "[Error:" in error
+        assert "missing.pdf" in error
+
+    def test_path_outside_sandbox_returns_error(self, tmp_path: Path) -> None:
+        builtin = _make_builtin(workspace_path=tmp_path)
+        _, error = builtin._resolve_attachments(["../etc/passwd"])
+        assert error is not None
+        assert "[Error:" in error
+
+    def test_absolute_path_rejected_by_sandbox(self, tmp_path: Path) -> None:
+        builtin = _make_builtin(workspace_path=tmp_path)
+        _, error = builtin._resolve_attachments(["/etc/passwd"])
+        assert error is not None
+        assert "[Error:" in error
+
+    def test_no_workspace_path_returns_error(self) -> None:
+        builtin = _make_builtin()  # no workspace_path
+        _, error = builtin._resolve_attachments(["somefile.txt"])
+        assert error is not None
+        assert "[Error:" in error
+
+    def test_directory_path_returns_error(self, tmp_path: Path) -> None:
+        subdir = tmp_path / "mydir"
+        subdir.mkdir()
+        builtin = _make_builtin(workspace_path=tmp_path)
+        _, error = builtin._resolve_attachments(["mydir"])
+        assert error is not None
+        assert "[Error:" in error
+
+    def test_multiple_valid_files_all_resolved(self, tmp_path: Path) -> None:
+        for name in ["a.txt", "b.txt", "c.txt"]:
+            (tmp_path / name).write_text(f"content of {name}")
+        builtin = _make_builtin(workspace_path=tmp_path)
+        attachments, error = builtin._resolve_attachments(["a.txt", "b.txt", "c.txt"])
+        assert error is None
+        assert len(attachments) == 3
+
+    def test_first_invalid_file_stops_processing(self, tmp_path: Path) -> None:
+        (tmp_path / "good.txt").write_text("good")
+        builtin = _make_builtin(workspace_path=tmp_path)
+        _, error = builtin._resolve_attachments(["good.txt", "missing.pdf"])
+        assert error is not None
+        assert "missing.pdf" in error
+
+    def test_mime_type_defaults_to_octet_stream_for_unknown_extension(
+        self, tmp_path: Path
+    ) -> None:
+        unknown = tmp_path / "data.xyzzy"
+        unknown.write_bytes(b"\x00\x01\x02")
+        builtin = _make_builtin(workspace_path=tmp_path)
+        attachments, error = builtin._resolve_attachments(["data.xyzzy"])
+        assert error is None
+        _, _, mime_type = attachments[0]
+        assert mime_type == "application/octet-stream"
+
+
+# ---------------------------------------------------------------------------
+# TestSendEmail
+# ---------------------------------------------------------------------------
+
+
+class TestSendEmail:
+    """Tests for the send_email tool."""
+
+    @pytest.mark.asyncio
+    async def test_successful_send_returns_message_id(self, tmp_path: Path) -> None:
+        mock_provider = MockEmailProvider()
+        builtin = _make_builtin(workspace_path=tmp_path, provider=mock_provider)
+        tool = _get_tool(builtin, "send_email")
+
+        result = await tool.ainvoke(
+            {"to": ["alice@example.com"], "subject": "Hello", "body": "Body text."}
+        )
+
+        assert "mock_sent_id" in result
+        assert len(mock_provider.sent_messages) == 1
+
+    @pytest.mark.asyncio
+    async def test_recipient_policy_violation_blocked(self, tmp_path: Path) -> None:
+        mock_provider = MockEmailProvider()
+        builtin = _make_builtin(
+            workspace_path=tmp_path,
+            allowed_recipients=["*@company.com"],
+            provider=mock_provider,
+        )
+        tool = _get_tool(builtin, "send_email")
+
+        result = await tool.ainvoke(
+            {
+                "to": ["outsider@gmail.com"],
+                "subject": "Blocked",
+                "body": "Should not send.",
+            }
+        )
+
+        assert "[Error:" in result
+        assert "policy" in result.lower() or "allowlist" in result.lower()
+        assert len(mock_provider.sent_messages) == 0
+
+    @pytest.mark.asyncio
+    async def test_cc_recipients_checked_against_policy(self, tmp_path: Path) -> None:
+        mock_provider = MockEmailProvider()
+        builtin = _make_builtin(
+            workspace_path=tmp_path,
+            allowed_recipients=["*@company.com"],
+            provider=mock_provider,
+        )
+        tool = _get_tool(builtin, "send_email")
+
+        result = await tool.ainvoke(
+            {
+                "to": ["alice@company.com"],
+                "subject": "Test",
+                "body": "Body.",
+                "cc": ["outsider@gmail.com"],
+            }
+        )
+
+        assert "[Error:" in result
+        assert len(mock_provider.sent_messages) == 0
+
+    @pytest.mark.asyncio
+    async def test_provider_exception_returns_error_string(self, tmp_path: Path) -> None:
+        mock_provider = MockEmailProvider()
+        mock_provider.send_exception = RuntimeError("SMTP connection refused")
+        builtin = _make_builtin(workspace_path=tmp_path, provider=mock_provider)
+        tool = _get_tool(builtin, "send_email")
+
+        result = await tool.ainvoke(
+            {"to": ["alice@example.com"], "subject": "Hi", "body": "Body."}
+        )
+
+        assert "[Error:" in result
+        assert "SMTP connection refused" in result
+
+    @pytest.mark.asyncio
+    async def test_attachment_included_in_send(self, tmp_path: Path) -> None:
+        (tmp_path / "doc.txt").write_text("document content")
+        mock_provider = MockEmailProvider()
+        builtin = _make_builtin(workspace_path=tmp_path, provider=mock_provider)
+        tool = _get_tool(builtin, "send_email")
+
+        result = await tool.ainvoke(
+            {
+                "to": ["alice@example.com"],
+                "subject": "With attachment",
+                "body": "See attached.",
+                "attachment_paths": ["doc.txt"],
+            }
+        )
+
+        assert "1 attachment" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_attachment_path_returns_error(self, tmp_path: Path) -> None:
+        mock_provider = MockEmailProvider()
+        builtin = _make_builtin(workspace_path=tmp_path, provider=mock_provider)
+        tool = _get_tool(builtin, "send_email")
+
+        result = await tool.ainvoke(
+            {
+                "to": ["alice@example.com"],
+                "subject": "Hi",
+                "body": "Body.",
+                "attachment_paths": ["nonexistent.pdf"],
+            }
+        )
+
+        assert "[Error:" in result
+        assert len(mock_provider.sent_messages) == 0
+
+
+# ---------------------------------------------------------------------------
+# TestCheckEmail
+# ---------------------------------------------------------------------------
+
+
+class TestCheckEmail:
+    """Tests for the check_email tool."""
+
+    @pytest.mark.asyncio
+    async def test_returns_formatted_summaries(self) -> None:
+        mock_provider = MockEmailProvider()
+        mock_provider.list_result = [
+            _make_email_message(msg_id="m1", subject="First Email"),
+            _make_email_message(msg_id="m2", subject="Second Email"),
+        ]
+        builtin = _make_builtin(provider=mock_provider)
+        tool = _get_tool(builtin, "check_email")
+
+        result = await tool.ainvoke({"max_results": 10})
+
+        assert "First Email" in result
+        assert "Second Email" in result
+        assert "2 message" in result
+
+    @pytest.mark.asyncio
+    async def test_no_messages_returns_informative_string(self) -> None:
+        mock_provider = MockEmailProvider()
+        mock_provider.list_result = []
+        builtin = _make_builtin(provider=mock_provider)
+        tool = _get_tool(builtin, "check_email")
+
+        result = await tool.ainvoke({})
+
+        assert "No messages" in result
+
+    @pytest.mark.asyncio
+    async def test_provider_exception_returns_error_string(self) -> None:
+        mock_provider = MockEmailProvider()
+
+        async def fail_list(*args, **kwargs):
+            raise RuntimeError("Service unavailable")
+
+        mock_provider.list_messages = fail_list  # type: ignore[method-assign]
+        builtin = _make_builtin(provider=mock_provider)
+        tool = _get_tool(builtin, "check_email")
+
+        result = await tool.ainvoke({})
+
+        assert "[Error:" in result
+
+
+# ---------------------------------------------------------------------------
+# TestGetEmail
+# ---------------------------------------------------------------------------
+
+
+class TestGetEmail:
+    """Tests for the get_email tool."""
+
+    @pytest.mark.asyncio
+    async def test_returns_full_format(self) -> None:
+        mock_provider = MockEmailProvider()
+        mock_provider.get_result = _make_email_message(
+            msg_id="msg_full", body="This is the full body."
+        )
+        builtin = _make_builtin(provider=mock_provider)
+        tool = _get_tool(builtin, "get_email")
+
+        result = await tool.ainvoke({"message_id": "msg_full"})
+
+        assert "msg_full" in result
+        assert "This is the full body." in result
+        assert "---" in result
+
+    @pytest.mark.asyncio
+    async def test_provider_exception_returns_error_string(self) -> None:
+        mock_provider = MockEmailProvider()
+        mock_provider.get_exception = RuntimeError("Message not found")
+        builtin = _make_builtin(provider=mock_provider)
+        tool = _get_tool(builtin, "get_email")
+
+        result = await tool.ainvoke({"message_id": "ghost_id"})
+
+        assert "[Error:" in result
+        assert "ghost_id" in result
+
+
+# ---------------------------------------------------------------------------
+# TestSearchEmail
+# ---------------------------------------------------------------------------
+
+
+class TestSearchEmail:
+    """Tests for the search_email tool."""
+
+    @pytest.mark.asyncio
+    async def test_returns_matching_summaries(self) -> None:
+        mock_provider = MockEmailProvider()
+        mock_provider.search_result = [
+            _make_email_message(subject="Invoice #123"),
+        ]
+        builtin = _make_builtin(provider=mock_provider)
+        tool = _get_tool(builtin, "search_email")
+
+        result = await tool.ainvoke({"query": "subject:invoice"})
+
+        assert "Invoice #123" in result
+        assert "1 result" in result
+
+    @pytest.mark.asyncio
+    async def test_no_results_returns_informative_string(self) -> None:
+        mock_provider = MockEmailProvider()
+        mock_provider.search_result = []
+        builtin = _make_builtin(provider=mock_provider)
+        tool = _get_tool(builtin, "search_email")
+
+        result = await tool.ainvoke({"query": "from:nobody@nowhere.com"})
+
+        assert "No messages" in result
+
+    @pytest.mark.asyncio
+    async def test_query_included_in_no_results_message(self) -> None:
+        mock_provider = MockEmailProvider()
+        mock_provider.search_result = []
+        builtin = _make_builtin(provider=mock_provider)
+        tool = _get_tool(builtin, "search_email")
+
+        result = await tool.ainvoke({"query": "is:unread"})
+
+        assert "is:unread" in result
+
+
+# ---------------------------------------------------------------------------
+# TestReplyEmail
+# ---------------------------------------------------------------------------
+
+
+class TestReplyEmail:
+    """Tests for the reply_email tool."""
+
+    @pytest.mark.asyncio
+    async def test_successful_reply_sends_to_original_sender(self) -> None:
+        mock_provider = MockEmailProvider()
+        original = _make_email_message(
+            msg_id="orig_001",
+            thread_id="thr_001",
+            sender="alice@example.com",
+        )
+        mock_provider.get_result = original
+
+        builtin = _make_builtin(
+            allowed_recipients=["*@example.com"], provider=mock_provider
+        )
+        tool = _get_tool(builtin, "reply_email")
+
+        result = await tool.ainvoke({"message_id": "orig_001", "body": "My reply."})
+
+        assert "[Error:" not in result
+        assert "alice@example.com" in result
+        assert len(mock_provider.sent_messages) == 1
+
+    @pytest.mark.asyncio
+    async def test_reply_uses_re_prefix_for_subject(self) -> None:
+        mock_provider = MockEmailProvider()
+        original = _make_email_message(
+            subject="Original Subject",
+            sender="alice@example.com",
+        )
+        mock_provider.get_result = original
+
+        builtin = _make_builtin(
+            allowed_recipients=["*@example.com"], provider=mock_provider
+        )
+        tool = _get_tool(builtin, "reply_email")
+
+        await tool.ainvoke({"message_id": "orig_001", "body": "Reply."})
+
+        sent = mock_provider.sent_messages[0]
+        assert sent["subject"] == "Re: Original Subject"
+
+    @pytest.mark.asyncio
+    async def test_reply_includes_threading_headers(self) -> None:
+        mock_provider = MockEmailProvider()
+        original = _make_email_message(
+            msg_id="orig_001",
+            thread_id="thr_001",
+            sender="alice@example.com",
+        )
+        mock_provider.get_result = original
+
+        builtin = _make_builtin(
+            allowed_recipients=["*@example.com"], provider=mock_provider
+        )
+        tool = _get_tool(builtin, "reply_email")
+
+        await tool.ainvoke({"message_id": "orig_001", "body": "Replying."})
+
+        sent = mock_provider.sent_messages[0]
+        assert sent["reply_to_message_id"] == "orig_001"
+        assert sent["thread_id"] == "thr_001"
+
+    @pytest.mark.asyncio
+    async def test_reply_blocked_when_sender_not_in_policy(self) -> None:
+        mock_provider = MockEmailProvider()
+        original = _make_email_message(
+            sender="external@gmail.com",
+        )
+        mock_provider.get_result = original
+
+        builtin = _make_builtin(
+            allowed_recipients=["*@company.com"], provider=mock_provider
+        )
+        tool = _get_tool(builtin, "reply_email")
+
+        result = await tool.ainvoke({"message_id": "msg001", "body": "Reply."})
+
+        assert "[Error:" in result
+        assert "external@gmail.com" in result
+        assert len(mock_provider.sent_messages) == 0
+
+    @pytest.mark.asyncio
+    async def test_reply_fetch_failure_returns_error(self) -> None:
+        mock_provider = MockEmailProvider()
+        mock_provider.get_exception = RuntimeError("Message not found")
+
+        builtin = _make_builtin(provider=mock_provider)
+        tool = _get_tool(builtin, "reply_email")
+
+        result = await tool.ainvoke({"message_id": "ghost_msg", "body": "Reply."})
+
+        assert "[Error:" in result
+        assert "ghost_msg" in result
+
+    @pytest.mark.asyncio
+    async def test_reply_with_attachment(self, tmp_path: Path) -> None:
+        (tmp_path / "attachment.txt").write_text("attached data")
+        mock_provider = MockEmailProvider()
+        original = _make_email_message(sender="alice@example.com")
+        mock_provider.get_result = original
+
+        builtin = _make_builtin(
+            workspace_path=tmp_path,
+            allowed_recipients=["*@example.com"],
+            provider=mock_provider,
+        )
+        tool = _get_tool(builtin, "reply_email")
+
+        result = await tool.ainvoke(
+            {
+                "message_id": "msg001",
+                "body": "Reply with attachment.",
+                "attachment_paths": ["attachment.txt"],
+            }
+        )
+
+        assert "1 attachment" in result
+
+
+# ---------------------------------------------------------------------------
+# TestDownloadAttachment
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadAttachment:
+    """Tests for the download_attachment tool."""
+
+    @pytest.mark.asyncio
+    async def test_saves_to_downloads_email_directory(self, tmp_path: Path) -> None:
+        content = b"PDF binary content"
+        mock_provider = MockEmailProvider()
+        mock_provider.download_result = EmailAttachment(
+            filename="invoice.pdf",
+            mime_type="application/pdf",
+            size_bytes=len(content),
+            attachment_id="att_001",
+            content=content,
+        )
+        builtin = _make_builtin(workspace_path=tmp_path, provider=mock_provider)
+        tool = _get_tool(builtin, "download_attachment")
+
+        result = await tool.ainvoke(
+            {"message_id": "msg001", "attachment_id": "att_001", "filename": "invoice.pdf"}
+        )
+
+        assert "[Error:" not in result
+        saved_path = tmp_path / "downloads" / "email" / "invoice.pdf"
+        assert saved_path.exists()
+        assert saved_path.read_bytes() == content
+
+    @pytest.mark.asyncio
+    async def test_workspace_relative_path_returned(self, tmp_path: Path) -> None:
+        content = b"content"
+        mock_provider = MockEmailProvider()
+        mock_provider.download_result = EmailAttachment(
+            filename="report.pdf",
+            mime_type="application/pdf",
+            size_bytes=len(content),
+            content=content,
+        )
+        builtin = _make_builtin(workspace_path=tmp_path, provider=mock_provider)
+        tool = _get_tool(builtin, "download_attachment")
+
+        result = await tool.ainvoke(
+            {"message_id": "msg001", "attachment_id": "att_001", "filename": "report.pdf"}
+        )
+
+        assert "downloads/email" in result
+        assert "report.pdf" in result
+
+    @pytest.mark.asyncio
+    async def test_save_as_overrides_filename(self, tmp_path: Path) -> None:
+        content = b"data"
+        mock_provider = MockEmailProvider()
+        mock_provider.download_result = EmailAttachment(
+            filename="original_name.pdf",
+            mime_type="application/pdf",
+            size_bytes=len(content),
+            content=content,
+        )
+        builtin = _make_builtin(workspace_path=tmp_path, provider=mock_provider)
+        tool = _get_tool(builtin, "download_attachment")
+
+        result = await tool.ainvoke(
+            {
+                "message_id": "msg001",
+                "attachment_id": "att_001",
+                "filename": "original_name.pdf",
+                "save_as": "custom_name.pdf",
+            }
+        )
+
+        assert "custom_name.pdf" in result
+        assert not (tmp_path / "downloads" / "email" / "original_name.pdf").exists()
+        saved = tmp_path / "downloads" / "email" / "custom_name.pdf"
+        assert saved.exists()
+
+    @pytest.mark.asyncio
+    async def test_no_workspace_path_returns_error(self) -> None:
+        mock_provider = MockEmailProvider()
+        mock_provider.download_result = EmailAttachment(
+            filename="file.pdf",
+            mime_type="application/pdf",
+            size_bytes=100,
+            content=b"data",
+        )
+        builtin = _make_builtin(provider=mock_provider)  # no workspace_path
+        tool = _get_tool(builtin, "download_attachment")
+
+        result = await tool.ainvoke(
+            {"message_id": "msg001", "attachment_id": "att_001", "filename": "file.pdf"}
+        )
+
+        assert "[Error:" in result
+        assert "workspace" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_provider_exception_returns_error_string(
+        self, tmp_path: Path
+    ) -> None:
+        mock_provider = MockEmailProvider()
+        mock_provider.download_exception = RuntimeError("Attachment unavailable")
+        builtin = _make_builtin(workspace_path=tmp_path, provider=mock_provider)
+        tool = _get_tool(builtin, "download_attachment")
+
+        result = await tool.ainvoke(
+            {"message_id": "msg001", "attachment_id": "att_bad", "filename": "file.pdf"}
+        )
+
+        assert "[Error:" in result
+
+    @pytest.mark.asyncio
+    async def test_null_content_returns_error(self, tmp_path: Path) -> None:
+        mock_provider = MockEmailProvider()
+        mock_provider.download_result = EmailAttachment(
+            filename="empty.pdf",
+            mime_type="application/pdf",
+            size_bytes=0,
+            content=None,  # Provider returned no content
+        )
+        builtin = _make_builtin(workspace_path=tmp_path, provider=mock_provider)
+        tool = _get_tool(builtin, "download_attachment")
+
+        result = await tool.ainvoke(
+            {"message_id": "msg001", "attachment_id": "att_empty", "filename": "empty.pdf"}
+        )
+
+        assert "[Error:" in result
+        assert "no content" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_filename_deduplicated(self, tmp_path: Path) -> None:
+        """If a file already exists, a deduplicated name should be used."""
+        content = b"data"
+        # Pre-create the target file so deduplication kicks in.
+        save_dir = tmp_path / "downloads" / "email"
+        save_dir.mkdir(parents=True, exist_ok=True)
+        (save_dir / "report.pdf").write_bytes(b"original")
+
+        mock_provider = MockEmailProvider()
+        mock_provider.download_result = EmailAttachment(
+            filename="report.pdf",
+            mime_type="application/pdf",
+            size_bytes=len(content),
+            content=content,
+        )
+        builtin = _make_builtin(workspace_path=tmp_path, provider=mock_provider)
+        tool = _get_tool(builtin, "download_attachment")
+
+        result = await tool.ainvoke(
+            {"message_id": "msg001", "attachment_id": "att_001", "filename": "report.pdf"}
+        )
+
+        # The deduplicated file should exist alongside the original.
+        assert "[Error:" not in result
+        files = list(save_dir.iterdir())
+        assert len(files) == 2
+
+    @pytest.mark.asyncio
+    async def test_size_reported_in_kb(self, tmp_path: Path) -> None:
+        content = b"x" * 2048  # 2 KB
+        mock_provider = MockEmailProvider()
+        mock_provider.download_result = EmailAttachment(
+            filename="data.bin",
+            mime_type="application/octet-stream",
+            size_bytes=len(content),
+            content=content,
+        )
+        builtin = _make_builtin(workspace_path=tmp_path, provider=mock_provider)
+        tool = _get_tool(builtin, "download_attachment")
+
+        result = await tool.ainvoke(
+            {"message_id": "msg001", "attachment_id": "att_001", "filename": "data.bin"}
+        )
+
+        assert "2.0 KB" in result
+
+
+# ---------------------------------------------------------------------------
+# TestMarkAsRead / TestMarkAsUnread
+# ---------------------------------------------------------------------------
+
+
+class TestMarkAsRead:
+    """Tests for the mark_as_read tool."""
+
+    @pytest.mark.asyncio
+    async def test_successful_mark_returns_confirmation(self) -> None:
+        mock_provider = MockEmailProvider()
+        builtin = _make_builtin(provider=mock_provider)
+        tool = _get_tool(builtin, "mark_as_read")
+
+        result = await tool.ainvoke({"message_id": "msg_001"})
+
+        assert "msg_001" in result
+        assert "read" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_provider_exception_returns_error(self) -> None:
+        mock_provider = MockEmailProvider()
+        mock_provider.mark_read_exception = RuntimeError("API error")
+        builtin = _make_builtin(provider=mock_provider)
+        tool = _get_tool(builtin, "mark_as_read")
+
+        result = await tool.ainvoke({"message_id": "msg_001"})
+
+        assert "[Error:" in result
+
+
+class TestMarkAsUnread:
+    """Tests for the mark_as_unread tool."""
+
+    @pytest.mark.asyncio
+    async def test_successful_mark_returns_confirmation(self) -> None:
+        mock_provider = MockEmailProvider()
+        builtin = _make_builtin(provider=mock_provider)
+        tool = _get_tool(builtin, "mark_as_unread")
+
+        result = await tool.ainvoke({"message_id": "msg_002"})
+
+        assert "msg_002" in result
+        assert "unread" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_provider_exception_returns_error(self) -> None:
+        mock_provider = MockEmailProvider()
+        mock_provider.mark_unread_exception = RuntimeError("Forbidden")
+        builtin = _make_builtin(provider=mock_provider)
+        tool = _get_tool(builtin, "mark_as_unread")
+
+        result = await tool.ainvoke({"message_id": "msg_002"})
+
+        assert "[Error:" in result


### PR DESCRIPTION
## Summary

- Add email builtin with abstract `EmailProvider` interface and Gmail implementation (service account + domain-wide delegation)
- 8 tools: `send_email`, `check_email`, `get_email`, `search_email`, `reply_email`, `download_attachment`, `mark_as_read`, `mark_as_unread`
- Safe-by-default `RecipientPolicy`: empty `allowed_recipients` blocks all outbound email
- 209 new tests (2688 total, zero regressions)

## Architecture

```
openpaw/builtins/tools/email/
├── base.py       # EmailProvider ABC, EmailMessage, EmailAttachment, RecipientPolicy
├── __init__.py   # EmailToolBuiltin (8 tools, multi-tool return pattern)
└── gmail.py      # GmailProvider (service account, asyncio.to_thread wrapping)
```

Provider interface designed for future SMTP/SES providers. Gmail auth uses `google.oauth2.service_account.Credentials` with `subject=` for domain-wide delegation. All blocking Google API calls dispatched via `asyncio.to_thread()`. Thread-safe lazy client init with double-checked locking.

## Config

```yaml
builtins:
  email:
    enabled: true
    config:
      provider: gmail
      service_account_file: config/service-account.json
      delegated_user: agent@yourdomain.com
      allowed_recipients:
        - "*@yourdomain.com"
      max_recipients: 10
```

## Test plan

- [x] 209 new tests across 3 test files (base, gmail, tools)
- [x] RecipientPolicy: empty allowlist blocks, patterns match, case insensitive, max recipients
- [x] Gmail provider: message parsing, MIME construction, date/header parsing, error formatting
- [x] Tool layer: all 8 tools with provider-not-configured, policy validation, sandbox paths, download saving
- [x] Full suite: 2688 passed, 0 regressions
- [x] Lint: ruff clean
- [x] Type check: mypy clean (no new errors)