### PR TITLE
ci: disable CUDA to fix torch segfault on CPU-only runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
           - "3.11"
           - "3.12"
 
+    env:
+      CUDA_VISIBLE_DEVICES: ""  # Disable CUDA to prevent torch segfault on CPU-only runners
+
     steps:
       - uses: actions/checkout@v4
         if: needs.changes.outputs.code == 'true'


### PR DESCRIPTION
**Problem:** CI tests on develop are failing with a segmentation fault during torch/CUDA initialization.

The import chain  →  →  →  → usage: transformers <command> [<args>]

positional arguments:
  {chat,convert,download,env,run,serve,add-new-model-like,add-fast-image-processor}
                        transformers command helpers
    convert             CLI tool to run convert model from original author
                        checkpoints to Transformers PyTorch checkpoints.
    run                 Run a pipeline through the CLI

options:
  -h, --help            show this help message and exit →  triggers a segfault when torch tries to preload CUDA libraries on GitHub's CPU-only runners.

**Fix:** Set  in the test job environment to disable CUDA initialization.

**Testing:** This is a CI-only change; no application code affected.