### PR TITLE
MR #5: Team Roster Extraction

### DIFF
--- a/openpaw/workspace/roster.py
+++ b/openpaw/workspace/roster.py
@@ -1,0 +1,72 @@
+"""Team roster builder for injection into the agent system prompt."""
+
+from __future__ import annotations
+
+from openpaw.workspace.profile_resolver import SpawnProfileResolver
+
+
+class TeamRosterBuilder:
+    """Builds a team roster string for the ``<team>`` prompt section."""
+
+    def __init__(self, resolver: SpawnProfileResolver) -> None:
+        """Initialize with a profile resolver.
+
+        Args:
+            resolver: Profile resolver with loaded team profiles.
+        """
+        self._resolver = resolver
+
+    def build(self) -> str:
+        """Build a team roster string for injection into the system prompt.
+
+        Provides the agent with awareness of its available sub-agent team members,
+        their roles, and dispatch guidance.
+
+        Returns:
+            Formatted team roster string for the ``<team>`` prompt section.
+        """
+        profiles = self._resolver.list_profiles()
+        if not profiles:
+            return ""
+
+        lines = [
+            "## Your Sub-Agent Team",
+            "",
+            "You have specialized sub-agent profiles available for delegation. "
+            "Use `spawn_agent(profile='name', task='...')` to dispatch work. "
+            "Sub-agents run in the background and notify you when complete.",
+            "",
+            "| Profile | Role | Model |",
+            "|---------|------|-------|",
+        ]
+
+        for p in profiles:
+            model = p.model or "(workspace default)"
+            desc = p.description or "(no description)"
+            lines.append(f"| `{p.name}` | {desc} | {model} |")
+
+        lines.append("")
+        lines.append("### Dispatch Guidelines")
+        lines.append("")
+        lines.append(
+            "- **Delegate proactively** — when you recognize a task that fits "
+            "a profile, spawn it without waiting to be asked"
+        )
+        lines.append(
+            "- **Prefer profiles over manual tool filtering** — profiles carry "
+            "focused prompts and tool restrictions tuned for their role"
+        )
+        lines.append(
+            "- **Sub-agents are fire-and-forget** — you cannot send follow-up "
+            "messages; write a thorough task prompt upfront"
+        )
+        lines.append(
+            "- **Chain results** — one sub-agent's output (saved to workspace) "
+            "can be input for another sub-agent or your own synthesis"
+        )
+        lines.append(
+            "- **Use `list_team_profiles` for details** — see tool restrictions, "
+            "timeouts, and skill configurations per profile"
+        )
+
+        return "\n".join(lines)

--- a/openpaw/workspace/runner.py
+++ b/openpaw/workspace/runner.py
@@ -46,66 +46,8 @@ from openpaw.workspace.loader import WorkspaceLoader
 from openpaw.workspace.message_processor import MessageProcessor
 from openpaw.workspace.profile_loader import load_spawn_profiles
 from openpaw.workspace.profile_resolver import SpawnProfileResolver
+from openpaw.workspace.roster import TeamRosterBuilder
 from openpaw.workspace.tool_loader import load_workspace_tools
-
-
-def _build_team_roster(resolver: SpawnProfileResolver) -> str:
-    """Build a team roster string for injection into the system prompt.
-
-    Provides the agent with awareness of its available sub-agent team members,
-    their roles, and dispatch guidance.
-
-    Args:
-        resolver: Profile resolver with loaded team profiles.
-
-    Returns:
-        Formatted team roster string for the ``<team>`` prompt section.
-    """
-    profiles = resolver.list_profiles()
-    if not profiles:
-        return ""
-
-    lines = [
-        "## Your Sub-Agent Team",
-        "",
-        "You have specialized sub-agent profiles available for delegation. "
-        "Use `spawn_agent(profile='name', task='...')` to dispatch work. "
-        "Sub-agents run in the background and notify you when complete.",
-        "",
-        "| Profile | Role | Model |",
-        "|---------|------|-------|",
-    ]
-
-    for p in profiles:
-        model = p.model or "(workspace default)"
-        desc = p.description or "(no description)"
-        lines.append(f"| `{p.name}` | {desc} | {model} |")
-
-    lines.append("")
-    lines.append("### Dispatch Guidelines")
-    lines.append("")
-    lines.append(
-        "- **Delegate proactively** — when you recognize a task that fits "
-        "a profile, spawn it without waiting to be asked"
-    )
-    lines.append(
-        "- **Prefer profiles over manual tool filtering** — profiles carry "
-        "focused prompts and tool restrictions tuned for their role"
-    )
-    lines.append(
-        "- **Sub-agents are fire-and-forget** — you cannot send follow-up "
-        "messages; write a thorough task prompt upfront"
-    )
-    lines.append(
-        "- **Chain results** — one sub-agent's output (saved to workspace) "
-        "can be input for another sub-agent or your own synthesis"
-    )
-    lines.append(
-        "- **Use `list_team_profiles` for details** — see tool restrictions, "
-        "timeouts, and skill configurations per profile"
-    )
-
-    return "\n".join(lines)
 
 
 class WorkspaceRunner:
@@ -822,7 +764,7 @@ class WorkspaceRunner:
 
         # Inject team roster into the workspace system prompt
         if len(profile_resolver) > 0:
-            self._workspace.team_roster = _build_team_roster(profile_resolver)
+            self._workspace.team_roster = TeamRosterBuilder(profile_resolver).build()
 
         # Start sub-agent runner
         subagent_session_logger = SessionLogger(self._workspace.path, session_type="subagent")

--- a/tests/test_team_roster.py
+++ b/tests/test_team_roster.py
@@ -1,0 +1,125 @@
+"""Tests for TeamRosterBuilder."""
+
+from openpaw.model.spawn_profile import SpawnProfile
+from openpaw.workspace.profile_resolver import SpawnProfileResolver
+from openpaw.workspace.roster import TeamRosterBuilder
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_profile(name: str, description: str | None = None, model: str | None = None) -> SpawnProfile:
+    """Construct a minimal SpawnProfile for roster tests."""
+    return SpawnProfile(
+        name=name,
+        description=description or "",
+        model=model,
+    )
+
+
+def make_resolver(profiles: list[SpawnProfile]) -> SpawnProfileResolver:
+    """Create a resolver from a list of profiles."""
+    return SpawnProfileResolver(workspace_profiles=profiles)
+
+
+# ---------------------------------------------------------------------------
+# Empty roster
+# ---------------------------------------------------------------------------
+
+
+def test_empty_profiles_returns_empty_string() -> None:
+    """When no profiles are loaded, build() returns an empty string."""
+    resolver = make_resolver([])
+    builder = TeamRosterBuilder(resolver)
+
+    result = builder.build()
+
+    assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# Single profile
+# ---------------------------------------------------------------------------
+
+
+def test_single_profile_returns_correct_markdown() -> None:
+    """A single profile produces a complete roster with the profile row."""
+    resolver = make_resolver([make_profile("news-scout", description="News research", model="anthropic:claude-haiku")])
+    builder = TeamRosterBuilder(resolver)
+
+    result = builder.build()
+
+    assert "## Your Sub-Agent Team" in result
+    assert "| Profile | Role | Model |" in result
+    assert "| `news-scout` | News research | anthropic:claude-haiku |" in result
+
+
+# ---------------------------------------------------------------------------
+# Multiple profiles
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_profiles_returns_correct_markdown() -> None:
+    """Multiple profiles are listed in sorted order with correct markdown."""
+    profiles = [
+        make_profile("code-reviewer", description="Review code", model="openai:gpt-4o"),
+        make_profile("news-scout", description="News research", model="anthropic:claude-haiku"),
+    ]
+    resolver = make_resolver(profiles)
+    builder = TeamRosterBuilder(resolver)
+
+    result = builder.build()
+
+    lines = result.splitlines()
+    # Profiles are sorted alphabetically by name
+    code_reviewer_idx = next(i for i, line in enumerate(lines) if "code-reviewer" in line)
+    news_scout_idx = next(i for i, line in enumerate(lines) if "news-scout" in line)
+    assert code_reviewer_idx < news_scout_idx
+    assert "| `code-reviewer` | Review code | openai:gpt-4o |" in result
+    assert "| `news-scout` | News research | anthropic:claude-haiku |" in result
+
+
+# ---------------------------------------------------------------------------
+# Dispatch guidelines
+# ---------------------------------------------------------------------------
+
+
+def test_build_includes_all_dispatch_guidelines() -> None:
+    """The roster includes all five dispatch guideline bullets."""
+    resolver = make_resolver([make_profile("alpha", description="Alpha role", model="xai:grok-3")])
+    builder = TeamRosterBuilder(resolver)
+
+    result = builder.build()
+
+    assert "### Dispatch Guidelines" in result
+    assert "Delegate proactively" in result
+    assert "Prefer profiles over manual tool filtering" in result
+    assert "Sub-agents are fire-and-forget" in result
+    assert "Chain results" in result
+    assert "Use `list_team_profiles` for details" in result
+
+
+# ---------------------------------------------------------------------------
+# Default placeholders
+# ---------------------------------------------------------------------------
+
+
+def test_profile_without_model_uses_workspace_default() -> None:
+    """A profile with no model shows the '(workspace default)' placeholder."""
+    resolver = make_resolver([make_profile("no-model", description="Has no model")])
+    builder = TeamRosterBuilder(resolver)
+
+    result = builder.build()
+
+    assert "| `no-model` | Has no model | (workspace default) |" in result
+
+
+def test_profile_without_description_uses_no_description() -> None:
+    """A profile with no description shows the '(no description)' placeholder."""
+    resolver = make_resolver([make_profile("no-desc", description="", model="openai:gpt-4o")])
+    builder = TeamRosterBuilder(resolver)
+
+    result = builder.build()
+
+    assert "| `no-desc` | (no description) | openai:gpt-4o |" in result


### PR DESCRIPTION
## Summary
Extracts `_build_team_roster()` from `workspace/runner.py` into a dedicated `workspace/roster.py` module.

## Changes
- **New:** `openpaw/workspace/roster.py` — `TeamRosterBuilder` class with `build()` method
- **Modified:** `workspace/runner.py` — removed 57-line standalone function, updated call site
- **New:** `tests/test_team_roster.py` — 6 unit tests covering empty profiles, single/multiple profiles, dispatch guidelines, default placeholders

## Verification
- Full test suite: **2,777 passed**
- Ruff: clean
- Mypy: clean

## Risk
Low — pure move, no behavior change.