### PR TITLE
MR #11: Channel Helper Extraction

### DIFF
--- a/openpaw/channels/discord.py
+++ b/openpaw/channels/discord.py
@@ -12,6 +12,14 @@ import discord
 from discord import app_commands
 
 from openpaw.channels.base import ChannelAdapter
+from openpaw.channels.helpers import (
+    SecurityMixin,
+    check_file_size,
+    format_approval_message,
+    format_unauthorized_response,
+    map_mime_type_to_attachment_type,
+    split_message,
+)
 from openpaw.model.channel import ChannelEvent, ChannelHistoryEntry
 from openpaw.model.message import Attachment, Message, MessageDirection
 
@@ -71,7 +79,7 @@ class _ApprovalView(discord.ui.View):
         self.stop()
 
 
-class DiscordChannel(ChannelAdapter):
+class DiscordChannel(ChannelAdapter, SecurityMixin):
     """Discord channel adapter.
 
     Handles:
@@ -339,12 +347,8 @@ class DiscordChannel(ChannelAdapter):
         if not self._client:
             raise RuntimeError("Discord channel not started")
 
+        check_file_size(file_data, self.MAX_FILE_SIZE, "Discord")
         file_size = len(file_data)
-        if file_size > self.MAX_FILE_SIZE:
-            size_mb = file_size / (1024 * 1024)
-            raise ValueError(
-                f"File size ({size_mb:.1f} MB) exceeds Discord's 25 MB limit"
-            )
 
         channel_id = self._channel_id_from_session_key(session_key)
         channel = await self._resolve_channel(channel_id)
@@ -382,15 +386,7 @@ class DiscordChannel(ChannelAdapter):
             logger.warning("send_approval_request called but no approval callback registered")
             return
 
-        # Build the request message text
-        safe_tool_name = tool_name.replace("`", "'")
-        text = f"**Approval Required**\nTool: `{safe_tool_name}`\n"
-        if show_args and tool_args:
-            args_str = str(tool_args)
-            if len(args_str) > 500:
-                args_str = args_str[:500] + "..."
-            args_str = args_str.replace("`", "'")
-            text += f"Args: `{args_str}`\n"
+        text = format_approval_message(tool_name, tool_args, show_args)
 
         channel_id = self._channel_id_from_session_key(session_key)
         channel = await self._resolve_channel(channel_id)
@@ -492,11 +488,7 @@ class DiscordChannel(ChannelAdapter):
     def _is_allowed(self, message: discord.Message) -> bool:
         """Check whether the message sender is permitted to use this workspace.
 
-        Security model:
-        - allow_all=True  → everyone is allowed (insecure, use with caution)
-        - In a guild + allowed_groups contains the guild → allowed (any user in that guild)
-        - allowed_users non-empty → user.id must be in the set (DMs and non-allowed guilds)
-        - No allowlists match → deny (secure default)
+        Extracts primitive IDs and delegates to SecurityMixin.
 
         Args:
             message: The incoming discord.Message.
@@ -504,36 +496,14 @@ class DiscordChannel(ChannelAdapter):
         Returns:
             True if the sender is allowed, False otherwise.
         """
-        if self.allow_all:
-            return True
-
-        # Guild allowlist: if the message is from an allowed guild, permit it
-        # without requiring the user to be individually allowlisted.
-        if message.guild and self.allowed_groups:
-            if message.guild.id in self.allowed_groups:
-                return True
-            # Message is from a guild not in the allowlist — fall through to
-            # user check (user might be individually allowed for DMs).
-
-        # User allowlist check (DMs and non-allowed guilds)
         user_id = message.author.id
-        if self.allowed_users:
-            if user_id not in self.allowed_users:
-                return False
-            return True
-
-        # No allowlists matched — deny
-        return False
+        guild_id = message.guild.id if message.guild else None
+        return self._check_user_allowed(user_id, guild_id)
 
     def _passes_activation_filter(self, message: discord.Message) -> bool:
         """Check whether the message passes activation filters (mention OR trigger).
 
-        In guild channels, messages must pass at least one activation condition:
-        - Bot is @mentioned (when mention_required is True)
-        - Message contains a trigger keyword (when triggers are configured)
-
-        If neither mention_required nor triggers are configured, all messages pass.
-        DMs always pass through regardless.
+        Extracts primitive flags and delegates to SecurityMixin.
 
         Args:
             message: The incoming discord.Message.
@@ -541,23 +511,16 @@ class DiscordChannel(ChannelAdapter):
         Returns:
             True if the message should be processed.
         """
-        # No activation filters configured — pass everything
-        if not self.mention_required and not self.triggers:
-            return True
-
-        # DMs always pass through
-        if message.guild is None:
-            return True
-
-        # OR logic: either mention or trigger is sufficient
-        if self.mention_required and self._client and self._client.user in message.mentions:
-            return True
-
+        is_dm = message.guild is None
+        is_command = False
         content = message.content or ""
-        if self._passes_trigger_filter(content, self.triggers):
-            return True
-
-        return False
+        is_mentioned = (
+            self._client is not None
+            and self._client.user in message.mentions
+        )
+        return self._check_activation(
+            content, is_dm, is_command, is_mentioned
+        )
 
     async def _send_unauthorized_response(self, message: discord.Message) -> None:
         """Reply to an unauthorized user with their IDs and config instructions.
@@ -568,22 +531,7 @@ class DiscordChannel(ChannelAdapter):
         user_id = message.author.id
         guild_id = message.guild.id if message.guild else None
 
-        text = (
-            f"Access denied.\n\n"
-            f"Your user ID: `{user_id}`\n"
-        )
-        if guild_id:
-            text += f"Guild (server) ID: `{guild_id}`\n"
-
-        text += (
-            f"\nTo gain access, add your ID to the allowlist:\n"
-            f"`agent_workspaces/{self.workspace_name}/agent.yaml`\n\n"
-            f"```yaml\n"
-            f"channel:\n"
-            f"  allowed_users:\n"
-            f"    - {user_id}\n"
-            f"```"
-        )
+        text = format_unauthorized_response(user_id, self.workspace_name, guild_id)
 
         try:
             await message.reply(text)
@@ -636,10 +584,7 @@ class DiscordChannel(ChannelAdapter):
     ) -> list[Attachment]:
         """Download all attachments from a discord.Message.
 
-        Determines the OpenPaw attachment type from the Discord MIME type:
-        - audio/* → "audio"
-        - image/* → "image"
-        - anything else → "document"
+        Determines the OpenPaw attachment type from the Discord MIME type.
 
         Args:
             discord_message: The discord.Message whose attachments to download.
@@ -661,13 +606,7 @@ class DiscordChannel(ChannelAdapter):
                 continue
 
             content_type = discord_attachment.content_type or "application/octet-stream"
-
-            if content_type.startswith("audio/"):
-                attachment_type = "audio"
-            elif content_type.startswith("image/"):
-                attachment_type = "image"
-            else:
-                attachment_type = "document"
+            attachment_type = map_mime_type_to_attachment_type(content_type)
 
             result.append(
                 Attachment(
@@ -695,8 +634,7 @@ class DiscordChannel(ChannelAdapter):
     def _split_message(self, text: str) -> list[str]:
         """Split text into chunks that fit Discord's 2000-char message limit.
 
-        Tries to break at paragraph boundaries (double newline), falls back
-        to single newlines, then hard-splits as a last resort.
+        Delegates to the shared split_message helper.
 
         Args:
             text: The full message text.
@@ -704,32 +642,7 @@ class DiscordChannel(ChannelAdapter):
         Returns:
             List of message chunks, each within MAX_MESSAGE_LENGTH.
         """
-        if len(text) <= self.MAX_MESSAGE_LENGTH:
-            return [text]
-
-        chunks: list[str] = []
-        remaining = text
-
-        while remaining:
-            if len(remaining) <= self.MAX_MESSAGE_LENGTH:
-                chunks.append(remaining)
-                break
-
-            # Prefer paragraph boundary
-            split_at = remaining.rfind("\n\n", 0, self.MAX_MESSAGE_LENGTH)
-
-            # Fall back to single newline
-            if split_at == -1:
-                split_at = remaining.rfind("\n", 0, self.MAX_MESSAGE_LENGTH)
-
-            # Hard split as last resort
-            if split_at == -1:
-                split_at = self.MAX_MESSAGE_LENGTH
-
-            chunks.append(remaining[:split_at])
-            remaining = remaining[split_at:].lstrip("\n")
-
-        return chunks
+        return split_message(text, self.MAX_MESSAGE_LENGTH)
 
     @staticmethod
     def _channel_id_from_session_key(session_key: str) -> int:

--- a/openpaw/channels/helpers/__init__.py
+++ b/openpaw/channels/helpers/__init__.py
@@ -1,0 +1,19 @@
+"""Shared channel helpers for message splitting, formatting, security, and attachments."""
+
+from openpaw.channels.helpers.attachments import map_mime_type_to_attachment_type
+from openpaw.channels.helpers.formatting import (
+    check_file_size,
+    format_approval_message,
+    format_unauthorized_response,
+)
+from openpaw.channels.helpers.security import SecurityMixin
+from openpaw.channels.helpers.splitting import split_message
+
+__all__ = [
+    "split_message",
+    "format_approval_message",
+    "format_unauthorized_response",
+    "map_mime_type_to_attachment_type",
+    "check_file_size",
+    "SecurityMixin",
+]

--- a/openpaw/channels/helpers/attachments.py
+++ b/openpaw/channels/helpers/attachments.py
@@ -1,0 +1,26 @@
+"""Attachment type mapping utilities for channel adapters.
+
+Provides a platform-agnostic MIME-type to attachment-type mapper used
+when downloading or classifying file attachments.
+"""
+
+
+def map_mime_type_to_attachment_type(mime_type: str | None) -> str:
+    """Map a MIME type to a simplified attachment category.
+
+    Categories:
+        - "audio" for MIME types starting with "audio/"
+        - "image" for MIME types starting with "image/"
+        - "document" for everything else (including unknown/None)
+
+    Args:
+        mime_type: The MIME type string, or None if unknown.
+
+    Returns:
+        One of "audio", "image", or "document".
+    """
+    if mime_type and mime_type.startswith("audio/"):
+        return "audio"
+    if mime_type and mime_type.startswith("image/"):
+        return "image"
+    return "document"

--- a/openpaw/channels/helpers/formatting.py
+++ b/openpaw/channels/helpers/formatting.py
@@ -1,0 +1,83 @@
+"""Formatting utilities for channel adapter messages.
+
+Provides platform-agnostic text formatting helpers used by multiple
+channel adapters (Discord, Telegram, and future channels).
+"""
+
+from typing import Any
+
+
+def format_approval_message(
+    tool_name: str, tool_args: dict[str, Any], show_args: bool
+) -> str:
+    """Build an approval-request message string.
+
+    Escapes backticks to prevent markdown injection and truncates long
+    argument strings.
+
+    Args:
+        tool_name: Name of the tool requiring approval.
+        tool_args: Arguments passed to the tool.
+        show_args: Whether to display tool arguments to the user.
+
+    Returns:
+        Formatted approval message text.
+    """
+    safe_tool_name = tool_name.replace("`", "'")
+    text = f"🔒 **Approval Required**\nTool: `{safe_tool_name}`\n"
+    if show_args and tool_args:
+        args_str = str(tool_args)
+        if len(args_str) > 500:
+            args_str = args_str[:500] + "..."
+        args_str = args_str.replace("`", "'")
+        text += f"Args: `{args_str}`\n"
+    return text
+
+
+def format_unauthorized_response(
+    user_id: int, workspace_name: str, group_id: int | None = None
+) -> str:
+    """Build a standard access-denied response with allowlist instructions.
+
+    Args:
+        user_id: The blocked user's platform ID.
+        workspace_name: Name of the workspace for config path display.
+        group_id: Optional group/server ID to include in the message.
+
+    Returns:
+        Formatted access-denied message text.
+    """
+    text = f"⛔ Access denied.\n\nYour user ID: `{user_id}`\n"
+    if group_id is not None:
+        text += f"Group ID: `{group_id}`\n"
+    text += (
+        f"\nTo gain access, add your ID to the allowlist:\n"
+        f"`agent_workspaces/{workspace_name}/agent.yaml`\n\n"
+        f"```yaml\n"
+        f"channel:\n"
+        f"  allowed_users:\n"
+        f"    - {user_id}\n"
+        f"```"
+    )
+    return text
+
+
+def check_file_size(file_data: bytes, max_size: int, platform_name: str) -> None:
+    """Validate that a file does not exceed a platform's size limit.
+
+    Args:
+        file_data: Raw file bytes.
+        max_size: Maximum allowed size in bytes.
+        platform_name: Human-readable platform name for error messages.
+
+    Raises:
+        ValueError: If file_data exceeds max_size.
+    """
+    size = len(file_data)
+    if size > max_size:
+        size_mb = size / (1024 * 1024)
+        max_mb = max_size // (1024 * 1024)
+        raise ValueError(
+            f"File size ({size_mb:.1f} MB) exceeds {platform_name}'s "
+            f"{max_mb} MB limit"
+        )

--- a/openpaw/channels/helpers/security.py
+++ b/openpaw/channels/helpers/security.py
@@ -1,0 +1,140 @@
+"""Security mixin for channel adapters.
+
+Provides allowlist enforcement and activation filtering (mention/trigger)
+that is shared across all channel adapters. Concrete adapters extract
+platform-specific primitives and delegate to these generic helpers.
+
+Usage::
+
+    class MyChannel(ChannelAdapter, SecurityMixin):
+        def _is_allowed(self, message: PlatformMessage) -> bool:
+            user_id = message.author.id
+            group_id = message.guild.id if message.guild else None
+            return self._check_user_allowed(user_id, group_id)
+
+Expected instance attributes (set by the adapter's __init__):
+    allowed_users: set[int]
+    allowed_groups: set[int]
+    allow_all: bool
+    mention_required: bool
+    triggers: list[str]
+    workspace_name: str
+"""
+
+from openpaw.channels.helpers.formatting import format_unauthorized_response
+
+
+class SecurityMixin:
+    """Allowlist and activation filtering mixin for channel adapters.
+
+    Both Discord and Telegram (and future adapters) need the same security
+    model: allowlist checking, group allowlist, mention/trigger activation
+    filtering, and unauthorized-response formatting. This mixin extracts the
+    shared logic so it can be unit-tested once and reused everywhere.
+    """
+
+    # Type annotations for expected instance attributes (set by adapters)
+    allowed_users: set[int]
+    allowed_groups: set[int]
+    allow_all: bool
+    mention_required: bool
+    triggers: list[str]
+    workspace_name: str
+
+    # --- Allowlist enforcement ---
+
+    def _check_user_allowed(self, user_id: int, group_id: int | None = None) -> bool:
+        """Check whether a user is permitted to use this workspace.
+
+        Security model:
+        - allow_all=True → everyone is allowed (insecure, use with caution)
+        - group_id provided and in allowed_groups → allowed (any member)
+        - allowed_users non-empty → user_id must be in the set
+        - No allowlists match → deny (secure default)
+
+        Args:
+            user_id: The platform-specific user ID.
+            group_id: Optional group/guild/chat ID. If provided and in
+                allowed_groups, the user is permitted regardless of
+                allowed_users.
+
+        Returns:
+            True if the user is allowed, False otherwise.
+        """
+        if self.allow_all:
+            return True
+
+        # Group allowlist: if the user is in an allowed group, permit them
+        # without requiring individual allowlisting.
+        if group_id is not None and self.allowed_groups:
+            if group_id in self.allowed_groups:
+                return True
+
+        # User allowlist check (applies to DMs and non-allowed groups)
+        if self.allowed_users:
+            return user_id in self.allowed_users
+
+        # No allowlists matched — deny
+        return False
+
+    # --- Activation filtering ---
+
+    def _check_activation(
+        self,
+        content: str,
+        is_dm: bool,
+        is_command: bool,
+        is_mentioned: bool,
+    ) -> bool:
+        """Check whether a message passes activation filters (mention OR trigger).
+
+        In group channels, messages must pass at least one activation condition:
+        - Bot is @mentioned (when mention_required is True)
+        - Message contains a trigger keyword (when triggers are configured)
+
+        If neither mention_required nor triggers are configured, all messages pass.
+        DMs and commands always pass through regardless.
+
+        Args:
+            content: The message text content.
+            is_dm: True if the message is from a DM/private chat.
+            is_command: True if the message is a framework command (e.g., starts with "/").
+            is_mentioned: True if the bot is @mentioned in the message.
+
+        Returns:
+            True if the message should be processed.
+        """
+        # No activation filters configured — pass everything
+        if not self.mention_required and not self.triggers:
+            return True
+
+        # DMs and commands always pass through
+        if is_dm or is_command:
+            return True
+
+        # OR logic: either mention or trigger is sufficient
+        if self.mention_required and is_mentioned:
+            return True
+
+        if self.triggers and self._passes_trigger_filter(content, self.triggers):
+            return True
+
+        return False
+
+    # --- Unauthorized response formatting ---
+
+    def _build_unauthorized_text(
+        self, user_id: int, group_id: int | None = None
+    ) -> str:
+        """Build the standard access-denied message text.
+
+        Args:
+            user_id: The blocked user's platform ID.
+            group_id: Optional group/server ID to include.
+
+        Returns:
+            Formatted access-denied message text.
+        """
+        return format_unauthorized_response(
+            user_id, self.workspace_name, group_id
+        )

--- a/openpaw/channels/helpers/splitting.py
+++ b/openpaw/channels/helpers/splitting.py
@@ -1,0 +1,46 @@
+"""Message splitting utilities for channel adapters.
+
+Provides a platform-agnostic message splitter that respects configurable
+character limits, trying to break at natural boundaries first.
+"""
+
+
+def split_message(text: str, max_length: int) -> list[str]:
+    """Split text into chunks that fit a message length limit.
+
+    Tries to break at paragraph boundaries (double newline), falls back
+    to single newlines, then hard-splits as a last resort.
+
+    Args:
+        text: The full message text to split.
+        max_length: Maximum character length per chunk.
+
+    Returns:
+        List of message chunks, each within max_length.
+    """
+    if len(text) <= max_length:
+        return [text]
+
+    chunks: list[str] = []
+    remaining = text
+
+    while remaining:
+        if len(remaining) <= max_length:
+            chunks.append(remaining)
+            break
+
+        # Prefer paragraph boundary
+        split_at = remaining.rfind("\n\n", 0, max_length)
+
+        # Fall back to single newline
+        if split_at == -1:
+            split_at = remaining.rfind("\n", 0, max_length)
+
+        # Hard split as last resort
+        if split_at == -1:
+            split_at = max_length
+
+        chunks.append(remaining[:split_at])
+        remaining = remaining[split_at:].lstrip("\n")
+
+    return chunks

--- a/openpaw/channels/telegram.py
+++ b/openpaw/channels/telegram.py
@@ -10,12 +10,19 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import Application, CallbackQueryHandler, ContextTypes, MessageHandler, filters
 
 from openpaw.channels.base import ChannelAdapter
+from openpaw.channels.helpers import (
+    SecurityMixin,
+    check_file_size,
+    format_approval_message,
+    format_unauthorized_response,
+    split_message,
+)
 from openpaw.model.message import Attachment, Message, MessageDirection
 
 logger = logging.getLogger(__name__)
 
 
-class TelegramChannel(ChannelAdapter):
+class TelegramChannel(ChannelAdapter, SecurityMixin):
     """Telegram channel adapter.
 
     Handles:
@@ -212,8 +219,7 @@ class TelegramChannel(ChannelAdapter):
     def _split_message(self, text: str) -> list[str]:
         """Split text into chunks that fit Telegram's message limit.
 
-        Tries to break at paragraph boundaries (double newline), falls back
-        to single newlines, then hard-splits as a last resort.
+        Delegates to the shared split_message helper.
 
         Args:
             text: The full message text.
@@ -221,32 +227,7 @@ class TelegramChannel(ChannelAdapter):
         Returns:
             List of message chunks, each within MAX_MESSAGE_LENGTH.
         """
-        if len(text) <= self.MAX_MESSAGE_LENGTH:
-            return [text]
-
-        chunks: list[str] = []
-        remaining = text
-
-        while remaining:
-            if len(remaining) <= self.MAX_MESSAGE_LENGTH:
-                chunks.append(remaining)
-                break
-
-            # Try to split at paragraph boundary
-            split_at = remaining.rfind("\n\n", 0, self.MAX_MESSAGE_LENGTH)
-
-            # Fall back to single newline
-            if split_at == -1:
-                split_at = remaining.rfind("\n", 0, self.MAX_MESSAGE_LENGTH)
-
-            # Hard split as last resort
-            if split_at == -1:
-                split_at = self.MAX_MESSAGE_LENGTH
-
-            chunks.append(remaining[:split_at])
-            remaining = remaining[split_at:].lstrip("\n")
-
-        return chunks
+        return split_message(text, self.MAX_MESSAGE_LENGTH)
 
     async def send_audio(
         self,
@@ -316,13 +297,8 @@ class TelegramChannel(ChannelAdapter):
         if not self._app:
             raise RuntimeError("Telegram channel not started")
 
-        # Validate file size
+        check_file_size(file_data, self.MAX_FILE_SIZE, "Telegram")
         file_size = len(file_data)
-        if file_size > self.MAX_FILE_SIZE:
-            size_mb = file_size / (1024 * 1024)
-            raise ValueError(
-                f"File size ({size_mb:.1f} MB) exceeds Telegram's 50 MB limit"
-            )
 
         from io import BytesIO
 
@@ -349,46 +325,27 @@ class TelegramChannel(ChannelAdapter):
     def _is_allowed(self, update: Update) -> bool:
         """Check if the message sender is allowed.
 
-        Security model:
-        - If allow_all is True, all users are allowed (insecure)
-        - If in a group chat and allowed_groups contains the group → allowed (any user)
-        - If allowed_users is set, user must be in the list (DMs and non-allowed groups)
-        - If neither allow_all nor allowlists match, deny by default (secure)
+        Extracts primitive IDs and delegates to SecurityMixin.
+
+        Args:
+            update: The Telegram Update object.
+
+        Returns:
+            True if the sender is allowed, False otherwise.
         """
         if not update.effective_user:
             return False
 
-        # Explicit allow-all mode (use with caution)
-        if self.allow_all:
-            return True
-
-        chat_id = update.effective_chat.id if update.effective_chat else None
-
-        # Group allowlist: if the message is from an allowed group, permit it
-        # without requiring the user to be individually allowlisted.
-        if chat_id and chat_id < 0 and self.allowed_groups:
-            if chat_id in self.allowed_groups:
-                return True
-
-        # User allowlist check (DMs and non-allowed groups)
         user_id = update.effective_user.id
-        if self.allowed_users:
-            if user_id not in self.allowed_users:
-                return False
-            return True
-
-        # No allowlists matched — deny
-        return False
+        chat_id = update.effective_chat.id if update.effective_chat else None
+        # In Telegram, negative chat IDs are group chats
+        group_id = chat_id if chat_id is not None and chat_id < 0 else None
+        return self._check_user_allowed(user_id, group_id)
 
     def _passes_activation_filter(self, update: Update) -> bool:
         """Check whether the message passes activation filters (mention OR trigger).
 
-        In group chats, messages must pass at least one activation condition:
-        - Bot is @mentioned (when mention_required is True)
-        - Message contains a trigger keyword (when triggers are configured)
-
-        If neither mention_required nor triggers are configured, all messages pass.
-        DMs and commands always pass through regardless.
+        Extracts primitive flags and delegates to SecurityMixin.
 
         Args:
             update: The Telegram Update object.
@@ -396,27 +353,24 @@ class TelegramChannel(ChannelAdapter):
         Returns:
             True if the message should be processed.
         """
-        # No activation filters configured — pass everything
-        if not self.mention_required and not self.triggers:
-            return True
-
-        # DMs always pass through (positive chat IDs are private chats)
-        if update.effective_chat and update.effective_chat.id > 0:
-            return True
-
-        # Commands always pass through (they're routed via CommandRouter)
-        if update.message and update.message.text and update.message.text.startswith("/"):
-            return True
-
-        # OR logic: either mention or trigger is sufficient
-        if self.mention_required and self._has_bot_mention(update):
-            return True
-
-        content = (update.message.text or update.message.caption or "") if update.message else ""
-        if self._passes_trigger_filter(content, self.triggers):
-            return True
-
-        return False
+        is_dm = (
+            update.effective_chat is not None
+            and update.effective_chat.id > 0
+        )
+        is_command = bool(
+            update.message
+            and update.message.text
+            and update.message.text.startswith("/")
+        )
+        content = (
+            (update.message.text or update.message.caption or "")
+            if update.message
+            else ""
+        )
+        is_mentioned = self._has_bot_mention(update)
+        return self._check_activation(
+            content, is_dm, is_command, is_mentioned
+        )
 
     def _has_bot_mention(self, update: Update) -> bool:
         """Check if the message contains an @mention of this bot."""
@@ -462,26 +416,11 @@ class TelegramChannel(ChannelAdapter):
 
         user_id = update.effective_user.id
         chat_id = update.effective_chat.id if update.effective_chat else None
+        group_id = chat_id if chat_id is not None and chat_id < 0 else None
 
-        message = (
-            f"⛔ Access denied.\n\n"
-            f"Your user ID: `{user_id}`\n"
-        )
+        text = format_unauthorized_response(user_id, self.workspace_name, group_id)
 
-        if chat_id and chat_id < 0:
-            message += f"Group ID: `{chat_id}`\n"
-
-        message += (
-            f"\nTo gain access, add your ID to the allowlist:\n"
-            f"`agent_workspaces/{self.workspace_name}/agent.yaml`\n\n"
-            f"```yaml\n"
-            f"channel:\n"
-            f"  allowed_users:\n"
-            f"    - {user_id}\n"
-            f"```"
-        )
-
-        await update.message.reply_text(message, parse_mode="Markdown")
+        await update.message.reply_text(text, parse_mode="Markdown")
         logger.warning(f"Blocked user {user_id} from workspace '{self.workspace_name}'")
 
     async def _handle_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -742,15 +681,7 @@ class TelegramChannel(ChannelAdapter):
         """Send approval request with Telegram inline keyboard."""
         chat_id = int(session_key.split(":")[1])
 
-        # Escape backticks to prevent markdown injection
-        safe_tool_name = tool_name.replace("`", "'")
-        text = f"🔒 **Approval Required**\nTool: `{safe_tool_name}`\n"
-        if show_args and tool_args:
-            args_str = str(tool_args)
-            if len(args_str) > 500:
-                args_str = args_str[:500] + "..."
-            args_str = args_str.replace("`", "'")
-            text += f"Args: `{args_str}`\n"
+        text = format_approval_message(tool_name, tool_args, show_args)
 
         keyboard = InlineKeyboardMarkup(
             [

--- a/tests/channels/test_helpers.py
+++ b/tests/channels/test_helpers.py
@@ -1,0 +1,397 @@
+"""Tests for shared channel helpers.
+
+Covers the extracted pure functions and SecurityMixin that are shared
+across Discord, Telegram, and future channel adapters.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from openpaw.channels.base import ChannelAdapter
+from openpaw.channels.helpers import (
+    SecurityMixin,
+    check_file_size,
+    format_approval_message,
+    format_unauthorized_response,
+    map_mime_type_to_attachment_type,
+    split_message,
+)
+from openpaw.model.message import Message
+
+# ---------------------------------------------------------------------------
+# split_message
+# ---------------------------------------------------------------------------
+
+
+class TestSplitMessage:
+    """Test the shared split_message helper."""
+
+    def test_short_message_returns_single_chunk(self) -> None:
+        text = "Short message."
+        result = split_message(text, 2000)
+        assert result == ["Short message."]
+
+    def test_exact_limit_no_split(self) -> None:
+        text = "x" * 2000
+        result = split_message(text, 2000)
+        assert len(result) == 1
+        assert len(result[0]) == 2000
+
+    def test_split_at_paragraph_boundary(self) -> None:
+        part_a = "A" * 1900 + "\n\n"
+        part_b = "B" * 200
+        text = part_a + part_b
+        result = split_message(text, 2000)
+        assert len(result) == 2
+        assert result[0] == "A" * 1900
+        assert result[1] == "B" * 200
+
+    def test_split_at_newline_when_no_paragraph_break(self) -> None:
+        part_a = "A" * 1990 + "\n"
+        part_b = "B" * 100
+        text = part_a + part_b
+        result = split_message(text, 2000)
+        assert len(result) == 2
+        assert result[0] == "A" * 1990
+        assert result[1] == "B" * 100
+
+    def test_hard_split_when_no_newlines(self) -> None:
+        text = "X" * 2500
+        result = split_message(text, 2000)
+        assert len(result) == 2
+        assert len(result[0]) == 2000
+        assert result[1] == "X" * 500
+
+    def test_very_long_message_produces_multiple_chunks(self) -> None:
+        text = "Z" * 5001
+        result = split_message(text, 2000)
+        assert len(result) == 3
+        assert all(len(chunk) <= 2000 for chunk in result)
+        assert "".join(result) == text
+
+    def test_empty_string_returns_single_empty_chunk(self) -> None:
+        result = split_message("", 2000)
+        assert result == [""]
+
+    def test_split_preserves_all_content(self) -> None:
+        text = "Hello world\n\n" * 200
+        result = split_message(text, 2000)
+        assert len(result) > 1
+        for chunk in result:
+            assert len(chunk) <= 2000
+
+    def test_different_max_lengths(self) -> None:
+        """Works with different max_length values (e.g., Telegram 4096)."""
+        text = "A" * 5000
+        result = split_message(text, 4096)
+        assert len(result) == 2
+        assert len(result[0]) == 4096
+        assert len(result[1]) == 904
+
+
+# ---------------------------------------------------------------------------
+# format_approval_message
+# ---------------------------------------------------------------------------
+
+
+class TestFormatApprovalMessage:
+    """Test the approval message formatter."""
+
+    def test_basic_tool_name(self) -> None:
+        result = format_approval_message("overwrite_file", {}, True)
+        assert "overwrite_file" in result
+        assert "Approval Required" in result
+
+    def test_escapes_backticks(self) -> None:
+        result = format_approval_message("`dangerous`", {}, True)
+        assert "'dangerous'" in result
+        assert "`dangerous`" not in result
+
+    def test_shows_args_when_configured(self) -> None:
+        result = format_approval_message("write_file", {"path": "/tmp/test"}, True)
+        assert "path" in result
+        assert "/tmp/test" in result
+
+    def test_hides_args_when_show_args_false(self) -> None:
+        result = format_approval_message("write_file", {"path": "/tmp/test"}, False)
+        assert "path" not in result
+
+    def test_truncates_long_args(self) -> None:
+        long_args = {"data": "x" * 1000}
+        result = format_approval_message("write_file", long_args, True)
+        assert "..." in result
+
+    def test_empty_args_no_args_section(self) -> None:
+        result = format_approval_message("write_file", {}, True)
+        assert "Args:" not in result
+
+
+# ---------------------------------------------------------------------------
+# format_unauthorized_response
+# ---------------------------------------------------------------------------
+
+
+class TestFormatUnauthorizedResponse:
+    """Test the unauthorized response formatter."""
+
+    def test_includes_user_id(self) -> None:
+        result = format_unauthorized_response(12345, "test_ws")
+        assert "12345" in result
+
+    def test_includes_workspace_name(self) -> None:
+        result = format_unauthorized_response(12345, "my_workspace")
+        assert "my_workspace" in result
+
+    def test_includes_group_id_when_provided(self) -> None:
+        result = format_unauthorized_response(12345, "test_ws", group_id=999)
+        assert "999" in result
+
+    def test_omits_group_id_when_none(self) -> None:
+        result = format_unauthorized_response(12345, "test_ws")
+        assert "Group ID" not in result
+
+    def test_includes_yaml_config_example(self) -> None:
+        result = format_unauthorized_response(12345, "test_ws")
+        assert "```yaml" in result
+        assert "allowed_users:" in result
+        assert "- 12345" in result
+
+    def test_includes_access_denied_emoji(self) -> None:
+        result = format_unauthorized_response(12345, "test_ws")
+        assert "⛔" in result
+
+
+# ---------------------------------------------------------------------------
+# map_mime_type_to_attachment_type
+# ---------------------------------------------------------------------------
+
+
+class TestMapMimeTypeToAttachmentType:
+    """Test MIME type to attachment category mapping."""
+
+    def test_audio_mime_type(self) -> None:
+        assert map_mime_type_to_attachment_type("audio/ogg") == "audio"
+        assert map_mime_type_to_attachment_type("audio/mpeg") == "audio"
+
+    def test_image_mime_type(self) -> None:
+        assert map_mime_type_to_attachment_type("image/png") == "image"
+        assert map_mime_type_to_attachment_type("image/jpeg") == "image"
+
+    def test_document_mime_types(self) -> None:
+        assert map_mime_type_to_attachment_type("application/pdf") == "document"
+        assert map_mime_type_to_attachment_type("text/plain") == "document"
+        assert map_mime_type_to_attachment_type("application/octet-stream") == "document"
+
+    def test_none_defaults_to_document(self) -> None:
+        assert map_mime_type_to_attachment_type(None) == "document"
+
+
+# ---------------------------------------------------------------------------
+# check_file_size
+# ---------------------------------------------------------------------------
+
+
+class TestCheckFileSize:
+    """Test the file size guard."""
+
+    def test_small_file_passes(self) -> None:
+        check_file_size(b"small", 1024, "TestPlatform")
+
+    def test_exact_limit_passes(self) -> None:
+        check_file_size(b"x" * 1024, 1024, "TestPlatform")
+
+    def test_oversized_file_raises(self) -> None:
+        with pytest.raises(ValueError, match="TestPlatform"):
+            check_file_size(b"x" * 1025, 1024, "TestPlatform")
+
+    def test_error_includes_size_mb(self) -> None:
+        with pytest.raises(ValueError, match="1.0 MB"):
+            check_file_size(b"x" * (1024 * 1024 + 1), 1024 * 1024, "Discord")
+
+
+# ---------------------------------------------------------------------------
+# SecurityMixin
+# ---------------------------------------------------------------------------
+
+
+class _TestChannel(ChannelAdapter, SecurityMixin):
+    """Minimal concrete implementation for testing SecurityMixin in isolation."""
+
+    name = "test"
+
+    def __init__(
+        self,
+        allowed_users: set[int] | None = None,
+        allowed_groups: set[int] | None = None,
+        allow_all: bool = False,
+        mention_required: bool = False,
+        triggers: list[str] | None = None,
+        workspace_name: str = "test",
+    ) -> None:
+        self.allowed_users = allowed_users or set()
+        self.allowed_groups = allowed_groups or set()
+        self.allow_all = allow_all
+        self.mention_required = mention_required
+        self.triggers = triggers or []
+        self.workspace_name = workspace_name
+
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+    async def send_message(self, session_key: str, content: str, **kwargs: Any) -> Message:
+        raise NotImplementedError
+
+    def on_message(self, callback: Any) -> None:
+        pass
+
+
+class TestSecurityMixinAllowlist:
+    """Test SecurityMixin allowlist enforcement."""
+
+    def test_allow_all_permits_any_user(self) -> None:
+        channel = _TestChannel(allow_all=True)
+        assert channel._check_user_allowed(99999) is True
+
+    def test_allow_all_overrides_empty_list(self) -> None:
+        channel = _TestChannel(allow_all=True, allowed_users=set())
+        assert channel._check_user_allowed(12345) is True
+
+    def test_allowed_user_permitted(self) -> None:
+        channel = _TestChannel(allowed_users={111, 222})
+        assert channel._check_user_allowed(111) is True
+
+    def test_disallowed_user_blocked(self) -> None:
+        channel = _TestChannel(allowed_users={111})
+        assert channel._check_user_allowed(999) is False
+
+    def test_empty_allowlist_denies_all(self) -> None:
+        channel = _TestChannel(allowed_users=set(), allow_all=False)
+        assert channel._check_user_allowed(111) is False
+
+    def test_allowed_group_permits_any_user(self) -> None:
+        channel = _TestChannel(allowed_users={111}, allowed_groups={500})
+        assert channel._check_user_allowed(999, group_id=500) is True
+
+    def test_allowed_user_in_non_allowed_group(self) -> None:
+        channel = _TestChannel(allowed_users={111}, allowed_groups={500})
+        assert channel._check_user_allowed(111, group_id=999) is True
+
+    def test_unknown_user_in_non_allowed_group_denied(self) -> None:
+        channel = _TestChannel(allowed_users={111}, allowed_groups={500})
+        assert channel._check_user_allowed(999, group_id=999) is False
+
+    def test_no_group_allowlist_ignores_group(self) -> None:
+        channel = _TestChannel(allowed_users={111}, allowed_groups=set())
+        assert channel._check_user_allowed(111, group_id=12345) is True
+
+    def test_only_group_allowlist_dm_denied(self) -> None:
+        channel = _TestChannel(allowed_users=set(), allowed_groups={500})
+        assert channel._check_user_allowed(999, group_id=None) is False
+
+    def test_only_group_allowlist_no_user_allowlist(self) -> None:
+        channel = _TestChannel(allowed_users=set(), allowed_groups={500})
+        assert channel._check_user_allowed(999, group_id=500) is True
+
+
+class TestSecurityMixinActivation:
+    """Test SecurityMixin activation filtering."""
+
+    def test_no_filters_passes_all(self) -> None:
+        channel = _TestChannel(mention_required=False, triggers=[])
+        assert channel._check_activation("hello", is_dm=False, is_command=False, is_mentioned=False) is True
+
+    def test_dm_always_passes(self) -> None:
+        channel = _TestChannel(triggers=["!ask"])
+        assert channel._check_activation("hello", is_dm=True, is_command=False, is_mentioned=False) is True
+
+    def test_command_always_passes(self) -> None:
+        channel = _TestChannel(triggers=["!ask"])
+        assert channel._check_activation("hello", is_dm=False, is_command=True, is_mentioned=False) is True
+
+    def test_trigger_match(self) -> None:
+        channel = _TestChannel(triggers=["!ask"])
+        assert channel._check_activation("!ask for help", is_dm=False, is_command=False, is_mentioned=False) is True
+
+    def test_trigger_no_match(self) -> None:
+        channel = _TestChannel(triggers=["!ask"])
+        assert channel._check_activation("hello there", is_dm=False, is_command=False, is_mentioned=False) is False
+
+    def test_mention_required_with_mention(self) -> None:
+        channel = _TestChannel(mention_required=True)
+        assert channel._check_activation("hey", is_dm=False, is_command=False, is_mentioned=True) is True
+
+    def test_mention_required_without_mention(self) -> None:
+        channel = _TestChannel(mention_required=True)
+        assert channel._check_activation("hey", is_dm=False, is_command=False, is_mentioned=False) is False
+
+    def test_mention_or_trigger_trigger_wins(self) -> None:
+        channel = _TestChannel(mention_required=True, triggers=["!ask"])
+        assert channel._check_activation("!ask", is_dm=False, is_command=False, is_mentioned=False) is True
+
+    def test_mention_or_trigger_mention_wins(self) -> None:
+        channel = _TestChannel(mention_required=True, triggers=["!ask"])
+        assert channel._check_activation("hey", is_dm=False, is_command=False, is_mentioned=True) is True
+
+    def test_mention_or_trigger_neither(self) -> None:
+        channel = _TestChannel(mention_required=True, triggers=["!ask"])
+        assert channel._check_activation("hey", is_dm=False, is_command=False, is_mentioned=False) is False
+
+    def test_case_insensitive_trigger(self) -> None:
+        channel = _TestChannel(triggers=["!Ask"])
+        assert channel._check_activation("!ask", is_dm=False, is_command=False, is_mentioned=False) is True
+
+
+class TestSecurityMixinUnauthorizedText:
+    """Test SecurityMixin unauthorized text building."""
+
+    def test_builds_text_with_workspace(self) -> None:
+        channel = _TestChannel(workspace_name="my_agent")
+        text = channel._build_unauthorized_text(12345)
+        assert "my_agent" in text
+        assert "12345" in text
+
+    def test_includes_group_id(self) -> None:
+        channel = _TestChannel(workspace_name="test")
+        text = channel._build_unauthorized_text(12345, group_id=999)
+        assert "999" in text
+
+
+# ---------------------------------------------------------------------------
+# Integration: Discord and Telegram use SecurityMixin
+# ---------------------------------------------------------------------------
+
+
+class TestMixinIntegration:
+    """Verify that Discord and Telegram actually inherit from SecurityMixin."""
+
+    def test_discord_inherits_security_mixin(self) -> None:
+        from openpaw.channels.discord import DiscordChannel
+        assert issubclass(DiscordChannel, SecurityMixin)
+
+    def test_telegram_inherits_security_mixin(self) -> None:
+        from openpaw.channels.telegram import TelegramChannel
+        assert issubclass(TelegramChannel, SecurityMixin)
+
+    def test_discord_delegates_to_mixin(self) -> None:
+        from openpaw.channels.discord import DiscordChannel
+
+        channel = DiscordChannel(token="test", allowed_users=[111])
+        msg = MagicMock()
+        msg.author.id = 111
+        msg.guild = None
+        assert channel._is_allowed(msg) is True
+
+    def test_telegram_delegates_to_mixin(self) -> None:
+        from openpaw.channels.telegram import TelegramChannel
+
+        channel = TelegramChannel(token="test", allowed_users=[111])
+        update = MagicMock()
+        update.effective_user = MagicMock()
+        update.effective_user.id = 111
+        update.effective_chat = None
+        assert channel._is_allowed(update) is True


### PR DESCRIPTION
Extract duplicated logic from Discord (846 → 759 lines) and Telegram (804 → 735 lines) into shared helpers.

## Changes

### New Package: `openpaw/channels/helpers/`
- `splitting.py` — `split_message()` (pure function, platform-agnostic message splitting)
- `formatting.py` — `format_approval_message()`, `format_unauthorized_response()`, `check_file_size()`
- `attachments.py` — `map_mime_type_to_attachment_type()`
- `security.py` — `SecurityMixin` with `_check_user_allowed()`, `_check_activation()`, `_build_unauthorized_text()`

### Updated Adapters
- `DiscordChannel` now inherits `SecurityMixin`; delegates allowlist/activation/filtering to mixin
- `TelegramChannel` now inherits `SecurityMixin`; same delegation pattern
- Both adapters use helper functions for formatting, splitting, file size guards, and attachment type mapping

### Tests
- Added `tests/channels/test_helpers.py` with 57 tests covering all extracted helpers and SecurityMixin

## Metrics
| Metric | Before | After |
|--------|--------|-------|
| Discord lines | 846 | 759 |
| Telegram lines | 804 | 735 |
| Tests | 2,777 | 2,834 |
| Files >700 lines | 6 | 5 |

## Verification
- All 2,834 tests pass
- Ruff clean
- No behavioral changes — pure code movement and delegation
