### PR TITLE
MR B3: Browser session decomposition

### DIFF
--- a/openpaw/builtins/tools/browser/__init__.py
+++ b/openpaw/builtins/tools/browser/__init__.py
@@ -77,7 +77,7 @@ class BrowserToolBuiltin(BaseBuiltinTool):
 
         logger.info("BrowserToolBuiltin initialized")
 
-    def get_langchain_tool(self) -> list:
+    def get_langchain_tool(self) -> list[Any]:
         """Return list of browser tools as LangChain StructuredTools."""
         return [
             create_navigate_tool(self),

--- a/openpaw/builtins/tools/browser/interaction.py
+++ b/openpaw/builtins/tools/browser/interaction.py
@@ -1,0 +1,264 @@
+"""Browser interaction: click, type, select, execute JS, and screenshot."""
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class BrowserInteraction:
+    """Handles element interaction and JavaScript execution.
+
+    Includes clicking, typing, selecting dropdown options, executing
+    JavaScript, and taking screenshots.
+    """
+
+    def __init__(self, session: Any) -> None:
+        """Initialize with parent BrowserSession.
+
+        Args:
+            session: The BrowserSession instance that owns this interaction.
+        """
+        self._session: Any = session
+
+    @property
+    def _timeout_seconds(self) -> int:
+        return int(self._session.timeout_seconds)
+
+    @property
+    def _screenshots_dir(self) -> Path:
+        return Path(self._session.screenshots_dir)
+
+    @property
+    def _workspace_path(self) -> Path:
+        return Path(self._session.workspace_path)
+
+    async def click(self, ref: int, keep_refs: bool = False) -> str:
+        """Click element by reference number.
+
+        Args:
+            ref: Element reference from snapshot.
+            keep_refs: When True, auto-refresh the snapshot after clicking
+                and return updated element refs. Useful for multi-selection
+                in custom dropdowns where the DOM re-renders after each click.
+
+        Returns:
+            Confirmation message or error. When keep_refs=True, includes
+            a refreshed snapshot so you can immediately click the next element.
+        """
+        if not self._session.is_active:
+            return "Browser not active. Use browser_navigate first."
+
+        if ref not in self._session._ref_map:
+            return (
+                f"Invalid element reference: {ref}\n"
+                "The page may have changed. Use browser_snapshot to get current refs."
+            )
+
+        try:
+            node = self._session._ref_map[ref]
+            role = node.get("role", "")
+            name = node.get("name", "")
+
+            logger.info(f"Clicking element {ref}: {name} ({role}) keep_refs={keep_refs}")
+
+            # Try to locate element by role and name
+            try:
+                locator = self._session._page.get_by_role(role, name=name)
+                await locator.click(timeout=self._timeout_seconds * 1000)
+            except Exception:
+                # Fallback: try by text if it's a link or button
+                if role in ("link", "button") and name:
+                    locator = self._session._page.get_by_text(name, exact=False)
+                    await locator.first.click(timeout=self._timeout_seconds * 1000)
+                else:
+                    raise
+
+            if keep_refs:
+                # Wait for DOM to settle, then refresh snapshot
+                try:
+                    await self._session._page.wait_for_load_state("domcontentloaded", timeout=5000)
+                except Exception:
+                    pass  # Best-effort wait; DOM may already be stable
+
+                refreshed = await self._session._state.snapshot()
+                return (
+                    f"Clicked: {name} ({role})\n\n"
+                    f"--- Refreshed snapshot ---\n{refreshed}"
+                )
+
+            # Invalidate refs (page may have changed)
+            self._session._ref_map = {}
+
+            return (
+                f"Clicked: {name} ({role})\n"
+                "Page may have changed. Use browser_snapshot to see current state."
+            )
+
+        except Exception as e:
+            logger.error(f"Click failed: {e}")
+            return f"Click failed: {str(e)}\nThe element may not be clickable or visible."
+
+    async def type_text(self, ref: int, text: str, press_enter: bool = False) -> str:
+        """Type text into input element.
+
+        Args:
+            ref: Element reference from snapshot.
+            text: Text to type.
+            press_enter: Whether to press Enter after typing.
+
+        Returns:
+            Confirmation message or error.
+        """
+        if not self._session.is_active:
+            return "Browser not active. Use browser_navigate first."
+
+        if ref not in self._session._ref_map:
+            return (
+                f"Invalid element reference: {ref}\n"
+                "The page may have changed. Use browser_snapshot to get current refs."
+            )
+
+        try:
+            node = self._session._ref_map[ref]
+            role = node.get("role", "")
+            name = node.get("name", "")
+
+            logger.info(f"Typing into element {ref}: {name} ({role})")
+
+            # Locate input element
+            locator = self._session._page.get_by_role(role, name=name)
+
+            # Clear and type
+            await locator.clear(timeout=self._timeout_seconds * 1000)
+            await locator.fill(text, timeout=self._timeout_seconds * 1000)
+
+            # Press Enter if requested
+            if press_enter:
+                await locator.press("Enter")
+                # Invalidate refs (page may have changed)
+                self._session._ref_map = {}
+                return (
+                    f"Typed '{text}' and pressed Enter in: {name}\n"
+                    "Page may have changed. Use browser_snapshot to see current state."
+                )
+
+            return f"Typed '{text}' into: {name}"
+
+        except Exception as e:
+            logger.error(f"Type failed: {e}")
+            return f"Type failed: {str(e)}\nThe element may not be an input or may not be visible."
+
+    async def select_option(self, ref: int, value: str) -> str:
+        """Select dropdown option.
+
+        Args:
+            ref: Element reference from snapshot.
+            value: Option value or text to select.
+
+        Returns:
+            Confirmation message or error.
+        """
+        if not self._session.is_active:
+            return "Browser not active. Use browser_navigate first."
+
+        if ref not in self._session._ref_map:
+            return (
+                f"Invalid element reference: {ref}\n"
+                "The page may have changed. Use browser_snapshot to get current refs."
+            )
+
+        try:
+            node = self._session._ref_map[ref]
+            role = node.get("role", "")
+            name = node.get("name", "")
+
+            logger.info(f"Selecting option in element {ref}: {name} ({role})")
+
+            # Locate select element
+            locator = self._session._page.get_by_role(role, name=name)
+
+            # Try to select by value, then by label
+            try:
+                await locator.select_option(value=value, timeout=self._timeout_seconds * 1000)
+            except Exception:
+                await locator.select_option(label=value, timeout=self._timeout_seconds * 1000)
+
+            return f"Selected '{value}' in: {name}"
+
+        except Exception as e:
+            logger.error(f"Select failed: {e}")
+            return f"Select failed: {str(e)}\nThe element may not be a dropdown or the option may not exist."
+
+    async def execute_js(self, script: str, arg: Any = None) -> str:
+        """Execute JavaScript in the browser page context.
+
+        Use this for direct DOM manipulation when accessibility tree interaction
+        is unreliable (custom React/Vue components, dynamic dropdowns, etc.).
+
+        Args:
+            script: JavaScript expression or arrow function body to evaluate.
+                If the script references ``arg``, the value is passed as the
+                second parameter to ``page.evaluate()`` and available as the
+                function argument.
+            arg: Optional JSON-serializable value passed into the script.
+
+        Returns:
+            JSON-serialized result string, or error message.
+        """
+        if not self._session.is_active:
+            return "Browser not active. Use browser_navigate first."
+
+        try:
+            logger.info(f"Executing JS (length={len(script)})")
+
+            if arg is not None:
+                result = await self._session._page.evaluate(script, arg)
+            else:
+                result = await self._session._page.evaluate(script)
+
+            if result is None:
+                return "Script executed (returned null/undefined)"
+
+            if isinstance(result, str):
+                return result
+
+            return json.dumps(result, default=str, ensure_ascii=False)
+
+        except Exception as e:
+            logger.error(f"JS execution failed: {e}")
+            return f"JS execution failed: {str(e)}"
+
+    async def screenshot(self, full_page: bool = False) -> str:
+        """Take screenshot and save to workspace.
+
+        Args:
+            full_page: Capture full scrollable page (default: viewport only).
+
+        Returns:
+            Relative path to screenshot file or error.
+        """
+        if not self._session.is_active:
+            return "Browser not active. Use browser_navigate first."
+
+        try:
+            # Generate filename with timestamp
+            timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+            filename = f"screenshot_{timestamp}.png"
+            file_path = self._screenshots_dir / filename
+
+            # Take screenshot
+            await self._session._page.screenshot(path=str(file_path), full_page=full_page)
+
+            # Return relative path from workspace root
+            rel_path = file_path.relative_to(self._workspace_path)
+
+            logger.info(f"Screenshot saved: {rel_path}")
+            return f"Screenshot saved: {rel_path}"
+
+        except Exception as e:
+            logger.error(f"Screenshot failed: {e}")
+            return f"Screenshot failed: {str(e)}"

--- a/openpaw/builtins/tools/browser/interaction.py
+++ b/openpaw/builtins/tools/browser/interaction.py
@@ -36,6 +36,12 @@ class BrowserInteraction:
     def _workspace_path(self) -> Path:
         return Path(self._session.workspace_path)
 
+    def _check_active(self) -> str | None:
+        """Return error message if browser is not active, else None."""
+        if not self._session.is_active:
+            return "Browser not active. Use browser_navigate first."
+        return None
+
     async def click(self, ref: int, keep_refs: bool = False) -> str:
         """Click element by reference number.
 
@@ -49,8 +55,8 @@ class BrowserInteraction:
             Confirmation message or error. When keep_refs=True, includes
             a refreshed snapshot so you can immediately click the next element.
         """
-        if not self._session.is_active:
-            return "Browser not active. Use browser_navigate first."
+        if error := self._check_active():
+            return error
 
         if ref not in self._session._ref_map:
             return (
@@ -113,8 +119,8 @@ class BrowserInteraction:
         Returns:
             Confirmation message or error.
         """
-        if not self._session.is_active:
-            return "Browser not active. Use browser_navigate first."
+        if error := self._check_active():
+            return error
 
         if ref not in self._session._ref_map:
             return (
@@ -162,8 +168,8 @@ class BrowserInteraction:
         Returns:
             Confirmation message or error.
         """
-        if not self._session.is_active:
-            return "Browser not active. Use browser_navigate first."
+        if error := self._check_active():
+            return error
 
         if ref not in self._session._ref_map:
             return (
@@ -209,8 +215,8 @@ class BrowserInteraction:
         Returns:
             JSON-serialized result string, or error message.
         """
-        if not self._session.is_active:
-            return "Browser not active. Use browser_navigate first."
+        if error := self._check_active():
+            return error
 
         try:
             logger.info(f"Executing JS (length={len(script)})")
@@ -241,8 +247,8 @@ class BrowserInteraction:
         Returns:
             Relative path to screenshot file or error.
         """
-        if not self._session.is_active:
-            return "Browser not active. Use browser_navigate first."
+        if error := self._check_active():
+            return error
 
         try:
             # Generate filename with timestamp

--- a/openpaw/builtins/tools/browser/lifecycle.py
+++ b/openpaw/builtins/tools/browser/lifecycle.py
@@ -1,0 +1,174 @@
+"""Browser lifecycle management: launch, close, and cookie persistence."""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class BrowserLifecycle:
+    """Manages Playwright browser launch, teardown, and cookie persistence.
+
+    This class is responsible for creating and destroying the browser
+    instance, context, and page. It also handles loading and saving
+    cookies when persistence is enabled.
+    """
+
+    def __init__(self, session: Any) -> None:
+        """Initialize with parent BrowserSession.
+
+        Args:
+            session: The BrowserSession instance that owns this lifecycle.
+        """
+        self._session: Any = session
+
+    @property
+    def _headless(self) -> bool:
+        return bool(self._session.headless)
+
+    @property
+    def _viewport_width(self) -> int:
+        return int(self._session.viewport_width)
+
+    @property
+    def _viewport_height(self) -> int:
+        return int(self._session.viewport_height)
+
+    @property
+    def _timeout_seconds(self) -> int:
+        return int(self._session.timeout_seconds)
+
+    @property
+    def _persist_cookies(self) -> bool:
+        return bool(self._session.persist_cookies)
+
+    @property
+    def _cookie_file(self) -> Path:
+        return Path(self._session.cookie_file)
+
+    async def launch(self) -> None:
+        """Launch Playwright browser and create context/page.
+
+        Called automatically on first navigate. Creates browser instance,
+        context with download handling, and initial page.
+        """
+        if self._session.is_active:
+            logger.debug("Browser already active, skipping launch")
+            return
+
+        try:
+            from playwright.async_api import async_playwright
+
+            logger.info("Launching Playwright browser...")
+
+            # Launch playwright
+            self._session._playwright = await async_playwright().start()
+
+            # Launch browser
+            self._session._browser = await self._session._playwright.chromium.launch(
+                headless=self._headless
+            )
+
+            # Create context with downloads enabled
+            context_kwargs = {
+                "viewport": {
+                    "width": self._viewport_width,
+                    "height": self._viewport_height,
+                },
+                "accept_downloads": True,
+            }
+
+            # Load cookies if persist is enabled
+            if self._persist_cookies and self._cookie_file.exists():
+                try:
+                    logger.info("Loading cookies from storage")
+                    with open(self._cookie_file) as f:
+                        storage_state = json.load(f)
+                        context_kwargs["storage_state"] = storage_state
+                except Exception as e:
+                    logger.warning(f"Failed to load cookies: {e}")
+
+            self._session._context = await self._session._browser.new_context(**context_kwargs)
+
+            # Create initial page
+            self._session._page = await self._session._context.new_page()
+            self._session._page.set_default_timeout(self._timeout_seconds * 1000)  # ms
+
+            # Register frame navigation handler for redirect detection
+            self._session._page.on("framenavigated", self._session._handle_frame_navigated)
+
+            logger.info("Browser launched successfully")
+
+        except ImportError:
+            logger.error(
+                "Playwright not installed. Run: pip install playwright && playwright install chromium"
+            )
+            raise
+        except Exception as e:
+            logger.error(f"Failed to launch browser: {e}")
+            raise
+
+    async def close(self) -> None:
+        """Close browser and cleanup resources.
+
+        Saves cookies if persistence is enabled, then closes page/context/browser.
+        """
+        if not self._session.is_active:
+            logger.debug("Browser not active, nothing to close")
+            return
+
+        try:
+            # Save cookies if persistence is enabled
+            if self._persist_cookies and self._session._context:
+                await self._save_cookies()
+
+            # Close resources
+            if self._session._page:
+                await self._session._page.close()
+                self._session._page = None
+
+            if self._session._context:
+                await self._session._context.close()
+                self._session._context = None
+
+            if self._session._browser:
+                await self._session._browser.close()
+                self._session._browser = None
+
+            if self._session._playwright:
+                await self._session._playwright.stop()
+                self._session._playwright = None
+
+            logger.info("Browser closed")
+
+        except Exception as e:
+            logger.error(f"Error closing browser: {e}")
+
+    async def _save_cookies(self) -> None:
+        """Save browser cookies to workspace storage."""
+        if not self._session._context:
+            return
+
+        try:
+            # Ensure the data/ directory exists
+            self._cookie_file.parent.mkdir(parents=True, exist_ok=True)
+
+            # Save storage state
+            storage_state = await self._session._context.storage_state()
+            with open(self._cookie_file, "w") as f:
+                json.dump(storage_state, f, indent=2)
+
+            logger.info(f"Cookies saved to {self._cookie_file}")
+
+        except Exception as e:
+            logger.warning(f"Failed to save cookies: {e}")
+
+    async def _load_cookies(self) -> None:
+        """Load browser cookies from workspace storage.
+
+        Note: This is called during context creation via storage_state kwarg,
+        not as a separate method. This is here for documentation.
+        """
+        pass

--- a/openpaw/builtins/tools/browser/lifecycle.py
+++ b/openpaw/builtins/tools/browser/lifecycle.py
@@ -158,7 +158,7 @@ class BrowserLifecycle:
             # Save storage state
             storage_state = await self._session._context.storage_state()
             with open(self._cookie_file, "w") as f:
-                json.dump(storage_state, f, indent=2)
+                json.dump(storage_state, f, indent=2, default=str)
 
             logger.info(f"Cookies saved to {self._cookie_file}")
 

--- a/openpaw/builtins/tools/browser/navigation.py
+++ b/openpaw/builtins/tools/browser/navigation.py
@@ -25,6 +25,12 @@ class BrowserNavigation:
     def _timeout_seconds(self) -> int:
         return int(self._session.timeout_seconds)
 
+    def _check_active(self) -> str | None:
+        """Return error message if browser is not active, else None."""
+        if not self._session.is_active:
+            return "Browser not active. Use browser_navigate first."
+        return None
+
     async def navigate(self, url: str) -> str:
         """Navigate to URL with domain validation.
 
@@ -78,8 +84,8 @@ class BrowserNavigation:
         Returns:
             Status message or error.
         """
-        if not self._session.is_active:
-            return "Browser not active. Use browser_navigate first."
+        if error := self._check_active():
+            return error
 
         try:
             await self._session._page.go_back(wait_until="domcontentloaded")
@@ -101,8 +107,8 @@ class BrowserNavigation:
         Returns:
             Confirmation message or error.
         """
-        if not self._session.is_active:
-            return "Browser not active. Use browser_navigate first."
+        if error := self._check_active():
+            return error
 
         try:
             # Calculate scroll distance
@@ -134,8 +140,8 @@ class BrowserNavigation:
         Returns:
             Confirmation message or error.
         """
-        if not self._session.is_active:
-            return "Browser not active. Use browser_navigate first."
+        if error := self._check_active():
+            return error
 
         try:
             pages = self._session._context.pages

--- a/openpaw/builtins/tools/browser/navigation.py
+++ b/openpaw/builtins/tools/browser/navigation.py
@@ -1,0 +1,164 @@
+"""Browser navigation: URL navigation, back, scroll, and tab switching."""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class BrowserNavigation:
+    """Handles browser navigation operations.
+
+    Includes URL navigation with domain validation, history navigation,
+    page scrolling, and tab switching.
+    """
+
+    def __init__(self, session: Any) -> None:
+        """Initialize with parent BrowserSession.
+
+        Args:
+            session: The BrowserSession instance that owns this navigation.
+        """
+        self._session: Any = session
+
+    @property
+    def _timeout_seconds(self) -> int:
+        return int(self._session.timeout_seconds)
+
+    async def navigate(self, url: str) -> str:
+        """Navigate to URL with domain validation.
+
+        Args:
+            url: URL to navigate to.
+
+        Returns:
+            Status message with page title or error.
+        """
+        # Validate domain policy
+        if not self._session.domain_policy.is_allowed(url):
+            logger.warning(f"Navigation blocked by domain policy: {url}")
+            return f"Navigation blocked: {url} is not in the allowed domains list"
+
+        # Launch browser if needed (lazy init)
+        if not self._session.is_active:
+            await self._session._lifecycle.launch()
+
+        try:
+            logger.info(f"Navigating to: {url}")
+            response = await self._session._page.goto(url, wait_until="domcontentloaded")
+
+            # Check if redirect went to disallowed domain
+            final_url = self._session._page.url
+            if final_url != url and not self._session.domain_policy.is_allowed(final_url):
+                logger.warning(f"Redirect blocked: {url} -> {final_url}")
+                return (
+                    f"Navigation blocked: redirected to disallowed domain {final_url}"
+                )
+
+            # Invalidate refs (page content changed)
+            self._session._ref_map = {}
+
+            # Get page title
+            title = await self._session._page.title()
+            status = response.status if response else "unknown"
+
+            logger.info(f"Navigated successfully: {title} (status: {status})")
+            return (
+                f"Navigated to: {title}\nURL: {final_url}\nStatus: {status}\n\n"
+                "Use browser_snapshot to see page content."
+            )
+
+        except Exception as e:
+            logger.error(f"Navigation failed: {e}")
+            return f"Navigation failed: {str(e)}"
+
+    async def back(self) -> str:
+        """Navigate back in history.
+
+        Returns:
+            Status message or error.
+        """
+        if not self._session.is_active:
+            return "Browser not active. Use browser_navigate first."
+
+        try:
+            await self._session._page.go_back(wait_until="domcontentloaded")
+            self._session._ref_map = {}  # Invalidate refs
+            title = await self._session._page.title()
+            logger.info(f"Navigated back: {title}")
+            return f"Navigated back to: {title}\n\nUse browser_snapshot to see page content."
+        except Exception as e:
+            logger.error(f"Back navigation failed: {e}")
+            return f"Back navigation failed: {str(e)}"
+
+    async def scroll(self, direction: str, amount: str = "page") -> str:
+        """Scroll the page.
+
+        Args:
+            direction: "up" or "down".
+            amount: "page" (full viewport) or "half" (half viewport).
+
+        Returns:
+            Confirmation message or error.
+        """
+        if not self._session.is_active:
+            return "Browser not active. Use browser_navigate first."
+
+        try:
+            # Calculate scroll distance
+            if amount == "half":
+                distance = self._session.viewport_height // 2
+            else:
+                distance = self._session.viewport_height
+
+            # Determine scroll direction
+            if direction.lower() == "up":
+                distance = -distance
+
+            # Execute scroll
+            await self._session._page.evaluate(f"window.scrollBy(0, {distance})")
+
+            logger.info(f"Scrolled {direction} by {abs(distance)}px")
+            return f"Scrolled {direction} ({amount})"
+
+        except Exception as e:
+            logger.error(f"Scroll failed: {e}")
+            return f"Scroll failed: {str(e)}"
+
+    async def switch_tab(self, index: int) -> str:
+        """Switch to tab by index.
+
+        Args:
+            index: Tab index from get_tabs.
+
+        Returns:
+            Confirmation message or error.
+        """
+        if not self._session.is_active:
+            return "Browser not active. Use browser_navigate first."
+
+        try:
+            pages = self._session._context.pages
+
+            if index < 0 or index >= len(pages):
+                return f"Invalid tab index: {index}. Use browser_tabs to see available tabs."
+
+            # Switch to page
+            self._session._page = pages[index]
+            self._session._page.set_default_timeout(self._timeout_seconds * 1000)
+
+            # Re-register navigation handler
+            self._session._page.on("framenavigated", self._session._handle_frame_navigated)
+
+            # Invalidate refs (different page)
+            self._session._ref_map = {}
+
+            title = await self._session._page.title()
+            url = self._session._page.url
+
+            logger.info(f"Switched to tab {index}: {title}")
+            return f"Switched to tab {index}: {title}\nURL: {url}\n\nUse browser_snapshot to see page content."
+
+        except Exception as e:
+            logger.error(f"Switch tab failed: {e}")
+            return f"Switch tab failed: {str(e)}"

--- a/openpaw/builtins/tools/browser/session.py
+++ b/openpaw/builtins/tools/browser/session.py
@@ -1,13 +1,15 @@
 """Browser session management for Playwright lifecycle."""
 
-import json
 import logging
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from openpaw.builtins.tools.browser.interaction import BrowserInteraction
+from openpaw.builtins.tools.browser.lifecycle import BrowserLifecycle
+from openpaw.builtins.tools.browser.navigation import BrowserNavigation
 from openpaw.builtins.tools.browser.security import DomainPolicy
 from openpaw.builtins.tools.browser.snapshot import SnapshotTransformer
+from openpaw.builtins.tools.browser.state import BrowserState
 from openpaw.core.paths import BROWSER_COOKIES_JSON
 
 logger = logging.getLogger(__name__)
@@ -86,6 +88,12 @@ class BrowserSession:
         # Element ref map from last snapshot (invalidated on navigation)
         self._ref_map: dict[int, dict[str, Any]] = {}
 
+        # Sub-components (initialized lazily on first use, or inline here)
+        self._lifecycle = BrowserLifecycle(self)
+        self._navigation = BrowserNavigation(self)
+        self._interaction = BrowserInteraction(self)
+        self._state = BrowserState(self)
+
         logger.info(
             f"BrowserSession initialized (headless={self.headless}, "
             f"timeout={self.timeout_seconds}s)"
@@ -102,97 +110,14 @@ class BrowserSession:
         Called automatically on first navigate. Creates browser instance,
         context with download handling, and initial page.
         """
-        if self.is_active:
-            logger.debug("Browser already active, skipping launch")
-            return
-
-        try:
-            from playwright.async_api import async_playwright
-
-            logger.info("Launching Playwright browser...")
-
-            # Launch playwright
-            self._playwright = await async_playwright().start()
-
-            # Launch browser
-            self._browser = await self._playwright.chromium.launch(
-                headless=self.headless
-            )
-
-            # Create context with downloads enabled
-            context_kwargs = {
-                "viewport": {
-                    "width": self.viewport_width,
-                    "height": self.viewport_height,
-                },
-                "accept_downloads": True,
-            }
-
-            # Load cookies if persist is enabled
-            if self.persist_cookies and self.cookie_file.exists():
-                try:
-                    logger.info("Loading cookies from storage")
-                    with open(self.cookie_file) as f:
-                        storage_state = json.load(f)
-                        context_kwargs["storage_state"] = storage_state
-                except Exception as e:
-                    logger.warning(f"Failed to load cookies: {e}")
-
-            self._context = await self._browser.new_context(**context_kwargs)
-
-            # Create initial page
-            self._page = await self._context.new_page()
-            self._page.set_default_timeout(self.timeout_seconds * 1000)  # ms
-
-            # Register frame navigation handler for redirect detection
-            self._page.on("framenavigated", self._handle_frame_navigated)
-
-            logger.info("Browser launched successfully")
-
-        except ImportError:
-            logger.error(
-                "Playwright not installed. Run: pip install playwright && playwright install chromium"
-            )
-            raise
-        except Exception as e:
-            logger.error(f"Failed to launch browser: {e}")
-            raise
+        await self._lifecycle.launch()
 
     async def close(self) -> None:
         """Close browser and cleanup resources.
 
         Saves cookies if persistence is enabled, then closes page/context/browser.
         """
-        if not self.is_active:
-            logger.debug("Browser not active, nothing to close")
-            return
-
-        try:
-            # Save cookies if persistence is enabled
-            if self.persist_cookies and self._context:
-                await self._save_cookies()
-
-            # Close resources
-            if self._page:
-                await self._page.close()
-                self._page = None
-
-            if self._context:
-                await self._context.close()
-                self._context = None
-
-            if self._browser:
-                await self._browser.close()
-                self._browser = None
-
-            if self._playwright:
-                await self._playwright.stop()
-                self._playwright = None
-
-            logger.info("Browser closed")
-
-        except Exception as e:
-            logger.error(f"Error closing browser: {e}")
+        await self._lifecycle.close()
 
     async def navigate(self, url: str) -> str:
         """Navigate to URL with domain validation.
@@ -203,43 +128,7 @@ class BrowserSession:
         Returns:
             Status message with page title or error.
         """
-        # Validate domain policy
-        if not self.domain_policy.is_allowed(url):
-            logger.warning(f"Navigation blocked by domain policy: {url}")
-            return f"Navigation blocked: {url} is not in the allowed domains list"
-
-        # Launch browser if needed (lazy init)
-        if not self.is_active:
-            await self.launch()
-
-        try:
-            logger.info(f"Navigating to: {url}")
-            response = await self._page.goto(url, wait_until="domcontentloaded")
-
-            # Check if redirect went to disallowed domain
-            final_url = self._page.url
-            if final_url != url and not self.domain_policy.is_allowed(final_url):
-                logger.warning(f"Redirect blocked: {url} -> {final_url}")
-                return (
-                    f"Navigation blocked: redirected to disallowed domain {final_url}"
-                )
-
-            # Invalidate refs (page content changed)
-            self._ref_map = {}
-
-            # Get page title
-            title = await self._page.title()
-            status = response.status if response else "unknown"
-
-            logger.info(f"Navigated successfully: {title} (status: {status})")
-            return (
-                f"Navigated to: {title}\nURL: {final_url}\nStatus: {status}\n\n"
-                "Use browser_snapshot to see page content."
-            )
-
-        except Exception as e:
-            logger.error(f"Navigation failed: {e}")
-            return f"Navigation failed: {str(e)}"
+        return await self._navigation.navigate(url)
 
     async def back(self) -> str:
         """Navigate back in history.
@@ -247,166 +136,7 @@ class BrowserSession:
         Returns:
             Status message or error.
         """
-        if not self.is_active:
-            return "Browser not active. Use browser_navigate first."
-
-        try:
-            await self._page.go_back(wait_until="domcontentloaded")
-            self._ref_map = {}  # Invalidate refs
-            title = await self._page.title()
-            logger.info(f"Navigated back: {title}")
-            return f"Navigated back to: {title}\n\nUse browser_snapshot to see page content."
-        except Exception as e:
-            logger.error(f"Back navigation failed: {e}")
-            return f"Back navigation failed: {str(e)}"
-
-    async def _get_accessibility_tree(self) -> dict | None:
-        """Get accessibility tree via CDP (Chrome DevTools Protocol).
-
-        Playwright 1.58+ removed page.accessibility.snapshot(), so we use
-        CDP's Accessibility.getFullAXTree instead and reconstruct the tree.
-
-        Returns:
-            Dict tree compatible with SnapshotTransformer, or None on error.
-        """
-        try:
-            # Create CDP session
-            client = await self._page.context.new_cdp_session(self._page)
-
-            try:
-                # Get full accessibility tree from CDP
-                response = await client.send("Accessibility.getFullAXTree")
-                nodes = response.get("nodes", [])
-
-                if not nodes:
-                    logger.debug("CDP returned empty accessibility tree")
-                    return None
-
-                # Build node lookup by ID
-                node_map = {node["nodeId"]: node for node in nodes}
-
-                # Helper to extract role string from CDP role object
-                def get_role(node: dict) -> str:
-                    role_obj = node.get("role", {})
-                    value = role_obj.get("value", "")
-
-                    # Normalize role names (CDP uses internal names like "RootWebArea")
-                    role_map = {
-                        "RootWebArea": "WebArea",
-                        "WebArea": "WebArea",
-                        "GenericContainer": "group",
-                        "StaticText": None,  # Skip - leaf noise
-                        "InlineTextBox": None,  # Skip - leaf noise
-                    }
-
-                    # Use mapping if available, otherwise keep lowercase
-                    if value in role_map:
-                        return role_map[value]
-                    return value.lower() if value else ""
-
-                # Helper to extract name from CDP name object
-                def get_name(node: dict) -> str:
-                    name_obj = node.get("name", {})
-                    return name_obj.get("value", "") if isinstance(name_obj, dict) else ""
-
-                # Helper to extract properties dict
-                def get_properties(node: dict) -> dict:
-                    props = {}
-                    for prop in node.get("properties", []):
-                        prop_name = prop.get("name", "")
-                        prop_value = prop.get("value", {})
-
-                        # Extract actual value based on type
-                        if isinstance(prop_value, dict):
-                            if "value" in prop_value:
-                                props[prop_name] = prop_value["value"]
-                        else:
-                            props[prop_name] = prop_value
-
-                    return props
-
-                # Recursive function to build tree
-                def build_tree(node_id: str) -> dict | None:
-                    if node_id not in node_map:
-                        return None
-
-                    cdp_node = node_map[node_id]
-
-                    # Skip ignored nodes (but include their children)
-                    if cdp_node.get("ignored", False):
-                        # Flatten through ignored nodes
-                        children = []
-                        for child_id in cdp_node.get("childIds", []):
-                            child = build_tree(child_id)
-                            if child:
-                                children.append(child)
-                        # Return children directly (unwrapped)
-                        if len(children) == 1:
-                            return children[0]
-                        elif children:
-                            return {"children": children}
-                        return None
-
-                    # Get role and skip internal leaf nodes
-                    role = get_role(cdp_node)
-                    if role is None:  # Explicitly filtered out (StaticText, etc.)
-                        return None
-
-                    # Build node dict
-                    tree_node = {}
-
-                    if role:
-                        tree_node["role"] = role
-
-                    name = get_name(cdp_node)
-                    if name:
-                        tree_node["name"] = name
-
-                    # Extract properties
-                    props = get_properties(cdp_node)
-                    if "level" in props:
-                        tree_node["level"] = props["level"]
-                    if "checked" in props:
-                        tree_node["checked"] = props["checked"]
-                    if "disabled" in props:
-                        tree_node["disabled"] = props["disabled"]
-                    if "value" in props and props["value"]:
-                        tree_node["value"] = props["value"]
-
-                    # Recursively build children
-                    children = []
-                    for child_id in cdp_node.get("childIds", []):
-                        child = build_tree(child_id)
-                        if child:
-                            # Handle flattened children from ignored nodes
-                            if isinstance(child, list):
-                                children.extend(child)
-                            elif isinstance(child, dict) and "children" in child and "role" not in child:
-                                # Unwrap container with only children
-                                children.extend(child["children"])
-                            else:
-                                children.append(child)
-
-                    if children:
-                        tree_node["children"] = children
-
-                    return tree_node
-
-                # Find root node (usually first node)
-                root_id = nodes[0]["nodeId"] if nodes else None
-                if not root_id:
-                    return None
-
-                tree = build_tree(root_id)
-                return tree
-
-            finally:
-                # Clean up CDP session
-                await client.detach()
-
-        except Exception as e:
-            logger.error(f"CDP accessibility tree extraction failed: {e}")
-            return None
+        return await self._navigation.back()
 
     async def snapshot(self) -> str:
         """Take accessibility snapshot with numbered element refs.
@@ -414,33 +144,7 @@ class BrowserSession:
         Returns:
             Formatted snapshot text with [ref] annotations.
         """
-        if not self.is_active:
-            return "Browser not active. Use browser_navigate first."
-
-        try:
-            # Get accessibility snapshot via CDP
-            a11y_tree = await self._get_accessibility_tree()
-
-            if not a11y_tree:
-                return "Page snapshot empty (no accessible content)"
-
-            # Transform to indexed format
-            formatted_text, ref_map = self.snapshot_transformer.transform(a11y_tree)
-
-            # Store ref map for element interaction
-            self._ref_map = ref_map
-
-            # Add header with metadata
-            title = await self._page.title()
-            url = self._page.url
-            header = f"Page: {title}\nURL: {url}\nInteractive elements: {len(ref_map)}\n\n"
-
-            logger.info(f"Snapshot captured: {len(ref_map)} interactive elements")
-            return header + formatted_text
-
-        except Exception as e:
-            logger.error(f"Snapshot failed: {e}")
-            return f"Snapshot failed: {str(e)}"
+        return await self._state.snapshot()
 
     async def click(self, ref: int, keep_refs: bool = False) -> str:
         """Click element by reference number.
@@ -455,58 +159,7 @@ class BrowserSession:
             Confirmation message or error. When keep_refs=True, includes
             a refreshed snapshot so you can immediately click the next element.
         """
-        if not self.is_active:
-            return "Browser not active. Use browser_navigate first."
-
-        if ref not in self._ref_map:
-            return (
-                f"Invalid element reference: {ref}\n"
-                "The page may have changed. Use browser_snapshot to get current refs."
-            )
-
-        try:
-            node = self._ref_map[ref]
-            role = node.get("role", "")
-            name = node.get("name", "")
-
-            logger.info(f"Clicking element {ref}: {name} ({role}) keep_refs={keep_refs}")
-
-            # Try to locate element by role and name
-            try:
-                locator = self._page.get_by_role(role, name=name)
-                await locator.click(timeout=self.timeout_seconds * 1000)
-            except Exception:
-                # Fallback: try by text if it's a link or button
-                if role in ("link", "button") and name:
-                    locator = self._page.get_by_text(name, exact=False)
-                    await locator.first.click(timeout=self.timeout_seconds * 1000)
-                else:
-                    raise
-
-            if keep_refs:
-                # Wait for DOM to settle, then refresh snapshot
-                try:
-                    await self._page.wait_for_load_state("domcontentloaded", timeout=5000)
-                except Exception:
-                    pass  # Best-effort wait; DOM may already be stable
-
-                refreshed = await self.snapshot()
-                return (
-                    f"Clicked: {name} ({role})\n\n"
-                    f"--- Refreshed snapshot ---\n{refreshed}"
-                )
-
-            # Invalidate refs (page may have changed)
-            self._ref_map = {}
-
-            return (
-                f"Clicked: {name} ({role})\n"
-                "Page may have changed. Use browser_snapshot to see current state."
-            )
-
-        except Exception as e:
-            logger.error(f"Click failed: {e}")
-            return f"Click failed: {str(e)}\nThe element may not be clickable or visible."
+        return await self._interaction.click(ref, keep_refs=keep_refs)
 
     async def type_text(self, ref: int, text: str, press_enter: bool = False) -> str:
         """Type text into input element.
@@ -519,44 +172,7 @@ class BrowserSession:
         Returns:
             Confirmation message or error.
         """
-        if not self.is_active:
-            return "Browser not active. Use browser_navigate first."
-
-        if ref not in self._ref_map:
-            return (
-                f"Invalid element reference: {ref}\n"
-                "The page may have changed. Use browser_snapshot to get current refs."
-            )
-
-        try:
-            node = self._ref_map[ref]
-            role = node.get("role", "")
-            name = node.get("name", "")
-
-            logger.info(f"Typing into element {ref}: {name} ({role})")
-
-            # Locate input element
-            locator = self._page.get_by_role(role, name=name)
-
-            # Clear and type
-            await locator.clear(timeout=self.timeout_seconds * 1000)
-            await locator.fill(text, timeout=self.timeout_seconds * 1000)
-
-            # Press Enter if requested
-            if press_enter:
-                await locator.press("Enter")
-                # Invalidate refs (page may have changed)
-                self._ref_map = {}
-                return (
-                    f"Typed '{text}' and pressed Enter in: {name}\n"
-                    "Page may have changed. Use browser_snapshot to see current state."
-                )
-
-            return f"Typed '{text}' into: {name}"
-
-        except Exception as e:
-            logger.error(f"Type failed: {e}")
-            return f"Type failed: {str(e)}\nThe element may not be an input or may not be visible."
+        return await self._interaction.type_text(ref, text, press_enter)
 
     async def select_option(self, ref: int, value: str) -> str:
         """Select dropdown option.
@@ -568,36 +184,7 @@ class BrowserSession:
         Returns:
             Confirmation message or error.
         """
-        if not self.is_active:
-            return "Browser not active. Use browser_navigate first."
-
-        if ref not in self._ref_map:
-            return (
-                f"Invalid element reference: {ref}\n"
-                "The page may have changed. Use browser_snapshot to get current refs."
-            )
-
-        try:
-            node = self._ref_map[ref]
-            role = node.get("role", "")
-            name = node.get("name", "")
-
-            logger.info(f"Selecting option in element {ref}: {name} ({role})")
-
-            # Locate select element
-            locator = self._page.get_by_role(role, name=name)
-
-            # Try to select by value, then by label
-            try:
-                await locator.select_option(value=value, timeout=self.timeout_seconds * 1000)
-            except Exception:
-                await locator.select_option(label=value, timeout=self.timeout_seconds * 1000)
-
-            return f"Selected '{value}' in: {name}"
-
-        except Exception as e:
-            logger.error(f"Select failed: {e}")
-            return f"Select failed: {str(e)}\nThe element may not be a dropdown or the option may not exist."
+        return await self._interaction.select_option(ref, value)
 
     async def execute_js(self, script: str, arg: Any = None) -> str:
         """Execute JavaScript in the browser page context.
@@ -615,28 +202,7 @@ class BrowserSession:
         Returns:
             JSON-serialized result string, or error message.
         """
-        if not self.is_active:
-            return "Browser not active. Use browser_navigate first."
-
-        try:
-            logger.info(f"Executing JS (length={len(script)})")
-
-            if arg is not None:
-                result = await self._page.evaluate(script, arg)
-            else:
-                result = await self._page.evaluate(script)
-
-            if result is None:
-                return "Script executed (returned null/undefined)"
-
-            if isinstance(result, str):
-                return result
-
-            return json.dumps(result, default=str, ensure_ascii=False)
-
-        except Exception as e:
-            logger.error(f"JS execution failed: {e}")
-            return f"JS execution failed: {str(e)}"
+        return await self._interaction.execute_js(script, arg)
 
     async def scroll(self, direction: str, amount: str = "page") -> str:
         """Scroll the page.
@@ -648,29 +214,7 @@ class BrowserSession:
         Returns:
             Confirmation message or error.
         """
-        if not self.is_active:
-            return "Browser not active. Use browser_navigate first."
-
-        try:
-            # Calculate scroll distance
-            if amount == "half":
-                distance = self.viewport_height // 2
-            else:
-                distance = self.viewport_height
-
-            # Determine scroll direction
-            if direction.lower() == "up":
-                distance = -distance
-
-            # Execute scroll
-            await self._page.evaluate(f"window.scrollBy(0, {distance})")
-
-            logger.info(f"Scrolled {direction} by {abs(distance)}px")
-            return f"Scrolled {direction} ({amount})"
-
-        except Exception as e:
-            logger.error(f"Scroll failed: {e}")
-            return f"Scroll failed: {str(e)}"
+        return await self._navigation.scroll(direction, amount)
 
     async def screenshot(self, full_page: bool = False) -> str:
         """Take screenshot and save to workspace.
@@ -681,27 +225,7 @@ class BrowserSession:
         Returns:
             Relative path to screenshot file or error.
         """
-        if not self.is_active:
-            return "Browser not active. Use browser_navigate first."
-
-        try:
-            # Generate filename with timestamp
-            timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
-            filename = f"screenshot_{timestamp}.png"
-            file_path = self.screenshots_dir / filename
-
-            # Take screenshot
-            await self._page.screenshot(path=str(file_path), full_page=full_page)
-
-            # Return relative path from workspace root
-            rel_path = file_path.relative_to(self.workspace_path)
-
-            logger.info(f"Screenshot saved: {rel_path}")
-            return f"Screenshot saved: {rel_path}"
-
-        except Exception as e:
-            logger.error(f"Screenshot failed: {e}")
-            return f"Screenshot failed: {str(e)}"
+        return await self._interaction.screenshot(full_page)
 
     async def get_tabs(self) -> str:
         """List all open tabs.
@@ -709,25 +233,7 @@ class BrowserSession:
         Returns:
             Formatted list of tabs with indices.
         """
-        if not self.is_active:
-            return "Browser not active. Use browser_navigate first."
-
-        try:
-            pages = self._context.pages
-            lines = ["Open tabs:"]
-
-            for i, page in enumerate(pages):
-                title = await page.title()
-                url = page.url
-                active = " (active)" if page == self._page else ""
-                lines.append(f"  [{i}] {title} - {url}{active}")
-
-            logger.info(f"Listed {len(pages)} tabs")
-            return "\n".join(lines)
-
-        except Exception as e:
-            logger.error(f"List tabs failed: {e}")
-            return f"List tabs failed: {str(e)}"
+        return await self._state.get_tabs()
 
     async def switch_tab(self, index: int) -> str:
         """Switch to tab by index.
@@ -738,71 +244,17 @@ class BrowserSession:
         Returns:
             Confirmation message or error.
         """
-        if not self.is_active:
-            return "Browser not active. Use browser_navigate first."
+        return await self._navigation.switch_tab(index)
 
-        try:
-            pages = self._context.pages
-
-            if index < 0 or index >= len(pages):
-                return f"Invalid tab index: {index}. Use browser_tabs to see available tabs."
-
-            # Switch to page
-            self._page = pages[index]
-            self._page.set_default_timeout(self.timeout_seconds * 1000)
-
-            # Re-register navigation handler
-            self._page.on("framenavigated", self._handle_frame_navigated)
-
-            # Invalidate refs (different page)
-            self._ref_map = {}
-
-            title = await self._page.title()
-            url = self._page.url
-
-            logger.info(f"Switched to tab {index}: {title}")
-            return f"Switched to tab {index}: {title}\nURL: {url}\n\nUse browser_snapshot to see page content."
-
-        except Exception as e:
-            logger.error(f"Switch tab failed: {e}")
-            return f"Switch tab failed: {str(e)}"
-
-    async def _save_cookies(self) -> None:
-        """Save browser cookies to workspace storage."""
-        if not self._context:
-            return
-
-        try:
-            # Ensure the data/ directory exists
-            self.cookie_file.parent.mkdir(parents=True, exist_ok=True)
-
-            # Save storage state
-            storage_state = await self._context.storage_state()
-            with open(self.cookie_file, "w") as f:
-                json.dump(storage_state, f, indent=2)
-
-            logger.info(f"Cookies saved to {self.cookie_file}")
-
-        except Exception as e:
-            logger.warning(f"Failed to save cookies: {e}")
-
-    async def _load_cookies(self) -> None:
-        """Load browser cookies from workspace storage.
-
-        Note: This is called during context creation via storage_state kwarg,
-        not as a separate method. This is here for documentation.
-        """
-        pass
-
-    def _handle_frame_navigated(self, frame) -> None:
+    def _handle_frame_navigated(self, frame: Any) -> None:
         """Handle frame navigation events for redirect detection.
 
         Args:
             frame: Playwright frame object.
         """
         # Check if this is the main frame
-        if frame == self._page.main_frame:
-            url = frame.url
+        if self._page and frame == self._page.main_frame:
+            url = getattr(frame, "url", "")
 
             # Validate domain (log warning, don't block — already navigated)
             if not self.domain_policy.is_allowed(url):

--- a/openpaw/builtins/tools/browser/state.py
+++ b/openpaw/builtins/tools/browser/state.py
@@ -1,0 +1,230 @@
+"""Browser state: accessibility snapshots, tab listing, and page info."""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class BrowserState:
+    """Manages browser state queries and accessibility snapshots.
+
+    Includes taking semantic snapshots of the page, listing open tabs,
+    and extracting the accessibility tree via CDP.
+    """
+
+    def __init__(self, session: Any) -> None:
+        """Initialize with parent BrowserSession.
+
+        Args:
+            session: The BrowserSession instance that owns this state.
+        """
+        self._session: Any = session
+
+    async def snapshot(self) -> str:
+        """Take accessibility snapshot with numbered element refs.
+
+        Returns:
+            Formatted snapshot text with [ref] annotations.
+        """
+        if not self._session.is_active:
+            return "Browser not active. Use browser_navigate first."
+
+        try:
+            # Get accessibility snapshot via CDP
+            a11y_tree = await self._get_accessibility_tree()
+
+            if not a11y_tree:
+                return "Page snapshot empty (no accessible content)"
+
+            # Transform to indexed format
+            formatted_text, ref_map = self._session.snapshot_transformer.transform(a11y_tree)
+
+            # Store ref map for element interaction
+            self._session._ref_map = ref_map
+
+            # Add header with metadata
+            title = await self._session._page.title()
+            url = self._session._page.url
+            header = f"Page: {title}\nURL: {url}\nInteractive elements: {len(ref_map)}\n\n"
+
+            logger.info(f"Snapshot captured: {len(ref_map)} interactive elements")
+            return str(header) + str(formatted_text)
+
+        except Exception as e:
+            logger.error(f"Snapshot failed: {e}")
+            return f"Snapshot failed: {str(e)}"
+
+    async def get_tabs(self) -> str:
+        """List all open tabs.
+
+        Returns:
+            Formatted list of tabs with indices.
+        """
+        if not self._session.is_active:
+            return "Browser not active. Use browser_navigate first."
+
+        try:
+            pages = self._session._context.pages
+            lines: list[str] = ["Open tabs:"]
+
+            for i, page in enumerate(pages):
+                title = await page.title()
+                url = page.url
+                active = " (active)" if page == self._session._page else ""
+                lines.append(f"  [{i}] {title} - {url}{active}")
+
+            logger.info(f"Listed {len(pages)} tabs")
+            return "\n".join(lines)
+
+        except Exception as e:
+            logger.error(f"List tabs failed: {e}")
+            return f"List tabs failed: {str(e)}"
+
+    async def _get_accessibility_tree(self) -> dict[str, Any] | None:
+        """Get accessibility tree via CDP (Chrome DevTools Protocol).
+
+        Playwright 1.58+ removed page.accessibility.snapshot(), so we use
+        CDP's Accessibility.getFullAXTree instead and reconstruct the tree.
+
+        Returns:
+            Dict tree compatible with SnapshotTransformer, or None on error.
+        """
+        try:
+            # Create CDP session
+            client = await self._session._page.context.new_cdp_session(self._session._page)
+
+            try:
+                # Get full accessibility tree from CDP
+                response = await client.send("Accessibility.getFullAXTree")
+                nodes: list[dict[str, Any]] = response.get("nodes", [])
+
+                if not nodes:
+                    logger.debug("CDP returned empty accessibility tree")
+                    return None
+
+                # Build node lookup by ID
+                node_map: dict[str, dict[str, Any]] = {node["nodeId"]: node for node in nodes}
+
+                # Helper to extract role string from CDP role object
+                def get_role(node: dict[str, Any]) -> str | None:
+                    role_obj = node.get("role", {})
+                    value = role_obj.get("value", "") if isinstance(role_obj, dict) else ""
+
+                    # Normalize role names (CDP uses internal names like "RootWebArea")
+                    role_map: dict[str, str | None] = {
+                        "RootWebArea": "WebArea",
+                        "WebArea": "WebArea",
+                        "GenericContainer": "group",
+                        "StaticText": None,  # Skip - leaf noise
+                        "InlineTextBox": None,  # Skip - leaf noise
+                    }
+
+                    # Use mapping if available, otherwise keep lowercase
+                    if value in role_map:
+                        return role_map[value]
+                    return value.lower() if value else ""
+
+                # Helper to extract name from CDP name object
+                def get_name(node: dict[str, Any]) -> str:
+                    name_obj = node.get("name", {})
+                    return name_obj.get("value", "") if isinstance(name_obj, dict) else ""
+
+                # Helper to extract properties dict
+                def get_properties(node: dict[str, Any]) -> dict[str, Any]:
+                    props: dict[str, Any] = {}
+                    for prop in node.get("properties", []):
+                        prop_name = prop.get("name", "")
+                        prop_value = prop.get("value", {})
+
+                        # Extract actual value based on type
+                        if isinstance(prop_value, dict):
+                            if "value" in prop_value:
+                                props[prop_name] = prop_value["value"]
+                        else:
+                            props[prop_name] = prop_value
+
+                    return props
+
+                # Recursive function to build tree
+                def build_tree(node_id: str) -> dict[str, Any] | None:
+                    if node_id not in node_map:
+                        return None
+
+                    cdp_node = node_map[node_id]
+
+                    # Skip ignored nodes (but include their children)
+                    if cdp_node.get("ignored", False):
+                        # Flatten through ignored nodes
+                        children: list[dict[str, Any]] = []
+                        for child_id in cdp_node.get("childIds", []):
+                            child = build_tree(child_id)
+                            if child:
+                                children.append(child)
+                        # Return children directly (unwrapped)
+                        if len(children) == 1:
+                            return children[0]
+                        elif children:
+                            return {"children": children}
+                        return None
+
+                    # Get role and skip internal leaf nodes
+                    role = get_role(cdp_node)
+                    if role is None:  # Explicitly filtered out (StaticText, etc.)
+                        return None
+
+                    # Build node dict
+                    tree_node: dict[str, Any] = {}
+
+                    if role:
+                        tree_node["role"] = role
+
+                    name = get_name(cdp_node)
+                    if name:
+                        tree_node["name"] = name
+
+                    # Extract properties
+                    props = get_properties(cdp_node)
+                    if "level" in props:
+                        tree_node["level"] = props["level"]
+                    if "checked" in props:
+                        tree_node["checked"] = props["checked"]
+                    if "disabled" in props:
+                        tree_node["disabled"] = props["disabled"]
+                    if "value" in props and props["value"]:
+                        tree_node["value"] = props["value"]
+
+                    # Recursively build children
+                    children = []
+                    for child_id in cdp_node.get("childIds", []):
+                        child = build_tree(child_id)
+                        if child:
+                            # Handle flattened children from ignored nodes
+                            if isinstance(child, list):
+                                children.extend(child)
+                            elif isinstance(child, dict) and "children" in child and "role" not in child:
+                                # Unwrap container with only children
+                                children.extend(child["children"])
+                            else:
+                                children.append(child)
+
+                    if children:
+                        tree_node["children"] = children
+
+                    return tree_node
+
+                # Find root node (usually first node)
+                root_id: str | None = nodes[0]["nodeId"] if nodes else None
+                if not root_id:
+                    return None
+
+                tree = build_tree(root_id)
+                return tree
+
+            finally:
+                # Clean up CDP session
+                await client.detach()
+
+        except Exception as e:
+            logger.error(f"CDP accessibility tree extraction failed: {e}")
+            return None

--- a/openpaw/builtins/tools/browser/state.py
+++ b/openpaw/builtins/tools/browser/state.py
@@ -98,7 +98,11 @@ class BrowserState:
         """
         try:
             # Create CDP session
-            client = await self._session._page.context.new_cdp_session(self._session._page)
+            try:
+                client = await self._session._page.context.new_cdp_session(self._session._page)
+            except Exception as e:
+                logger.warning(f"Failed to create CDP session: {e}")
+                return None
 
             try:
                 # Get full accessibility tree from CDP

--- a/openpaw/builtins/tools/browser/state.py
+++ b/openpaw/builtins/tools/browser/state.py
@@ -21,14 +21,20 @@ class BrowserState:
         """
         self._session: Any = session
 
+    def _check_active(self) -> str | None:
+        """Return error message if browser is not active, else None."""
+        if not self._session.is_active:
+            return "Browser not active. Use browser_navigate first."
+        return None
+
     async def snapshot(self) -> str:
         """Take accessibility snapshot with numbered element refs.
 
         Returns:
             Formatted snapshot text with [ref] annotations.
         """
-        if not self._session.is_active:
-            return "Browser not active. Use browser_navigate first."
+        if error := self._check_active():
+            return error
 
         try:
             # Get accessibility snapshot via CDP
@@ -61,8 +67,8 @@ class BrowserState:
         Returns:
             Formatted list of tabs with indices.
         """
-        if not self._session.is_active:
-            return "Browser not active. Use browser_navigate first."
+        if error := self._check_active():
+            return error
 
         try:
             pages = self._session._context.pages

--- a/tests/builtins/browser/test_interaction.py
+++ b/tests/builtins/browser/test_interaction.py
@@ -1,0 +1,274 @@
+"""Tests for BrowserInteraction component."""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+# Mock playwright module before importing BrowserSession
+mock_playwright_module = MagicMock()
+sys.modules["playwright"] = mock_playwright_module
+sys.modules["playwright.async_api"] = MagicMock()
+
+from openpaw.builtins.tools.browser.session import BrowserSession  # noqa: E402
+
+
+@pytest.fixture
+def config(tmp_path: Path) -> dict:
+    """Test configuration for browser session."""
+    return {
+        "workspace_path": str(tmp_path),
+        "headless": True,
+        "viewport_width": 1280,
+        "viewport_height": 720,
+        "timeout_seconds": 30,
+        "downloads_dir": "workspace/downloads",
+        "screenshots_dir": "workspace/screenshots",
+        "persist_cookies": False,
+        "allowed_domains": [],
+        "blocked_domains": [],
+        "max_snapshot_depth": 10,
+    }
+
+
+@pytest.fixture
+def mock_playwright():
+    """Mock Playwright module and instances."""
+    mock_pw = MagicMock()
+    mock_browser = AsyncMock()
+    mock_context = AsyncMock()
+    mock_page = AsyncMock()
+
+    mock_pw.chromium.launch = AsyncMock(return_value=mock_browser)
+    mock_browser.new_context = AsyncMock(return_value=mock_context)
+    mock_context.new_page = AsyncMock(return_value=mock_page)
+
+    mock_page.set_default_timeout = Mock()
+    mock_page.on = Mock()
+    mock_page.goto = AsyncMock(return_value=Mock(status=200))
+    mock_page.title = AsyncMock(return_value="Test Page")
+    mock_page.url = "https://example.com"
+    mock_page.main_frame = Mock()
+    mock_page.get_by_role = Mock()
+    mock_page.go_back = AsyncMock()
+    mock_page.evaluate = AsyncMock()
+    mock_page.screenshot = AsyncMock()
+    mock_page.close = AsyncMock()
+    mock_page.context = mock_context
+
+    mock_context.new_cdp_session = AsyncMock()
+    mock_context.pages = [mock_page]
+    mock_context.storage_state = AsyncMock(
+        return_value={"cookies": [], "origins": []}
+    )
+    mock_context.close = AsyncMock()
+
+    mock_browser.close = AsyncMock()
+
+    async_playwright_obj = MagicMock()
+    async_playwright_obj.start = AsyncMock(return_value=mock_pw)
+    mock_async_playwright = MagicMock(return_value=async_playwright_obj)
+    mock_pw.stop = AsyncMock()
+
+    return {
+        "playwright": mock_pw,
+        "browser": mock_browser,
+        "context": mock_context,
+        "page": mock_page,
+        "async_playwright": mock_async_playwright,
+    }
+
+
+@pytest.mark.asyncio
+async def test_click_resolves_ref_from_ref_map(config: dict, mock_playwright):
+    """Test click uses ref map to locate element."""
+    session = BrowserSession(config)
+    interaction = session._interaction
+
+    # Set up ref map manually (simulating snapshot result)
+    session._ref_map = {1: {"role": "button", "name": "Login"}}
+
+    # Mock locator
+    mock_locator = AsyncMock()
+    mock_playwright["page"].get_by_role.return_value = mock_locator
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await session._lifecycle.launch()
+        result = await interaction.click(1)
+
+    assert "clicked" in result.lower() or "login" in result.lower()
+    mock_locator.click.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_click_with_invalid_ref_returns_error(config: dict, mock_playwright):
+    """Test click with invalid ref returns helpful error."""
+    session = BrowserSession(config)
+    interaction = session._interaction
+    session._ref_map = {}
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await session._lifecycle.launch()
+        result = await interaction.click(999)
+
+    assert "invalid" in result.lower()
+    assert "snapshot" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_click_returns_error_if_not_active(config: dict):
+    """Test click returns error when browser not active."""
+    session = BrowserSession(config)
+    interaction = session._interaction
+
+    result = await interaction.click(1)
+    assert "not active" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_type_text_fills_input(config: dict, mock_playwright):
+    """Test type_text fills element with text."""
+    session = BrowserSession(config)
+    interaction = session._interaction
+    session._ref_map = {1: {"role": "textbox", "name": "Username"}}
+
+    mock_locator = AsyncMock()
+    mock_playwright["page"].get_by_role.return_value = mock_locator
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await session._lifecycle.launch()
+        result = await interaction.type_text(1, "testuser")
+
+    assert "typed" in result.lower()
+    mock_locator.clear.assert_called_once()
+    mock_locator.fill.assert_called_once_with("testuser", timeout=30000)
+
+
+@pytest.mark.asyncio
+async def test_type_text_with_enter_invalidates_refs(config: dict, mock_playwright):
+    """Test type with press_enter invalidates ref map."""
+    session = BrowserSession(config)
+    interaction = session._interaction
+    session._ref_map = {1: {"role": "textbox", "name": "Search"}}
+
+    mock_locator = AsyncMock()
+    mock_playwright["page"].get_by_role.return_value = mock_locator
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await session._lifecycle.launch()
+        await interaction.type_text(1, "query", press_enter=True)
+
+    # Refs should be cleared after pressing Enter
+    assert len(session._ref_map) == 0
+    mock_locator.press.assert_called_once_with("Enter")
+
+
+@pytest.mark.asyncio
+async def test_type_text_returns_error_if_not_active(config: dict):
+    """Test type_text returns error when browser not active."""
+    session = BrowserSession(config)
+    interaction = session._interaction
+
+    result = await interaction.type_text(1, "test")
+    assert "not active" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_select_option(config: dict, mock_playwright):
+    """Test select_option selects dropdown value."""
+    session = BrowserSession(config)
+    interaction = session._interaction
+    session._ref_map = {1: {"role": "combobox", "name": "Country"}}
+
+    mock_locator = AsyncMock()
+    mock_playwright["page"].get_by_role.return_value = mock_locator
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await session._lifecycle.launch()
+        result = await interaction.select_option(1, "USA")
+
+    assert "selected" in result.lower()
+    mock_locator.select_option.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_select_option_returns_error_if_not_active(config: dict):
+    """Test select_option returns error when browser not active."""
+    session = BrowserSession(config)
+    interaction = session._interaction
+
+    result = await interaction.select_option(1, "USA")
+    assert "not active" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_screenshot_saves_to_workspace(config: dict, tmp_path: Path, mock_playwright):
+    """Test screenshot saves to correct path."""
+    session = BrowserSession(config)
+    interaction = session._interaction
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await session._lifecycle.launch()
+        result = await interaction.screenshot()
+
+    assert "screenshot" in result.lower()
+    assert "workspace/screenshots/" in result
+    mock_playwright["page"].screenshot.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_screenshot_returns_error_if_not_active(config: dict):
+    """Test screenshot returns error when browser not active."""
+    session = BrowserSession(config)
+    interaction = session._interaction
+
+    result = await interaction.screenshot()
+    assert "not active" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_js_evaluates_script(config: dict, mock_playwright):
+    """Test execute_js evaluates script in page context."""
+    session = BrowserSession(config)
+    interaction = session._interaction
+
+    mock_playwright["page"].evaluate = AsyncMock(return_value="result")
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await session._lifecycle.launch()
+        result = await interaction.execute_js("document.title")
+
+    assert result == "result"
+    mock_playwright["page"].evaluate.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_js_returns_error_if_not_active(config: dict):
+    """Test execute_js returns error when browser not active."""
+    session = BrowserSession(config)
+    interaction = session._interaction
+
+    result = await interaction.execute_js("document.title")
+    assert "not active" in result.lower()

--- a/tests/builtins/browser/test_lifecycle.py
+++ b/tests/builtins/browser/test_lifecycle.py
@@ -1,0 +1,187 @@
+"""Tests for BrowserLifecycle component."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+# Mock playwright module before importing BrowserSession
+mock_playwright_module = MagicMock()
+sys.modules["playwright"] = mock_playwright_module
+sys.modules["playwright.async_api"] = MagicMock()
+
+from openpaw.builtins.tools.browser.session import BrowserSession  # noqa: E402
+
+
+@pytest.fixture
+def config(tmp_path: Path) -> dict:
+    """Test configuration for browser session."""
+    return {
+        "workspace_path": str(tmp_path),
+        "headless": True,
+        "viewport_width": 1280,
+        "viewport_height": 720,
+        "timeout_seconds": 30,
+        "downloads_dir": "workspace/downloads",
+        "screenshots_dir": "workspace/screenshots",
+        "persist_cookies": False,
+        "allowed_domains": [],
+        "blocked_domains": [],
+        "max_snapshot_depth": 10,
+    }
+
+
+@pytest.fixture
+def mock_playwright():
+    """Mock Playwright module and instances."""
+    mock_pw = MagicMock()
+    mock_browser = AsyncMock()
+    mock_context = AsyncMock()
+    mock_page = AsyncMock()
+
+    mock_pw.chromium.launch = AsyncMock(return_value=mock_browser)
+    mock_browser.new_context = AsyncMock(return_value=mock_context)
+    mock_context.new_page = AsyncMock(return_value=mock_page)
+
+    mock_page.set_default_timeout = Mock()
+    mock_page.on = Mock()
+    mock_page.goto = AsyncMock(return_value=Mock(status=200))
+    mock_page.title = AsyncMock(return_value="Test Page")
+    mock_page.url = "https://example.com"
+    mock_page.main_frame = Mock()
+    mock_page.get_by_role = Mock()
+    mock_page.go_back = AsyncMock()
+    mock_page.evaluate = AsyncMock()
+    mock_page.screenshot = AsyncMock()
+    mock_page.close = AsyncMock()
+    mock_page.context = mock_context
+
+    mock_context.new_cdp_session = AsyncMock()
+    mock_context.pages = [mock_page]
+    mock_context.storage_state = AsyncMock(
+        return_value={"cookies": [], "origins": []}
+    )
+    mock_context.close = AsyncMock()
+
+    mock_browser.close = AsyncMock()
+
+    async_playwright_obj = MagicMock()
+    async_playwright_obj.start = AsyncMock(return_value=mock_pw)
+    mock_async_playwright = MagicMock(return_value=async_playwright_obj)
+    mock_pw.stop = AsyncMock()
+
+    return {
+        "playwright": mock_pw,
+        "browser": mock_browser,
+        "context": mock_context,
+        "page": mock_page,
+        "async_playwright": mock_async_playwright,
+    }
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_launch_creates_browser(config: dict, mock_playwright):
+    """Test lifecycle launch creates browser resources."""
+    session = BrowserSession(config)
+    lifecycle = session._lifecycle
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await lifecycle.launch()
+
+    assert session.is_active
+    mock_playwright["playwright"].chromium.launch.assert_called_once()
+    mock_playwright["browser"].new_context.assert_called_once()
+    mock_playwright["context"].new_page.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_launch_is_idempotent(config: dict, mock_playwright):
+    """Test launching multiple times doesn't create duplicate browsers."""
+    session = BrowserSession(config)
+    lifecycle = session._lifecycle
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await lifecycle.launch()
+        await lifecycle.launch()  # Second launch should be no-op
+
+    mock_playwright["playwright"].chromium.launch.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_close_cleans_up(config: dict, mock_playwright):
+    """Test lifecycle close cleans up browser resources."""
+    session = BrowserSession(config)
+    lifecycle = session._lifecycle
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await lifecycle.launch()
+        await lifecycle.close()
+
+    assert not session.is_active
+    mock_playwright["page"].close.assert_called_once()
+    mock_playwright["context"].close.assert_called_once()
+    mock_playwright["browser"].close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cookie_persistence_saves_on_close(config: dict, tmp_path: Path, mock_playwright):
+    """Test cookie persistence saves to file on close."""
+    config["persist_cookies"] = True
+    session = BrowserSession(config)
+    lifecycle = session._lifecycle
+
+    storage_state = {"cookies": [{"name": "test", "value": "123"}], "origins": []}
+    mock_playwright["context"].storage_state.return_value = storage_state
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await lifecycle.launch()
+        await lifecycle.close()
+
+    # Check cookie file was created
+    cookie_file = tmp_path / "data" / "browser_cookies.json"
+    assert cookie_file.exists()
+
+    with open(cookie_file) as f:
+        saved_state = json.load(f)
+        assert saved_state["cookies"][0]["name"] == "test"
+
+
+@pytest.mark.asyncio
+async def test_cookie_persistence_loads_on_launch(config: dict, tmp_path: Path, mock_playwright):
+    """Test cookie persistence loads from file on launch."""
+    config["persist_cookies"] = True
+
+    # Create cookie file
+    cookie_file = tmp_path / "data" / "browser_cookies.json"
+    cookie_file.parent.mkdir(parents=True, exist_ok=True)
+    storage_state = {"cookies": [{"name": "test", "value": "456"}], "origins": []}
+    with open(cookie_file, "w") as f:
+        json.dump(storage_state, f)
+
+    session = BrowserSession(config)
+    lifecycle = session._lifecycle
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await lifecycle.launch()
+
+    # Check context was created with storage state
+    mock_playwright["browser"].new_context.assert_called_once()
+    call_kwargs = mock_playwright["browser"].new_context.call_args.kwargs
+    assert "storage_state" in call_kwargs

--- a/tests/builtins/browser/test_navigation.py
+++ b/tests/builtins/browser/test_navigation.py
@@ -1,0 +1,243 @@
+"""Tests for BrowserNavigation component."""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+# Mock playwright module before importing BrowserSession
+mock_playwright_module = MagicMock()
+sys.modules["playwright"] = mock_playwright_module
+sys.modules["playwright.async_api"] = MagicMock()
+
+from openpaw.builtins.tools.browser.session import BrowserSession  # noqa: E402
+
+
+@pytest.fixture
+def config(tmp_path: Path) -> dict:
+    """Test configuration for browser session."""
+    return {
+        "workspace_path": str(tmp_path),
+        "headless": True,
+        "viewport_width": 1280,
+        "viewport_height": 720,
+        "timeout_seconds": 30,
+        "downloads_dir": "workspace/downloads",
+        "screenshots_dir": "workspace/screenshots",
+        "persist_cookies": False,
+        "allowed_domains": [],
+        "blocked_domains": [],
+        "max_snapshot_depth": 10,
+    }
+
+
+@pytest.fixture
+def mock_playwright():
+    """Mock Playwright module and instances."""
+    mock_pw = MagicMock()
+    mock_browser = AsyncMock()
+    mock_context = AsyncMock()
+    mock_page = AsyncMock()
+
+    mock_pw.chromium.launch = AsyncMock(return_value=mock_browser)
+    mock_browser.new_context = AsyncMock(return_value=mock_context)
+    mock_context.new_page = AsyncMock(return_value=mock_page)
+
+    mock_page.set_default_timeout = Mock()
+    mock_page.on = Mock()
+    mock_page.goto = AsyncMock(return_value=Mock(status=200))
+    mock_page.title = AsyncMock(return_value="Test Page")
+    mock_page.url = "https://example.com"
+    mock_page.main_frame = Mock()
+    mock_page.get_by_role = Mock()
+    mock_page.go_back = AsyncMock()
+    mock_page.evaluate = AsyncMock()
+    mock_page.screenshot = AsyncMock()
+    mock_page.close = AsyncMock()
+    mock_page.context = mock_context
+
+    mock_context.new_cdp_session = AsyncMock()
+    mock_context.pages = [mock_page]
+    mock_context.storage_state = AsyncMock(
+        return_value={"cookies": [], "origins": []}
+    )
+    mock_context.close = AsyncMock()
+
+    mock_browser.close = AsyncMock()
+
+    async_playwright_obj = MagicMock()
+    async_playwright_obj.start = AsyncMock(return_value=mock_pw)
+    mock_async_playwright = MagicMock(return_value=async_playwright_obj)
+    mock_pw.stop = AsyncMock()
+
+    return {
+        "playwright": mock_pw,
+        "browser": mock_browser,
+        "context": mock_context,
+        "page": mock_page,
+        "async_playwright": mock_async_playwright,
+    }
+
+
+@pytest.mark.asyncio
+async def test_navigate_validates_domain_policy(config: dict, mock_playwright):
+    """Test navigate validates domain before going."""
+    config["allowed_domains"] = ["example.com"]
+    session = BrowserSession(config)
+    navigation = session._navigation
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        # Allowed domain should succeed
+        result = await navigation.navigate("https://example.com/page")
+        assert "example.com" in result or "Test Page" in result
+
+        # Blocked domain should fail
+        result = await navigation.navigate("https://blocked.com")
+        assert "blocked" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_navigate_auto_launches_browser(config: dict, mock_playwright):
+    """Test navigate auto-launches browser on first call."""
+    session = BrowserSession(config)
+    navigation = session._navigation
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await navigation.navigate("https://example.com")
+
+    assert session.is_active
+    mock_playwright["page"].goto.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_navigate_checks_redirect_domain(config: dict, mock_playwright):
+    """Test navigate checks domain after redirect."""
+    config["allowed_domains"] = ["example.com"]
+    session = BrowserSession(config)
+    navigation = session._navigation
+
+    # Mock a redirect to blocked domain
+    mock_playwright["page"].url = "https://blocked.com"
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        result = await navigation.navigate("https://example.com")
+        assert "blocked" in result.lower() or "disallowed" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_back_navigation_invalidates_refs(config: dict, mock_playwright):
+    """Test back navigation clears ref map."""
+    session = BrowserSession(config)
+    navigation = session._navigation
+    session._ref_map = {1: {"role": "button", "name": "Test"}}
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await session._lifecycle.launch()
+        await navigation.back()
+
+    assert len(session._ref_map) == 0
+    mock_playwright["page"].go_back.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_back_returns_error_if_not_active(config: dict):
+    """Test back returns error when browser not active."""
+    session = BrowserSession(config)
+    navigation = session._navigation
+
+    result = await navigation.back()
+    assert "not active" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_scroll_executes_javascript(config: dict, mock_playwright):
+    """Test scroll executes page evaluation."""
+    session = BrowserSession(config)
+    navigation = session._navigation
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await session._lifecycle.launch()
+        await navigation.scroll("down", "page")
+
+    mock_playwright["page"].evaluate.assert_called_once()
+    call_arg = mock_playwright["page"].evaluate.call_args[0][0]
+    assert "scrollBy" in call_arg
+    assert "720" in call_arg  # viewport height
+
+
+@pytest.mark.asyncio
+async def test_scroll_returns_error_if_not_active(config: dict):
+    """Test scroll returns error when browser not active."""
+    session = BrowserSession(config)
+    navigation = session._navigation
+
+    result = await navigation.scroll("down", "page")
+    assert "not active" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_switch_tab_changes_active_page(config: dict, mock_playwright):
+    """Test switch tab changes active page."""
+    session = BrowserSession(config)
+    navigation = session._navigation
+
+    # Mock multiple pages
+    mock_page2 = AsyncMock()
+    mock_page2.title = AsyncMock(return_value="Page 2")
+    mock_page2.url = "https://example.com/page2"
+    mock_page2.set_default_timeout = Mock()
+    mock_page2.on = Mock()
+    mock_playwright["context"].pages = [mock_playwright["page"], mock_page2]
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await session._lifecycle.launch()
+
+        # Switch to second tab
+        result = await navigation.switch_tab(1)
+        assert session._page == mock_page2
+        assert "page 2" in result.lower() or "switched" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_switch_tab_invalid_index(config: dict, mock_playwright):
+    """Test switch tab with invalid index returns error."""
+    session = BrowserSession(config)
+    navigation = session._navigation
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await session._lifecycle.launch()
+        result = await navigation.switch_tab(99)
+
+    assert "invalid" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_switch_tab_returns_error_if_not_active(config: dict):
+    """Test switch tab returns error when browser not active."""
+    session = BrowserSession(config)
+    navigation = session._navigation
+
+    result = await navigation.switch_tab(0)
+    assert "not active" in result.lower()

--- a/tests/builtins/browser/test_state.py
+++ b/tests/builtins/browser/test_state.py
@@ -1,0 +1,177 @@
+"""Tests for BrowserState component."""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+# Mock playwright module before importing BrowserSession
+mock_playwright_module = MagicMock()
+sys.modules["playwright"] = mock_playwright_module
+sys.modules["playwright.async_api"] = MagicMock()
+
+from openpaw.builtins.tools.browser.session import BrowserSession  # noqa: E402
+
+
+@pytest.fixture
+def config(tmp_path: Path) -> dict:
+    """Test configuration for browser session."""
+    return {
+        "workspace_path": str(tmp_path),
+        "headless": True,
+        "viewport_width": 1280,
+        "viewport_height": 720,
+        "timeout_seconds": 30,
+        "downloads_dir": "workspace/downloads",
+        "screenshots_dir": "workspace/screenshots",
+        "persist_cookies": False,
+        "allowed_domains": [],
+        "blocked_domains": [],
+        "max_snapshot_depth": 10,
+    }
+
+
+@pytest.fixture
+def mock_playwright():
+    """Mock Playwright module and instances."""
+    mock_pw = MagicMock()
+    mock_browser = AsyncMock()
+    mock_context = AsyncMock()
+    mock_page = AsyncMock()
+
+    mock_pw.chromium.launch = AsyncMock(return_value=mock_browser)
+    mock_browser.new_context = AsyncMock(return_value=mock_context)
+    mock_context.new_page = AsyncMock(return_value=mock_page)
+
+    mock_page.set_default_timeout = Mock()
+    mock_page.on = Mock()
+    mock_page.goto = AsyncMock(return_value=Mock(status=200))
+    mock_page.title = AsyncMock(return_value="Test Page")
+    mock_page.url = "https://example.com"
+    mock_page.main_frame = Mock()
+    mock_page.get_by_role = Mock()
+    mock_page.go_back = AsyncMock()
+    mock_page.evaluate = AsyncMock()
+    mock_page.screenshot = AsyncMock()
+    mock_page.close = AsyncMock()
+    mock_page.context = mock_context
+
+    # Mock CDP session for accessibility tree
+    mock_cdp_session = AsyncMock()
+    mock_cdp_session.send = AsyncMock(
+        return_value={
+            "nodes": [
+                {
+                    "nodeId": "1",
+                    "role": {"type": "internalRole", "value": "RootWebArea"},
+                    "name": {"type": "computedString", "value": "Test Page"},
+                    "properties": [],
+                    "childIds": ["2", "3"],
+                    "ignored": False,
+                },
+                {
+                    "nodeId": "2",
+                    "role": {"type": "role", "value": "button"},
+                    "name": {"type": "computedString", "value": "Login"},
+                    "childIds": [],
+                    "ignored": False,
+                    "properties": [],
+                },
+                {
+                    "nodeId": "3",
+                    "role": {"type": "role", "value": "textbox"},
+                    "name": {"type": "computedString", "value": "Username"},
+                    "childIds": [],
+                    "ignored": False,
+                    "properties": [],
+                },
+            ]
+        }
+    )
+    mock_cdp_session.detach = AsyncMock()
+
+    mock_context.new_cdp_session = AsyncMock(return_value=mock_cdp_session)
+    mock_context.pages = [mock_page]
+    mock_context.storage_state = AsyncMock(
+        return_value={"cookies": [], "origins": []}
+    )
+    mock_context.close = AsyncMock()
+
+    mock_browser.close = AsyncMock()
+
+    async_playwright_obj = MagicMock()
+    async_playwright_obj.start = AsyncMock(return_value=mock_pw)
+    mock_async_playwright = MagicMock(return_value=async_playwright_obj)
+    mock_pw.stop = AsyncMock()
+
+    return {
+        "playwright": mock_pw,
+        "browser": mock_browser,
+        "context": mock_context,
+        "page": mock_page,
+        "async_playwright": mock_async_playwright,
+    }
+
+
+@pytest.mark.asyncio
+async def test_snapshot_transforms_accessibility_tree(config: dict, mock_playwright):
+    """Test snapshot calls transformer and stores ref map."""
+    session = BrowserSession(config)
+    state = session._state
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await session._lifecycle.launch()
+        result = await state.snapshot()
+
+    # Should have refs for interactive elements
+    assert "[1]" in result or "[2]" in result
+    assert len(session._ref_map) > 0
+    assert "Login" in result or "Username" in result
+
+
+@pytest.mark.asyncio
+async def test_snapshot_returns_error_if_not_active(config: dict):
+    """Test snapshot returns error when browser not active."""
+    session = BrowserSession(config)
+    state = session._state
+
+    result = await state.snapshot()
+    assert "not active" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_get_tabs_lists_all_pages(config: dict, mock_playwright):
+    """Test get_tabs lists all open pages."""
+    session = BrowserSession(config)
+    state = session._state
+
+    # Mock multiple pages
+    mock_page2 = AsyncMock()
+    mock_page2.title = AsyncMock(return_value="Page 2")
+    mock_page2.url = "https://example.com/page2"
+    mock_playwright["context"].pages = [mock_playwright["page"], mock_page2]
+
+    with patch(
+        "playwright.async_api.async_playwright",
+        mock_playwright["async_playwright"],
+    ):
+        await session._lifecycle.launch()
+        result = await state.get_tabs()
+
+    assert "[0]" in result and "[1]" in result
+    assert "Test Page" in result
+    assert "Page 2" in result
+
+
+@pytest.mark.asyncio
+async def test_get_tabs_returns_error_if_not_active(config: dict):
+    """Test get_tabs returns error when browser not active."""
+    session = BrowserSession(config)
+    state = session._state
+
+    result = await state.get_tabs()
+    assert "not active" in result.lower()


### PR DESCRIPTION
## Summary

Decompose `BrowserSession` (812 lines) into 5 focused modules, completing MR B3 of Phase B.

## Decomposition

| File | Lines | Responsibility |
|------|-------|---------------|
| `browser/session.py` | 264 | Facade — delegates to helpers, maintains public API |
| `browser/lifecycle.py` | 174 | Launch, close, cookie persistence |
| `browser/navigation.py` | 164 | URL navigate, back, scroll, tab switch |
| `browser/interaction.py` | 264 | Click, type, select, JS execution, screenshot |
| `browser/state.py` | 231 | Accessibility snapshots, tab listing |

## Key Decisions

- **Shared state preserved**: `_browser`, `_page`, `_context`, `_ref_map` remain on `BrowserSession`; helper classes receive session reference
- **Backward-compatible API**: All public methods keep same signatures; existing tests pass unchanged
- **No new dependencies**: Reuses existing Playwright mocking pattern

## Tests

- Added 4 new focused test modules (32 tests) covering each extracted class
- Existing `test_browser_session.py` (19 tests) passes unchanged
- All 2944 tests pass
- ruff clean, no new mypy errors introduced

## Metrics

- Files >700 lines: 8 → 7 ✅
- `browser/session.py`: 812 → 264 lines

## Risks

Low — organizational decomposition only. No behavioral changes. All browser operations still exercised through the facade.