### PR TITLE
MR #8: Scheduler Base Class

### DIFF
--- a/tests/test_session_persistence.py
+++ b/tests/test_session_persistence.py
@@ -219,13 +219,10 @@ class TestConfigModels:
         config2 = HeartbeatConfig(delivery="agent")
         assert config2.delivery == "agent"
 
-    def test_heartbeat_config_delivery_both_rejected(self):
-        """delivery='both' raises ValidationError with migration message."""
-        with pytest.raises(ValidationError) as exc_info:
-            HeartbeatConfig(delivery="both")
-
-        error_text = str(exc_info.value)
-        assert "delivery: 'both' has been removed" in error_text
+    def test_heartbeat_config_delivery_both_accepted(self):
+        """delivery='both' is now valid (Phase 0 bugfix)."""
+        config = HeartbeatConfig(delivery="both")
+        assert config.delivery == "both"
 
     def test_cron_output_delivery_default(self):
         """Verify default is 'channel'."""
@@ -237,13 +234,10 @@ class TestConfigModels:
         with pytest.raises(ValidationError):
             CronOutputConfig(channel="telegram", chat_id=123, delivery="invalid")
 
-    def test_cron_output_delivery_both_rejected(self):
-        """delivery='both' raises ValidationError with migration message."""
-        with pytest.raises(ValidationError) as exc_info:
-            CronOutputConfig(channel="telegram", chat_id=123, delivery="both")
-
-        error_text = str(exc_info.value)
-        assert "delivery: 'both' has been removed" in error_text
+    def test_cron_output_delivery_both_accepted(self):
+        """delivery='both' is now valid (Phase 0 bugfix)."""
+        output = CronOutputConfig(channel="telegram", chat_id=123, delivery="both")
+        assert output.delivery == "both"
 
 
 # --- System Event Template Tests ---


### PR DESCRIPTION
## Summary
Extracts shared orchestration logic from `CronScheduler` and `HeartbeatScheduler` into a new `BaseScheduler` abstract class.

## Changes
- **New:** `openpaw/runtime/scheduling/base.py` — `BaseScheduler` with shared infrastructure:
  - `_execute_agent()` — agent factory invocation, timing, token-cap warning, session logging
  - `_deliver_result()` — channel delivery + agent injection with `delivery: "both"` support
  - `_resolve_session_key()` — target_id/chat_id/channel_id resolution
  - `_log_event()` — generic JSONL event writer
- **Updated:** `openpaw/runtime/scheduling/cron.py` — `CronScheduler` extends `BaseScheduler`; removed ~200 lines of duplicated logic
- **Updated:** `openpaw/runtime/scheduling/heartbeat.py` — `HeartbeatScheduler` extends `BaseScheduler`; removed ~200 lines of duplicated logic
- **Updated:** `openpaw/core/config/models/cron.py` — `HeartbeatConfig` and `CronOutputConfig` now accept `delivery: "both"`
- **Updated:** `openpaw/builtins/tools/cron_manager.py` — `_validate_delivery()` now accepts `"both"`
- **Updated:** `tests/test_session_persistence.py` — fixed 2 tests that asserted old `"both"` rejection behavior

## Behavioral Fixes
1. **`delivery: "both"` mode** — `BaseScheduler._deliver_result()` now executes both channel delivery and agent queue injection when `delivery == "both"`. (Phase 0 bugfix, now properly implemented.)
2. **Heartbeat channel context** — `HeartbeatScheduler._run_heartbeat()` now passes `set_channel_ctx=True` to `_execute_agent()`, so `send_message`/`send_file` builtins work during heartbeat execution.

## Verification
- Full test suite: **2,777 passed**
- Ruff: clean
- Mypy: no new errors in changed files

## Risk
Medium — shared logic extraction. Both schedulers now delegate to base class for agent execution, delivery routing, and event logging. The behavior must be identical.