### PR TITLE
fix: rate-limit-aware backoff for Fireworks provider

### DIFF
--- a/openpaw/agent/runner.py
+++ b/openpaw/agent/runner.py
@@ -151,7 +151,7 @@ def create_chat_model(
     if provider == "fireworks":
         import httpx
         import tenacity
-        from fireworks.client.error import FireworksError, InvalidRequestError
+        from fireworks.client.error import FireworksError, InvalidRequestError, RateLimitError
         from langchain_fireworks import ChatFireworks
 
         if api_key:
@@ -162,8 +162,21 @@ def create_chat_model(
         # The Fireworks SDK's _max_retries is a no-op — patch _agenerate with
         # tenacity for real retry behavior.  This preserves bind_tools() and all
         # model attributes (unlike .with_retry() which wraps the entire Runnable).
+        #
+        # Fireworks changed their rate limit error format (Apr 2025): the code
+        # field shifted from "too_many_requests" (transient overload) to
+        # "invalid_request_error" (hard rate limit).  Hard rate limits need much
+        # longer backoff than transient 5xx errors, so we use a composite wait
+        # strategy that applies longer delays specifically for RateLimitError.
         if effective_retries > 0:
-            logger.info(f"Patching ChatFireworks._agenerate with retry (max_attempts={effective_retries + 1})")
+            # Use more attempts for Fireworks — the default of 3 is too few when
+            # multiple workspaces share one API key (rate limits may need 30-60s
+            # to clear, and 3 retries only yields ~8s total backoff).
+            fireworks_attempts = max(effective_retries, 6)
+            logger.info(
+                f"Patching ChatFireworks._agenerate with retry "
+                f"(max_attempts={fireworks_attempts + 1}, effective_retries={effective_retries})"
+            )
             original_agenerate = model._agenerate
 
             def _is_retryable_fireworks_error(exc: BaseException) -> bool:
@@ -181,10 +194,17 @@ def create_chat_model(
                     | FireworksError,
                 )
 
+            def _fireworks_wait(retry_state: tenacity.RetryCallState) -> float:
+                """Rate-limit-aware backoff: longer delays for RateLimitError."""
+                exc = retry_state.outcome.exception() if retry_state.outcome and retry_state.outcome.failed else None
+                if isinstance(exc, RateLimitError):
+                    return tenacity.wait_exponential_jitter(initial=5, max=120)(retry_state)
+                return tenacity.wait_exponential_jitter(initial=1, max=60)(retry_state)
+
             @tenacity.retry(
                 retry=tenacity.retry_if_exception(_is_retryable_fireworks_error),
-                stop=tenacity.stop_after_attempt(effective_retries + 1),
-                wait=tenacity.wait_exponential_jitter(initial=1, max=60),
+                stop=tenacity.stop_after_attempt(fireworks_attempts + 1),
+                wait=_fireworks_wait,
                 before_sleep=tenacity.before_sleep_log(logger, logging.WARNING),
                 reraise=True,
             )

--- a/tests/test_max_retries.py
+++ b/tests/test_max_retries.py
@@ -1,13 +1,9 @@
 """Tests for max_retries retry configuration across model providers."""
 
-from pathlib import Path
 from unittest.mock import Mock, patch
-
-import pytest
 
 from openpaw.agent.runner import create_chat_model
 from openpaw.core.config.models import WorkspaceModelConfig
-
 
 # ---------------------------------------------------------------------------
 # Config model tests
@@ -124,9 +120,92 @@ def test_fireworks_agenerate_patched_with_tenacity() -> None:
     # Model itself is returned (not a wrapper), preserving bind_tools()
     assert result is mock_model
     # _agenerate should be replaced with a tenacity-wrapped version
-    assert result._agenerate is not mock_model._agenerate.__func__ if hasattr(mock_model._agenerate, '__func__') else True
+    assert (
+        result._agenerate is not mock_model._agenerate.__func__
+        if hasattr(mock_model._agenerate, "__func__")
+        else True
+    )
     # The patched function should have tenacity retry attributes
     assert hasattr(result._agenerate, "retry")
+
+
+def test_fireworks_uses_minimum_6_attempts() -> None:
+    """Fireworks retries are floored at 6 attempts regardless of max_retries config."""
+    import tenacity
+
+    mock_model = Mock()
+    mock_model._agenerate = Mock()
+
+    with patch("langchain_fireworks.ChatFireworks", return_value=mock_model):
+        result = create_chat_model(
+            model_str="fireworks:accounts/fireworks/models/deepseek-v3p1",
+            api_key="test-key",
+            temperature=0.7,
+            extra_kwargs={"max_retries": 3},
+        )
+
+    stop_strategy = result._agenerate.retry.stop
+    assert isinstance(stop_strategy, tenacity.stop_after_attempt)
+    assert stop_strategy.max_attempt_number == 7  # 6 retries + 1 initial
+
+
+def test_fireworks_custom_high_retries_preserved() -> None:
+    """When max_retries > 6, Fireworks uses the user's value instead of the floor."""
+    import tenacity
+
+    mock_model = Mock()
+    mock_model._agenerate = Mock()
+
+    with patch("langchain_fireworks.ChatFireworks", return_value=mock_model):
+        result = create_chat_model(
+            model_str="fireworks:accounts/fireworks/models/deepseek-v3p1",
+            api_key="test-key",
+            temperature=0.7,
+            extra_kwargs={"max_retries": 10},
+        )
+
+    stop_strategy = result._agenerate.retry.stop
+    assert isinstance(stop_strategy, tenacity.stop_after_attempt)
+    assert stop_strategy.max_attempt_number == 11  # 10 retries + 1 initial
+
+
+def test_fireworks_rate_limit_wait_longer() -> None:
+    """Rate limit errors get longer backoff (initial=5s) than transient errors (initial=1s)."""
+    import tenacity
+    from fireworks.client.error import RateLimitError
+
+    mock_model = Mock()
+    mock_model._agenerate = Mock()
+
+    with patch("langchain_fireworks.ChatFireworks", return_value=mock_model):
+        result = create_chat_model(
+            model_str="fireworks:accounts/fireworks/models/deepseek-v3p1",
+            api_key="test-key",
+            temperature=0.7,
+            extra_kwargs={"max_retries": 3},
+        )
+
+    wait_fn = result._agenerate.retry.wait
+
+    # Simulate a RateLimitError retry state (3rd attempt)
+    rl_state = Mock(spec=tenacity.RetryCallState)
+    rl_state.outcome = Mock()
+    rl_state.outcome.failed = True
+    rl_state.outcome.exception = Mock(return_value=RateLimitError("rate limit exceeded"))
+    rl_state.attempt_number = 3
+
+    rl_wait = wait_fn(rl_state)
+    assert rl_wait >= 5  # initial=5 for rate limit errors
+
+    # Simulate a transient error retry state (3rd attempt)
+    trans_state = Mock(spec=tenacity.RetryCallState)
+    trans_state.outcome = Mock()
+    trans_state.outcome.failed = True
+    trans_state.outcome.exception = Mock(return_value=ConnectionError("connection reset"))
+    trans_state.attempt_number = 3
+
+    trans_wait = wait_fn(trans_state)
+    assert trans_wait >= 1  # initial=1 for transient errors
 
 
 def test_fireworks_no_patch_when_retries_disabled() -> None:


### PR DESCRIPTION
## Summary

- Fireworks changed their rate limit error format (Apr 2025): code shifted from `"too_many_requests"` (transient overload) to `"invalid_request_error"` (hard rate limit), making the existing 3-retry / ~8s-total backoff strategy insufficient
- Floor Fireworks retry attempts at 6 (up from 3) so backoff can reach meaningful durations when multiple workspaces share one API key
- Add rate-limit-aware wait strategy: `RateLimitError` gets `initial=5s, max=120s` backoff vs `initial=1s, max=60s` for transient errors

## Testing

- 3 new tests: minimum 6 attempts, custom high retries preserved, differentiated backoff timing
- All 16 tests in `test_max_retries.py` pass
- Lint and typecheck clean
- Validated in production — retries now survive rate limit windows that previously failed after ~8s