### PR TITLE
MR B10: Scheduler slimming — decompose cron.py and heartbeat.py

### DIFF
--- a/openpaw/runtime/scheduling/__init__.py
+++ b/openpaw/runtime/scheduling/__init__.py
@@ -4,7 +4,21 @@ Provides cron and heartbeat scheduling capabilities.
 """
 
 from openpaw.runtime.scheduling.cron import CronScheduler
+from openpaw.runtime.scheduling.cron_executor import CronExecutor
+from openpaw.runtime.scheduling.cron_job_manager import CronJobManager
 from openpaw.runtime.scheduling.heartbeat import HeartbeatScheduler
+from openpaw.runtime.scheduling.heartbeat_executor import HeartbeatExecutor
+from openpaw.runtime.scheduling.heartbeat_preflight import HeartbeatPreflight
+from openpaw.runtime.scheduling.heartbeat_prompt import HeartbeatPromptBuilder
 from openpaw.runtime.scheduling.loader import CronLoader
 
-__all__ = ["CronScheduler", "HeartbeatScheduler", "CronLoader"]
+__all__ = [
+    "CronExecutor",
+    "CronJobManager",
+    "CronLoader",
+    "CronScheduler",
+    "HeartbeatExecutor",
+    "HeartbeatPreflight",
+    "HeartbeatPromptBuilder",
+    "HeartbeatScheduler",
+]

--- a/openpaw/runtime/scheduling/cron.py
+++ b/openpaw/runtime/scheduling/cron.py
@@ -1,37 +1,23 @@
 """APScheduler-based cron execution for OpenPaw."""
 
-import json
 import logging
-import time as time_module
 from collections.abc import Awaitable, Callable, Mapping
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from apscheduler.triggers.cron import CronTrigger
-from apscheduler.triggers.date import DateTrigger
-from apscheduler.triggers.interval import IntervalTrigger
+from apscheduler.triggers.cron import CronTrigger  # noqa: F401
+from apscheduler.triggers.date import DateTrigger  # noqa: F401
+from apscheduler.triggers.interval import IntervalTrigger  # noqa: F401
 
 from openpaw.agent.metrics import TokenUsageLogger
 from openpaw.agent.session_logger import SessionLogger
-from openpaw.builtins.tools._channel_context import (
-    clear_channel_context,
-    set_channel_context,
-    set_invocation_origin,
-)
 from openpaw.channels.base import ChannelAdapter
 from openpaw.core.config.models import CronDefinition, CronOutputConfig
-from openpaw.core.paths import CRON_LOG_JSONL
-from openpaw.core.prompts.system_events import (
-    CRON_RESULT_TEMPLATE,
-    CRON_RESULT_TRUNCATED_TEMPLATE,
-    DYNAMIC_TASK_RESULT_TEMPLATE,
-    DYNAMIC_TASK_RESULT_TRUNCATED_TEMPLATE,
-    INJECTION_TRUNCATION_LIMIT,
-)
 from openpaw.model.cron import DynamicCronTask
+from openpaw.runtime.scheduling.cron_executor import CronExecutor
+from openpaw.runtime.scheduling.cron_job_manager import CronJobManager
 from openpaw.runtime.scheduling.loader import CronLoader
 from openpaw.stores.cron import DynamicCronStore
 
@@ -58,18 +44,7 @@ class CronScheduler:
         result_callback: Callable[[str, str], Awaitable[None]] | None = None,
         session_logger: SessionLogger | None = None,
     ):
-        """Initialize the cron scheduler.
-
-        Args:
-            workspace_path: Path to the agent workspace.
-            agent_factory: Factory function to create fresh agent instances.
-            channels: Dictionary mapping channel types to channel instances for routing.
-            token_logger: Optional token usage logger for tracking cron invocations.
-            workspace_name: Name of the workspace (for logging and token tracking).
-            timezone: IANA timezone string for cron schedules (e.g., "America/New_York").
-            result_callback: Optional callback for queue injection of results.
-            session_logger: Optional SessionLogger for writing session logs.
-        """
+        """Initialize the cron scheduler."""
         self.workspace_path = Path(workspace_path)
         self.agent_factory = agent_factory
         self.channels = channels
@@ -80,10 +55,33 @@ class CronScheduler:
         self._result_callback = result_callback
         self._session_logger = session_logger
         self._scheduler: AsyncIOScheduler | None = None
+        self._job_manager: CronJobManager | None = None
         self._jobs: dict[str, Any] = {}
         self._dynamic_store = DynamicCronStore(workspace_path)
         self._dynamic_jobs: dict[str, Any] = {}
-        self._running_jobs: set[str] = set()
+        self._executor = CronExecutor(
+            workspace_path=self.workspace_path,
+            agent_factory=self.agent_factory,
+            channels=self.channels,
+            workspace_name=self._workspace_name,
+            token_logger=self._token_logger,
+            session_logger=self._session_logger,
+            result_callback=self._result_callback,
+            dynamic_store=self._dynamic_store,
+            dynamic_jobs=self._dynamic_jobs,
+        )
+
+    def _ensure_job_manager(self) -> CronJobManager:
+        if self._job_manager is None:
+            self._job_manager = CronJobManager(
+                scheduler=self._scheduler,
+                tz=self._tz,
+                dynamic_store=self._dynamic_store,
+                executor=self._executor,
+                jobs=self._jobs,
+                dynamic_jobs=self._dynamic_jobs,
+            )
+        return self._job_manager
 
     async def start(self) -> None:
         """Start the scheduler and register all cron jobs."""
@@ -95,6 +93,7 @@ class CronScheduler:
                 "misfire_grace_time": 300,
             },
         )
+        self._ensure_job_manager()
 
         # Load and schedule YAML-defined cron jobs
         loader = CronLoader(self.workspace_path)
@@ -135,535 +134,62 @@ class CronScheduler:
         delivery: str | None = None,
         tools_used: list[str] | None = None,
     ) -> None:
-        """Append cron execution event to workspace JSONL log.
-
-        Args:
-            cron_name: Name of the cron job (or "dynamic_<id[:8]>" for dynamic tasks).
-            outcome: Execution outcome: "completed", "error", or "skipped".
-            duration_ms: Execution duration in milliseconds.
-            error: Error message if outcome is "error".
-            input_tokens: Input token count from the agent invocation.
-            output_tokens: Output token count from the agent invocation.
-            total_tokens: Total token count from the agent invocation.
-            llm_calls: Number of LLM calls made during execution.
-            session_path: Relative path to the session log file, if written.
-            delivery: Delivery mode used ("channel" or "agent").
-            tools_used: List of tool names invoked during execution.
-        """
-        log_path = self.workspace_path / str(CRON_LOG_JSONL)
-        event: dict[str, Any] = {
-            "timestamp": datetime.now(UTC).isoformat(),
-            "workspace": self._workspace_name,
-            "cron_name": cron_name,
-            "outcome": outcome,
-        }
-        if duration_ms is not None:
-            event["duration_ms"] = round(duration_ms, 1)
-        if error:
-            event["error"] = error
-        if input_tokens is not None:
-            event["input_tokens"] = input_tokens
-        if output_tokens is not None:
-            event["output_tokens"] = output_tokens
-        if total_tokens is not None:
-            event["total_tokens"] = total_tokens
-        if llm_calls is not None:
-            event["llm_calls"] = llm_calls
-        if session_path:
-            event["session_path"] = session_path
-        if delivery:
-            event["delivery"] = delivery
-        if tools_used:
-            event["tools_used"] = tools_used
-
-        try:
-            log_path.parent.mkdir(parents=True, exist_ok=True)
-            with log_path.open("a", encoding="utf-8") as f:
-                f.write(json.dumps(event) + "\n")
-        except OSError as e:
-            logger.warning(f"Failed to write cron log: {e}")
+        """Append cron execution event to workspace JSONL log."""
+        self._executor.log_cron_event(
+            cron_name=cron_name,
+            outcome=outcome,
+            duration_ms=duration_ms,
+            error=error,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=total_tokens,
+            llm_calls=llm_calls,
+            session_path=session_path,
+            delivery=delivery,
+            tools_used=tools_used,
+        )
 
     async def _execute_cron(self, cron: CronDefinition) -> None:
-        """Execute a cron job.
-
-        Args:
-            cron: The cron definition to execute.
-        """
-        job_id = cron.name
-        if job_id in self._running_jobs:
-            logger.warning(f"Skipping cron job {cron.name}: previous execution still running")
-            return
-
-        self._running_jobs.add(job_id)
-        logger.info(f"Executing cron job: {cron.name}")
-        set_invocation_origin(f"cron:{cron.name}")
-
-        # Set up channel context so send_message/send_file work during cron execution
-        cron_channel = self.channels.get(cron.output.channel)
-        cron_session_key = self._resolve_session_key(cron_channel, cron.output) if cron_channel else None
-        if cron_channel and cron_session_key:
-            set_channel_context(cron_channel, cron_session_key)
-
-        try:
-            # Resolve max_output_tokens: per-cron definition takes precedence over
-            # the workspace-level default already baked into the factory's
-            # extra_model_kwargs. Passing it as extra_overrides lets the
-            # cron-specific cap win without mutating factory state.
-            extra_overrides: dict[str, Any] = {}
-            if cron.max_output_tokens is not None:
-                extra_overrides["max_tokens"] = cron.max_output_tokens
-
-            agent_runner = (
-                self.agent_factory(extra_overrides=extra_overrides)
-                if extra_overrides
-                else self.agent_factory()
-            )
-
-            start_time = time_module.monotonic()
-            response = await agent_runner.run(message=cron.prompt)
-            duration_ms = (time_module.monotonic() - start_time) * 1000
-
-            # Log a warning when the output cap was hit — response is likely truncated
-            cron_metrics_check = agent_runner.last_metrics
-            cron_cap = agent_runner.max_output_tokens
-            if (
-                isinstance(cron_cap, int)
-                and cron_metrics_check
-                and isinstance(cron_metrics_check.output_tokens, int)
-                and cron_metrics_check.output_tokens >= cron_cap
-            ):
-                logger.warning(
-                    f"Cron '{cron.name}' output token cap reached: "
-                    f"{cron_metrics_check.output_tokens}/{cron_cap} tokens "
-                    f"— response likely truncated (workspace: {self._workspace_name})"
-                )
-
-            # Write session log
-            session_path: str | None = None
-            if self._session_logger:
-                try:
-                    session_path = self._session_logger.write_session(
-                        name=cron.name,
-                        prompt=cron.prompt,
-                        response=response,
-                        tools_used=agent_runner.last_tools_used or [],
-                        metrics=agent_runner.last_metrics,
-                        duration_ms=duration_ms,
-                    )
-                except Exception as e:
-                    logger.warning(f"Failed to write cron session log for {cron.name}: {e}")
-
-            delivery = cron.output.delivery
-
-            # Channel delivery ("channel" or "both")
-            if delivery in ("channel", "both"):
-                channel = self.channels.get(cron.output.channel)
-                if not channel:
-                    logger.error(f"Channel not found for cron {cron.name}: {cron.output.channel}")
-                else:
-                    session_key = self._resolve_session_key(channel, cron.output)
-                    if session_key:
-                        await channel.send_message(session_key=session_key, content=response)
-                    else:
-                        logger.warning(f"Unsupported output config for cron {cron.name}: {cron.output}")
-
-            # Agent queue injection ("agent" or "both")
-            if delivery in ("agent", "both") and self._result_callback and session_path:
-                try:
-                    channel = self.channels.get(cron.output.channel)
-                    session_key = self._resolve_session_key(channel, cron.output) if channel else None
-                    if channel and session_key:
-                        output = response
-                        if len(output) > INJECTION_TRUNCATION_LIMIT:
-                            output = output[:INJECTION_TRUNCATION_LIMIT]
-                            injection_content = CRON_RESULT_TRUNCATED_TEMPLATE.format(
-                                cron_name=cron.name, output=output, session_path=session_path,
-                            )
-                        else:
-                            injection_content = CRON_RESULT_TEMPLATE.format(
-                                cron_name=cron.name, output=output, session_path=session_path,
-                            )
-                        await self._result_callback(session_key, injection_content)
-                        logger.info(f"Cron {cron.name} result injected into agent queue")
-                except Exception as e:
-                    logger.warning(f"Failed to inject cron result for {cron.name}: {e}")
-
-            # Log token usage for cron invocation
-            metrics = agent_runner.last_metrics
-            if self._token_logger and self._workspace_name and metrics:
-                self._token_logger.log(
-                    metrics=metrics,
-                    workspace=self._workspace_name,
-                    invocation_type="cron",
-                    session_key=None,
-                )
-
-            self._log_cron_event(
-                cron_name=cron.name,
-                outcome="completed",
-                duration_ms=duration_ms,
-                input_tokens=metrics.input_tokens if metrics else None,
-                output_tokens=metrics.output_tokens if metrics else None,
-                total_tokens=metrics.total_tokens if metrics else None,
-                llm_calls=metrics.llm_calls if metrics else None,
-                session_path=session_path,
-                delivery=delivery,
-                tools_used=agent_runner.last_tools_used or None,
-            )
-
-            logger.info(f"Cron job {cron.name} completed successfully")
-
-        except Exception as e:
-            logger.error(f"Failed to execute cron job {cron.name}: {e}", exc_info=True)
-            self._log_cron_event(
-                cron_name=cron.name,
-                outcome="error",
-                error=str(e),
-            )
-        finally:
-            self._running_jobs.discard(job_id)
-            clear_channel_context()
+        """Execute a cron job."""
+        await self._executor.execute_cron(cron)
 
     @staticmethod
     def _resolve_session_key(channel: ChannelAdapter, output: CronOutputConfig) -> str | None:
-        """Resolve session key from cron output config.
-
-        Uses ``target_id`` (preferred) with fallback to legacy ``chat_id``/``channel_id``.
-
-        Args:
-            channel: The channel adapter instance to build the session key against.
-            output: The cron output config specifying channel name and target ID.
-
-        Returns:
-            A session key string, or None if no supported routing config is found.
-        """
-        target = next(
-            (v for v in (output.target_id, output.chat_id, output.channel_id) if v is not None),
-            None,
-        )
-        if target:
-            return channel.build_session_key(target)
-        return None
+        """Resolve session key from cron output config."""
+        return CronExecutor._resolve_session_key(channel, output)
 
     def add_job(self, cron: CronDefinition) -> None:
-        """Add a cron job to the scheduler.
-
-        Args:
-            cron: The cron definition to schedule.
-        """
-        if not self._scheduler:
-            raise RuntimeError("Scheduler not initialized. Call start() first.")
-
-        trigger = CronTrigger.from_crontab(cron.schedule, timezone=self._tz)
-
-        job = self._scheduler.add_job(
-            func=self._execute_cron,
-            trigger=trigger,
-            args=[cron],
-            id=cron.name,
-            name=cron.name,
-            replace_existing=True,
-        )
-
-        self._jobs[cron.name] = job
+        """Add a cron job to the scheduler."""
+        self._ensure_job_manager().add_job(cron)
 
     def remove_job(self, name: str) -> None:
-        """Remove a cron job by name.
-
-        Args:
-            name: The cron job name to remove.
-        """
-        if not self._scheduler:
-            raise RuntimeError("Scheduler not initialized. Call start() first.")
-
-        if name in self._jobs:
-            self._scheduler.remove_job(name)
-            del self._jobs[name]
-            logger.info(f"Removed cron job: {name}")
+        """Remove a cron job by name."""
+        self._ensure_job_manager().remove_job(name)
 
     def reload_cron(self, cron_def: CronDefinition) -> None:
-        """Remove the old job (if present) and re-add it from the updated definition.
-
-        Used by CronManagerBuiltin to apply in-place changes to YAML cron jobs
-        without requiring a workspace restart.
-
-        If the definition has ``enabled=False``, the job is removed and not
-        re-added, effectively pausing it.
-
-        Args:
-            cron_def: Updated cron definition to register.
-        """
-        if cron_def.name in self._jobs:
-            self.remove_job(cron_def.name)
-
-        if cron_def.enabled:
-            self.add_job(cron_def)
-            logger.info(f"Reloaded cron job: {cron_def.name} ({cron_def.schedule})")
-        else:
-            logger.info(f"Cron job '{cron_def.name}' is disabled — skipped re-registration")
+        """Remove the old job (if present) and re-add it from the updated definition."""
+        self._ensure_job_manager().reload_cron(cron_def)
 
     def remove_cron(self, name: str) -> None:
-        """Remove a YAML-defined cron job from the live scheduler.
-
-        Public wrapper around :meth:`remove_job` for use by CronManagerBuiltin.
-        Silently does nothing if the job is not currently registered (e.g., it
-        was disabled and never added to the APScheduler instance) or if the
-        scheduler has not been started yet.
-
-        Args:
-            name: The cron job name to remove.
-        """
-        if not self._scheduler or name not in self._jobs:
-            return
-        self.remove_job(name)
+        """Remove a YAML-defined cron job from the live scheduler."""
+        self._ensure_job_manager().remove_cron(name)
 
     def add_dynamic_job(self, task: DynamicCronTask) -> None:
-        """Add a dynamic task to the scheduler.
-
-        Args:
-            task: DynamicCronTask to schedule.
-        """
-        if not self._scheduler:
-            raise RuntimeError("Scheduler not initialized. Call start() first.")
-
-        if task.task_type == "once":
-            # Use DateTrigger for one-shot execution
-            trigger = DateTrigger(run_date=task.run_at)
-        else:
-            # Use IntervalTrigger for recurring execution
-            trigger = IntervalTrigger(seconds=task.interval_seconds)
-
-        job = self._scheduler.add_job(
-            func=self._execute_dynamic_task,
-            trigger=trigger,
-            args=[task],
-            id=f"dynamic_{task.id}",
-            name=f"Dynamic: {task.prompt[:30]}...",
-            replace_existing=True,
-        )
-
-        self._dynamic_jobs[task.id] = job
-        self._dynamic_store.add_task(task)  # Persist to disk
-        logger.info(f"Added dynamic task: {task.id} ({task.task_type})")
+        """Add a dynamic task to the scheduler."""
+        self._ensure_job_manager().add_dynamic_job(task)
 
     def remove_dynamic_job(self, task_id: str) -> bool:
-        """Remove a dynamic task from the scheduler.
-
-        Note: This method expects a full UUID (used internally). For prefix-based
-        cancellation, use the CronTool's cancel_scheduled which resolves prefixes
-        via DynamicCronStore before calling _remove_from_live_scheduler.
-
-        Args:
-            task_id: Full UUID of the task to remove.
-
-        Returns:
-            True if removed, False if not found.
-        """
-        if not self._scheduler:
-            raise RuntimeError("Scheduler not initialized. Call start() first.")
-
-        job_id = f"dynamic_{task_id}"
-        if task_id in self._dynamic_jobs:
-            self._scheduler.remove_job(job_id)
-            del self._dynamic_jobs[task_id]
-            self._dynamic_store.remove_task(task_id)
-            logger.info(f"Removed dynamic task: {task_id}")
-            return True
-
-        logger.warning(f"Dynamic task not found: {task_id}")
-        return False
+        """Remove a dynamic task from the scheduler."""
+        return self._ensure_job_manager().remove_dynamic_job(task_id)
 
     async def _execute_dynamic_task(self, task: DynamicCronTask) -> None:
-        """Execute a dynamic task.
-
-        For one-shot tasks: remove after execution.
-        For interval tasks: continue recurring.
-
-        Args:
-            task: DynamicCronTask to execute.
-        """
-        job_id = f"dynamic_{task.id}"
-        if job_id in self._running_jobs:
-            logger.warning(f"Skipping dynamic task {task.id}: previous execution still running")
-            return
-
-        self._running_jobs.add(job_id)
-
-        # Remove one-shot tasks from store before execution.
-        # APScheduler DateTrigger guarantees single fire, so this is safe.
-        # Prevents list_scheduled() from showing ghost entries during execution.
-        if task.task_type == "once":
-            self._dynamic_store.remove_task(task.id)
-            if task.id in self._dynamic_jobs:
-                del self._dynamic_jobs[task.id]
-
-        logger.info(f"Executing dynamic task: {task.id}")
-        set_invocation_origin(f"dynamic_cron:{task.id[:8]}")
-
-        # Set up channel context so send_message/send_file work during execution
-        if task.channel and task.chat_id:
-            dyn_channel = self.channels.get(task.channel)
-            if dyn_channel:
-                set_channel_context(dyn_channel, dyn_channel.build_session_key(task.chat_id))
-
-        try:
-            agent_runner = self.agent_factory()
-            start_time = time_module.monotonic()
-            response = await agent_runner.run(message=task.prompt)
-            duration_ms = (time_module.monotonic() - start_time) * 1000
-
-            # Write session log
-            session_path: str | None = None
-            if self._session_logger:
-                try:
-                    session_path = self._session_logger.write_session(
-                        name=f"dynamic_{task.id}",
-                        prompt=task.prompt,
-                        response=response,
-                        tools_used=agent_runner.last_tools_used or [],
-                        metrics=agent_runner.last_metrics,
-                        duration_ms=duration_ms,
-                    )
-                except Exception as e:
-                    logger.warning(f"Failed to write session log for dynamic task {task.id}: {e}")
-
-            # Log token usage for dynamic cron invocation
-            dyn_metrics = agent_runner.last_metrics
-            if self._token_logger and self._workspace_name and dyn_metrics:
-                self._token_logger.log(
-                    metrics=dyn_metrics,
-                    workspace=self._workspace_name,
-                    invocation_type="cron",
-                    session_key=None,
-                )
-
-            # Route response using task's stored routing info
-            if task.channel and task.chat_id:
-                channel = self.channels.get(task.channel)
-                if channel:
-                    # Guard against empty responses
-                    if response and response.strip():
-                        session_key = channel.build_session_key(task.chat_id)
-                        await channel.send_message(
-                            session_key=session_key,
-                            content=response,
-                        )
-                        logger.info(f"Dynamic task {task.id} response sent to {task.channel}:{task.chat_id}")
-                    else:
-                        logger.warning(f"Dynamic task {task.id} produced empty response, not sending")
-                else:
-                    logger.warning(f"Channel '{task.channel}' not found for dynamic task {task.id}")
-            else:
-                logger.warning(
-                    f"Dynamic task {task.id} has no routing config. "
-                    f"Response ({len(response) if response else 0} chars) not sent."
-                )
-
-            # Inject result into agent queue (dynamic tasks always notify the main agent)
-            if self._result_callback and session_path and task.channel and task.chat_id:
-                try:
-                    channel = self.channels.get(task.channel)
-                    if channel:
-                        session_key = channel.build_session_key(task.chat_id)
-                        output = response
-                        if len(output) > INJECTION_TRUNCATION_LIMIT:
-                            output = output[:INJECTION_TRUNCATION_LIMIT]
-                            injection_content = DYNAMIC_TASK_RESULT_TRUNCATED_TEMPLATE.format(
-                                task_id=task.id[:8],
-                                prompt_preview=task.prompt[:80],
-                                output=output,
-                                session_path=session_path,
-                            )
-                        else:
-                            injection_content = DYNAMIC_TASK_RESULT_TEMPLATE.format(
-                                task_id=task.id[:8],
-                                prompt_preview=task.prompt[:80],
-                                output=output,
-                                session_path=session_path,
-                            )
-                        await self._result_callback(session_key, injection_content)
-                        logger.info(f"Dynamic task {task.id} result injected into agent queue")
-                except Exception as e:
-                    logger.warning(f"Failed to inject dynamic task result for {task.id}: {e}")
-
-            self._log_cron_event(
-                cron_name=f"dynamic_{task.id[:8]}",
-                outcome="completed",
-                duration_ms=duration_ms,
-                input_tokens=dyn_metrics.input_tokens if dyn_metrics else None,
-                output_tokens=dyn_metrics.output_tokens if dyn_metrics else None,
-                total_tokens=dyn_metrics.total_tokens if dyn_metrics else None,
-                llm_calls=dyn_metrics.llm_calls if dyn_metrics else None,
-                session_path=session_path,
-                tools_used=agent_runner.last_tools_used or None,
-            )
-
-            logger.info(f"Dynamic task {task.id} completed successfully")
-
-        except Exception as e:
-            logger.error(f"Dynamic task {task.id} failed: {e}", exc_info=True)
-            self._log_cron_event(
-                cron_name=f"dynamic_{task.id[:8]}",
-                outcome="error",
-                error=str(e),
-            )
-        finally:
-            self._running_jobs.discard(job_id)
-            clear_channel_context()
+        """Execute a dynamic task."""
+        await self._executor.execute_dynamic_task(task)
 
     def _prune_expired_tasks(self, tasks: list[DynamicCronTask]) -> list[DynamicCronTask]:
-        """Remove expired one-time tasks that will never execute.
-
-        Args:
-            tasks: List of tasks to filter.
-
-        Returns:
-            List with expired one-time tasks removed.
-        """
-        now = datetime.now(UTC)
-        valid_tasks = []
-        pruned_count = 0
-
-        for task in tasks:
-            # One-time tasks with run_at in the past are expired
-            if task.task_type == "once" and task.run_at:
-                if task.run_at < now:
-                    self._dynamic_store.remove_task(task.id)
-                    pruned_count += 1
-                    continue
-
-            valid_tasks.append(task)
-
-        if pruned_count > 0:
-            logger.info(f"Pruned {pruned_count} expired one-time task(s)")
-
-        return valid_tasks
+        """Remove expired one-time tasks that will never execute."""
+        return self._ensure_job_manager()._prune_expired_tasks(tasks)
 
     def _schedule_dynamic_task(self, task: DynamicCronTask) -> None:
-        """Schedule a task that was loaded from storage.
-
-        Internal helper that schedules without re-persisting to storage.
-
-        Args:
-            task: DynamicCronTask to schedule.
-        """
-        if not self._scheduler:
-            raise RuntimeError("Scheduler not initialized. Call start() first.")
-
-        if task.task_type == "once":
-            # Use DateTrigger for one-shot execution
-            trigger = DateTrigger(run_date=task.run_at)
-        else:
-            # Use IntervalTrigger for recurring execution
-            trigger = IntervalTrigger(seconds=task.interval_seconds)
-
-        job = self._scheduler.add_job(
-            func=self._execute_dynamic_task,
-            trigger=trigger,
-            args=[task],
-            id=f"dynamic_{task.id}",
-            name=f"Dynamic: {task.prompt[:30]}...",
-            replace_existing=True,
-        )
-
-        self._dynamic_jobs[task.id] = job
+        """Schedule a task that was loaded from storage."""
+        self._ensure_job_manager()._schedule_dynamic_task(task)

--- a/openpaw/runtime/scheduling/cron_executor.py
+++ b/openpaw/runtime/scheduling/cron_executor.py
@@ -1,0 +1,420 @@
+"""Cron execution logic for OpenPaw."""
+
+import json
+import logging
+import time as time_module
+from collections.abc import Awaitable, Callable, Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from openpaw.agent.metrics import TokenUsageLogger
+from openpaw.agent.session_logger import SessionLogger
+from openpaw.builtins.tools._channel_context import (
+    clear_channel_context,
+    set_channel_context,
+    set_invocation_origin,
+)
+from openpaw.channels.base import ChannelAdapter
+from openpaw.core.config.models import CronDefinition, CronOutputConfig
+from openpaw.core.paths import CRON_LOG_JSONL
+from openpaw.core.prompts.system_events import (
+    CRON_RESULT_TEMPLATE,
+    CRON_RESULT_TRUNCATED_TEMPLATE,
+    DYNAMIC_TASK_RESULT_TEMPLATE,
+    DYNAMIC_TASK_RESULT_TRUNCATED_TEMPLATE,
+    INJECTION_TRUNCATION_LIMIT,
+)
+from openpaw.model.cron import DynamicCronTask
+from openpaw.stores.cron import DynamicCronStore
+
+logger = logging.getLogger(__name__)
+
+
+class CronExecutor:
+    """Executes cron jobs and dynamic tasks, handling logging and delivery."""
+
+    def __init__(
+        self,
+        workspace_path: Path,
+        agent_factory: Callable[..., Any],
+        channels: Mapping[str, ChannelAdapter],
+        workspace_name: str,
+        token_logger: TokenUsageLogger | None,
+        session_logger: SessionLogger | None,
+        result_callback: Callable[[str, str], Awaitable[None]] | None,
+        dynamic_store: DynamicCronStore,
+        dynamic_jobs: dict[str, Any],
+    ):
+        self.workspace_path = Path(workspace_path)
+        self.agent_factory = agent_factory
+        self.channels = channels
+        self._workspace_name = workspace_name
+        self._token_logger = token_logger
+        self._session_logger = session_logger
+        self._result_callback = result_callback
+        self._dynamic_store = dynamic_store
+        self._dynamic_jobs = dynamic_jobs
+        self._running_jobs: set[str] = set()
+
+    async def execute_cron(self, cron: CronDefinition) -> None:
+        """Execute a cron job.
+
+        Args:
+            cron: The cron definition to execute.
+        """
+        job_id = cron.name
+        if job_id in self._running_jobs:
+            logger.warning(f"Skipping cron job {cron.name}: previous execution still running")
+            return
+
+        self._running_jobs.add(job_id)
+        logger.info(f"Executing cron job: {cron.name}")
+        set_invocation_origin(f"cron:{cron.name}")
+
+        # Set up channel context so send_message/send_file work during cron execution
+        cron_channel = self.channels.get(cron.output.channel)
+        cron_session_key = self._resolve_session_key(cron_channel, cron.output) if cron_channel else None
+        if cron_channel and cron_session_key:
+            set_channel_context(cron_channel, cron_session_key)
+
+        try:
+            # Resolve max_output_tokens: per-cron definition takes precedence over
+            # the workspace-level default already baked into the factory's
+            # extra_model_kwargs. Passing it as extra_overrides lets the
+            # cron-specific cap win without mutating factory state.
+            extra_overrides: dict[str, Any] = {}
+            if cron.max_output_tokens is not None:
+                extra_overrides["max_tokens"] = cron.max_output_tokens
+
+            agent_runner = (
+                self.agent_factory(extra_overrides=extra_overrides)
+                if extra_overrides
+                else self.agent_factory()
+            )
+
+            start_time = time_module.monotonic()
+            response = await agent_runner.run(message=cron.prompt)
+            duration_ms = (time_module.monotonic() - start_time) * 1000
+
+            # Log a warning when the output cap was hit — response is likely truncated
+            cron_metrics_check = agent_runner.last_metrics
+            cron_cap = agent_runner.max_output_tokens
+            if (
+                isinstance(cron_cap, int)
+                and cron_metrics_check
+                and isinstance(cron_metrics_check.output_tokens, int)
+                and cron_metrics_check.output_tokens >= cron_cap
+            ):
+                logger.warning(
+                    f"Cron '{cron.name}' output token cap reached: "
+                    f"{cron_metrics_check.output_tokens}/{cron_cap} tokens "
+                    f"— response likely truncated (workspace: {self._workspace_name})"
+                )
+
+            # Write session log
+            session_path: str | None = None
+            if self._session_logger:
+                try:
+                    session_path = self._session_logger.write_session(
+                        name=cron.name,
+                        prompt=cron.prompt,
+                        response=response,
+                        tools_used=agent_runner.last_tools_used or [],
+                        metrics=agent_runner.last_metrics,
+                        duration_ms=duration_ms,
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to write cron session log for {cron.name}: {e}")
+
+            delivery = cron.output.delivery
+
+            # Channel delivery ("channel" or "both")
+            if delivery in ("channel", "both"):
+                channel = self.channels.get(cron.output.channel)
+                if not channel:
+                    logger.error(f"Channel not found for cron {cron.name}: {cron.output.channel}")
+                else:
+                    session_key = self._resolve_session_key(channel, cron.output)
+                    if session_key:
+                        await channel.send_message(session_key=session_key, content=response)
+                    else:
+                        logger.warning(f"Unsupported output config for cron {cron.name}: {cron.output}")
+
+            # Agent queue injection ("agent" or "both")
+            if delivery in ("agent", "both") and self._result_callback and session_path:
+                try:
+                    channel = self.channels.get(cron.output.channel)
+                    session_key = self._resolve_session_key(channel, cron.output) if channel else None
+                    if channel and session_key:
+                        output = response
+                        if len(output) > INJECTION_TRUNCATION_LIMIT:
+                            output = output[:INJECTION_TRUNCATION_LIMIT]
+                            injection_content = CRON_RESULT_TRUNCATED_TEMPLATE.format(
+                                cron_name=cron.name, output=output, session_path=session_path,
+                            )
+                        else:
+                            injection_content = CRON_RESULT_TEMPLATE.format(
+                                cron_name=cron.name, output=output, session_path=session_path,
+                            )
+                        await self._result_callback(session_key, injection_content)
+                        logger.info(f"Cron {cron.name} result injected into agent queue")
+                except Exception as e:
+                    logger.warning(f"Failed to inject cron result for {cron.name}: {e}")
+
+            # Log token usage for cron invocation
+            metrics = agent_runner.last_metrics
+            if self._token_logger and self._workspace_name and metrics:
+                self._token_logger.log(
+                    metrics=metrics,
+                    workspace=self._workspace_name,
+                    invocation_type="cron",
+                    session_key=None,
+                )
+
+            self.log_cron_event(
+                cron_name=cron.name,
+                outcome="completed",
+                duration_ms=duration_ms,
+                input_tokens=metrics.input_tokens if metrics else None,
+                output_tokens=metrics.output_tokens if metrics else None,
+                total_tokens=metrics.total_tokens if metrics else None,
+                llm_calls=metrics.llm_calls if metrics else None,
+                session_path=session_path,
+                delivery=delivery,
+                tools_used=agent_runner.last_tools_used or None,
+            )
+
+            logger.info(f"Cron job {cron.name} completed successfully")
+
+        except Exception as e:
+            logger.error(f"Failed to execute cron job {cron.name}: {e}", exc_info=True)
+            self.log_cron_event(
+                cron_name=cron.name,
+                outcome="error",
+                error=str(e),
+            )
+        finally:
+            self._running_jobs.discard(job_id)
+            clear_channel_context()
+
+    @staticmethod
+    def _resolve_session_key(channel: ChannelAdapter, output: CronOutputConfig) -> str | None:
+        """Resolve session key from cron output config.
+
+        Uses ``target_id`` (preferred) with fallback to legacy ``chat_id``/``channel_id``.
+
+        Args:
+            channel: The channel adapter instance to build the session key against.
+            output: The cron output config specifying channel name and target ID.
+
+        Returns:
+            A session key string, or None if no supported routing config is found.
+        """
+        target = next(
+            (v for v in (output.target_id, output.chat_id, output.channel_id) if v is not None),
+            None,
+        )
+        if target:
+            return channel.build_session_key(target)
+        return None
+
+    def log_cron_event(
+        self,
+        cron_name: str,
+        outcome: str,
+        duration_ms: float | None = None,
+        error: str | None = None,
+        input_tokens: int | None = None,
+        output_tokens: int | None = None,
+        total_tokens: int | None = None,
+        llm_calls: int | None = None,
+        session_path: str | None = None,
+        delivery: str | None = None,
+        tools_used: list[str] | None = None,
+    ) -> None:
+        """Append cron execution event to workspace JSONL log.
+
+        Args:
+            cron_name: Name of the cron job (or "dynamic_<id[:8]>" for dynamic tasks).
+            outcome: Execution outcome: "completed", "error", or "skipped".
+            duration_ms: Execution duration in milliseconds.
+            error: Error message if outcome is "error".
+            input_tokens: Input token count from the agent invocation.
+            output_tokens: Output token count from the agent invocation.
+            total_tokens: Total token count from the agent invocation.
+            llm_calls: Number of LLM calls made during execution.
+            session_path: Relative path to the session log file, if written.
+            delivery: Delivery mode used ("channel" or "agent").
+            tools_used: List of tool names invoked during execution.
+        """
+        log_path = self.workspace_path / str(CRON_LOG_JSONL)
+        event: dict[str, Any] = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "workspace": self._workspace_name,
+            "cron_name": cron_name,
+            "outcome": outcome,
+        }
+        if duration_ms is not None:
+            event["duration_ms"] = round(duration_ms, 1)
+        if error:
+            event["error"] = error
+        if input_tokens is not None:
+            event["input_tokens"] = input_tokens
+        if output_tokens is not None:
+            event["output_tokens"] = output_tokens
+        if total_tokens is not None:
+            event["total_tokens"] = total_tokens
+        if llm_calls is not None:
+            event["llm_calls"] = llm_calls
+        if session_path:
+            event["session_path"] = session_path
+        if delivery:
+            event["delivery"] = delivery
+        if tools_used:
+            event["tools_used"] = tools_used
+
+        try:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            with log_path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(event) + "\n")
+        except OSError as e:
+            logger.warning(f"Failed to write cron log: {e}")
+
+    async def execute_dynamic_task(self, task: DynamicCronTask) -> None:
+        """Execute a dynamic task.
+
+        For one-shot tasks: remove after execution.
+        For interval tasks: continue recurring.
+
+        Args:
+            task: DynamicCronTask to execute.
+        """
+        job_id = f"dynamic_{task.id}"
+        if job_id in self._running_jobs:
+            logger.warning(f"Skipping dynamic task {task.id}: previous execution still running")
+            return
+
+        self._running_jobs.add(job_id)
+
+        # Remove one-shot tasks from store before execution.
+        # APScheduler DateTrigger guarantees single fire, so this is safe.
+        # Prevents list_scheduled() from showing ghost entries during execution.
+        if task.task_type == "once":
+            self._dynamic_store.remove_task(task.id)
+            if task.id in self._dynamic_jobs:
+                del self._dynamic_jobs[task.id]
+
+        logger.info(f"Executing dynamic task: {task.id}")
+        set_invocation_origin(f"dynamic_cron:{task.id[:8]}")
+
+        # Set up channel context so send_message/send_file work during execution
+        if task.channel and task.chat_id:
+            dyn_channel = self.channels.get(task.channel)
+            if dyn_channel:
+                set_channel_context(dyn_channel, dyn_channel.build_session_key(task.chat_id))
+
+        try:
+            agent_runner = self.agent_factory()
+            start_time = time_module.monotonic()
+            response = await agent_runner.run(message=task.prompt)
+            duration_ms = (time_module.monotonic() - start_time) * 1000
+
+            # Write session log
+            session_path: str | None = None
+            if self._session_logger:
+                try:
+                    session_path = self._session_logger.write_session(
+                        name=f"dynamic_{task.id}",
+                        prompt=task.prompt,
+                        response=response,
+                        tools_used=agent_runner.last_tools_used or [],
+                        metrics=agent_runner.last_metrics,
+                        duration_ms=duration_ms,
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to write session log for dynamic task {task.id}: {e}")
+
+            # Log token usage for dynamic cron invocation
+            dyn_metrics = agent_runner.last_metrics
+            if self._token_logger and self._workspace_name and dyn_metrics:
+                self._token_logger.log(
+                    metrics=dyn_metrics,
+                    workspace=self._workspace_name,
+                    invocation_type="cron",
+                    session_key=None,
+                )
+
+            # Route response using task's stored routing info
+            if task.channel and task.chat_id:
+                channel = self.channels.get(task.channel)
+                if channel:
+                    # Guard against empty responses
+                    if response and response.strip():
+                        session_key = channel.build_session_key(task.chat_id)
+                        await channel.send_message(
+                            session_key=session_key,
+                            content=response,
+                        )
+                        logger.info(f"Dynamic task {task.id} response sent to {task.channel}:{task.chat_id}")
+                    else:
+                        logger.warning(f"Dynamic task {task.id} produced empty response, not sending")
+                else:
+                    logger.warning(f"Channel '{task.channel}' not found for dynamic task {task.id}")
+            else:
+                logger.warning(
+                    f"Dynamic task {task.id} has no routing config. "
+                    f"Response ({len(response) if response else 0} chars) not sent."
+                )
+
+            # Inject result into agent queue (dynamic tasks always notify the main agent)
+            if self._result_callback and session_path and task.channel and task.chat_id:
+                try:
+                    channel = self.channels.get(task.channel)
+                    if channel:
+                        session_key = channel.build_session_key(task.chat_id)
+                        output = response
+                        if len(output) > INJECTION_TRUNCATION_LIMIT:
+                            output = output[:INJECTION_TRUNCATION_LIMIT]
+                            injection_content = DYNAMIC_TASK_RESULT_TRUNCATED_TEMPLATE.format(
+                                task_id=task.id[:8],
+                                prompt_preview=task.prompt[:80],
+                                output=output,
+                                session_path=session_path,
+                            )
+                        else:
+                            injection_content = DYNAMIC_TASK_RESULT_TEMPLATE.format(
+                                task_id=task.id[:8],
+                                prompt_preview=task.prompt[:80],
+                                output=output,
+                                session_path=session_path,
+                            )
+                        await self._result_callback(session_key, injection_content)
+                        logger.info(f"Dynamic task {task.id} result injected into agent queue")
+                except Exception as e:
+                    logger.warning(f"Failed to inject dynamic task result for {task.id}: {e}")
+
+            self.log_cron_event(
+                cron_name=f"dynamic_{task.id[:8]}",
+                outcome="completed",
+                duration_ms=duration_ms,
+                input_tokens=dyn_metrics.input_tokens if dyn_metrics else None,
+                output_tokens=dyn_metrics.output_tokens if dyn_metrics else None,
+                total_tokens=dyn_metrics.total_tokens if dyn_metrics else None,
+                llm_calls=dyn_metrics.llm_calls if dyn_metrics else None,
+                session_path=session_path,
+                tools_used=agent_runner.last_tools_used or None,
+            )
+
+            logger.info(f"Dynamic task {task.id} completed successfully")
+
+        except Exception as e:
+            logger.error(f"Dynamic task {task.id} failed: {e}", exc_info=True)
+            self.log_cron_event(
+                cron_name=f"dynamic_{task.id[:8]}",
+                outcome="error",
+                error=str(e),
+            )
+        finally:
+            self._running_jobs.discard(job_id)
+            clear_channel_context()

--- a/openpaw/runtime/scheduling/cron_job_manager.py
+++ b/openpaw/runtime/scheduling/cron_job_manager.py
@@ -1,0 +1,228 @@
+"""Cron job management for OpenPaw."""
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+from openpaw.core.config.models import CronDefinition
+from openpaw.model.cron import DynamicCronTask
+from openpaw.stores.cron import DynamicCronStore
+
+logger = logging.getLogger(__name__)
+
+
+class CronJobManager:
+    """Manages APScheduler jobs for cron and dynamic task scheduling."""
+
+    def __init__(
+        self,
+        scheduler: AsyncIOScheduler | None,
+        tz: ZoneInfo,
+        dynamic_store: DynamicCronStore,
+        executor: Any,
+        jobs: dict[str, Any],
+        dynamic_jobs: dict[str, Any],
+    ):
+        self._scheduler = scheduler
+        self._tz = tz
+        self._dynamic_store = dynamic_store
+        self._executor = executor
+        self._jobs = jobs
+        self._dynamic_jobs = dynamic_jobs
+
+    def add_job(self, cron: CronDefinition) -> None:
+        """Add a cron job to the scheduler.
+
+        Args:
+            cron: The cron definition to schedule.
+        """
+        if not self._scheduler:
+            raise RuntimeError("Scheduler not initialized. Call start() first.")
+
+        from openpaw.runtime.scheduling.cron import CronTrigger  # type: ignore[attr-defined]
+        trigger = CronTrigger.from_crontab(cron.schedule, timezone=self._tz)
+
+        job = self._scheduler.add_job(
+            func=self._executor.execute_cron,
+            trigger=trigger,
+            args=[cron],
+            id=cron.name,
+            name=cron.name,
+            replace_existing=True,
+        )
+
+        self._jobs[cron.name] = job
+
+    def remove_job(self, name: str) -> None:
+        """Remove a cron job by name.
+
+        Args:
+            name: The cron job name to remove.
+        """
+        if not self._scheduler:
+            raise RuntimeError("Scheduler not initialized. Call start() first.")
+
+        if name in self._jobs:
+            self._scheduler.remove_job(name)
+            del self._jobs[name]
+            logger.info(f"Removed cron job: {name}")
+
+    def reload_cron(self, cron_def: CronDefinition) -> None:
+        """Remove the old job (if present) and re-add it from the updated definition.
+
+        Used by CronManagerBuiltin to apply in-place changes to YAML cron jobs
+        without requiring a workspace restart.
+
+        If the definition has ``enabled=False``, the job is removed and not
+        re-added, effectively pausing it.
+
+        Args:
+            cron_def: Updated cron definition to register.
+        """
+        if cron_def.name in self._jobs:
+            self.remove_job(cron_def.name)
+
+        if cron_def.enabled:
+            self.add_job(cron_def)
+            logger.info(f"Reloaded cron job: {cron_def.name} ({cron_def.schedule})")
+        else:
+            logger.info(f"Cron job '{cron_def.name}' is disabled — skipped re-registration")
+
+    def remove_cron(self, name: str) -> None:
+        """Remove a YAML-defined cron job from the live scheduler.
+
+        Public wrapper around :meth:`remove_job` for use by CronManagerBuiltin.
+        Silently does nothing if the job is not currently registered (e.g., it
+        was disabled and never added to the APScheduler instance) or if the
+        scheduler has not been started yet.
+
+        Args:
+            name: The cron job name to remove.
+        """
+        if not self._scheduler or name not in self._jobs:
+            return
+        self.remove_job(name)
+
+    def add_dynamic_job(self, task: DynamicCronTask) -> None:
+        """Add a dynamic task to the scheduler.
+
+        Args:
+            task: DynamicCronTask to schedule.
+        """
+        if not self._scheduler:
+            raise RuntimeError("Scheduler not initialized. Call start() first.")
+
+        from openpaw.runtime.scheduling.cron import (  # type: ignore[attr-defined]
+            DateTrigger,
+            IntervalTrigger,
+        )
+        if task.task_type == "once":
+            # Use DateTrigger for one-shot execution
+            trigger = DateTrigger(run_date=task.run_at)
+        else:
+            # Use IntervalTrigger for recurring execution
+            trigger = IntervalTrigger(seconds=task.interval_seconds)
+
+        job = self._scheduler.add_job(
+            func=self._executor.execute_dynamic_task,
+            trigger=trigger,
+            args=[task],
+            id=f"dynamic_{task.id}",
+            name=f"Dynamic: {task.prompt[:30]}...",
+            replace_existing=True,
+        )
+
+        self._dynamic_jobs[task.id] = job
+        self._dynamic_store.add_task(task)  # Persist to disk
+        logger.info(f"Added dynamic task: {task.id} ({task.task_type})")
+
+    def remove_dynamic_job(self, task_id: str) -> bool:
+        """Remove a dynamic task from the scheduler.
+
+        Note: This method expects a full UUID (used internally). For prefix-based
+        cancellation, use the CronTool's cancel_scheduled which resolves prefixes
+        via DynamicCronStore before calling _remove_from_live_scheduler.
+
+        Args:
+            task_id: Full UUID of the task to remove.
+
+        Returns:
+            True if removed, False if not found.
+        """
+        if not self._scheduler:
+            raise RuntimeError("Scheduler not initialized. Call start() first.")
+
+        job_id = f"dynamic_{task_id}"
+        if task_id in self._dynamic_jobs:
+            self._scheduler.remove_job(job_id)
+            del self._dynamic_jobs[task_id]
+            self._dynamic_store.remove_task(task_id)
+            logger.info(f"Removed dynamic task: {task_id}")
+            return True
+
+        logger.warning(f"Dynamic task not found: {task_id}")
+        return False
+
+    def _schedule_dynamic_task(self, task: DynamicCronTask) -> None:
+        """Schedule a task that was loaded from storage.
+
+        Internal helper that schedules without re-persisting to storage.
+
+        Args:
+            task: DynamicCronTask to schedule.
+        """
+        if not self._scheduler:
+            raise RuntimeError("Scheduler not initialized. Call start() first.")
+
+        from openpaw.runtime.scheduling.cron import (  # type: ignore[attr-defined]
+            DateTrigger,
+            IntervalTrigger,
+        )
+        if task.task_type == "once":
+            # Use DateTrigger for one-shot execution
+            trigger = DateTrigger(run_date=task.run_at)
+        else:
+            # Use IntervalTrigger for recurring execution
+            trigger = IntervalTrigger(seconds=task.interval_seconds)
+
+        job = self._scheduler.add_job(
+            func=self._executor.execute_dynamic_task,
+            trigger=trigger,
+            args=[task],
+            id=f"dynamic_{task.id}",
+            name=f"Dynamic: {task.prompt[:30]}...",
+            replace_existing=True,
+        )
+
+        self._dynamic_jobs[task.id] = job
+
+    def _prune_expired_tasks(self, tasks: list[DynamicCronTask]) -> list[DynamicCronTask]:
+        """Remove expired one-time tasks that will never execute.
+
+        Args:
+            tasks: List of tasks to filter.
+
+        Returns:
+            List with expired one-time tasks removed.
+        """
+        now = datetime.now(UTC)
+        valid_tasks = []
+        pruned_count = 0
+
+        for task in tasks:
+            # One-time tasks with run_at in the past are expired
+            if task.task_type == "once" and task.run_at:
+                if task.run_at < now:
+                    self._dynamic_store.remove_task(task.id)
+                    pruned_count += 1
+                    continue
+
+            valid_tasks.append(task)
+
+        if pruned_count > 0:
+            logger.info(f"Pruned {pruned_count} expired one-time task(s)")
+
+        return valid_tasks

--- a/openpaw/runtime/scheduling/heartbeat.py
+++ b/openpaw/runtime/scheduling/heartbeat.py
@@ -1,39 +1,20 @@
 """HeartbeatScheduler for periodic agent task evaluation."""
 
-import json
 import logging
 from collections.abc import Awaitable, Callable, Mapping
-from datetime import UTC, datetime, time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-import yaml
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 
 from openpaw.agent.session_logger import SessionLogger
-from openpaw.builtins.tools._channel_context import (
-    clear_channel_context,
-    set_channel_context,
-    set_invocation_origin,
-)
-from openpaw.channels.base import ChannelAdapter
 from openpaw.core.config import HeartbeatConfig
-from openpaw.core.paths import HEARTBEAT_LOG_JSONL, HEARTBEAT_MD, TASKS_YAML
-from openpaw.core.prompts.heartbeat import (
-    ACTIVE_TASKS_TEMPLATE,
-    HEARTBEAT_PROMPT,
-    build_task_summary,
-)
-from openpaw.core.prompts.system_events import (
-    HEARTBEAT_RESULT_TEMPLATE,
-    HEARTBEAT_RESULT_TRUNCATED_TEMPLATE,
-    INJECTION_TRUNCATION_LIMIT,
-)
+from openpaw.core.prompts.heartbeat import HEARTBEAT_PROMPT  # noqa: F401
 from openpaw.core.timezone import workspace_now
-
-if TYPE_CHECKING:
-    pass
+from openpaw.runtime.scheduling.heartbeat_executor import HeartbeatExecutor
+from openpaw.runtime.scheduling.heartbeat_preflight import HeartbeatPreflight
+from openpaw.runtime.scheduling.heartbeat_prompt import HeartbeatPromptBuilder
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +32,7 @@ class HeartbeatScheduler:
         workspace_name: str,
         workspace_path: Path,
         agent_factory: Callable[..., Any],
-        channels: Mapping[str, ChannelAdapter],
+        channels: Mapping[str, Any],
         config: HeartbeatConfig,
         timezone: str = "UTC",
         token_logger: Any | None = None,
@@ -59,22 +40,7 @@ class HeartbeatScheduler:
         session_logger: SessionLogger | None = None,
         ack_tool: Any | None = None,
     ):
-        """Initialize the heartbeat scheduler.
-
-        Args:
-            workspace_name: Name of the agent workspace.
-            workspace_path: Path to the workspace directory.
-            agent_factory: Factory function to create fresh agent instances (no checkpointer).
-            channels: Dictionary mapping channel types to channel instances for routing.
-            config: Heartbeat configuration settings.
-            timezone: IANA timezone identifier for workspace timezone (default: "UTC").
-            token_logger: Optional TokenUsageLogger for logging token metrics.
-            result_callback: Optional callback for queue injection of results.
-            session_logger: Optional SessionLogger for writing session logs.
-            ack_tool: Optional AcknowledgeTool instance for unified silence. When the
-                heartbeat agent calls acknowledge_event(), this takes precedence over
-                the HEARTBEAT_OK magic string.
-        """
+        """Initialize the heartbeat scheduler."""
         self.workspace_name = workspace_name
         self.workspace_path = workspace_path
         self.agent_factory = agent_factory
@@ -88,158 +54,49 @@ class HeartbeatScheduler:
         self._scheduler: AsyncIOScheduler | None = None
         self._job: Any = None
 
-        # Parse active hours at initialization
-        self._active_hours = self._parse_active_hours(config.active_hours)
+        self._preflight = HeartbeatPreflight(workspace_path, timezone)
+        self._prompt_builder = HeartbeatPromptBuilder()
+        self._active_hours = self._preflight.parse_active_hours(config.active_hours)
+        self._executor = HeartbeatExecutor(
+            workspace_path=workspace_path,
+            workspace_name=workspace_name,
+            config=config,
+            token_logger=token_logger,
+            result_callback=result_callback,
+            session_logger=session_logger,
+            ack_tool=ack_tool,
+        )
 
     @staticmethod
-    def _resolve_heartbeat_session_key(channel: ChannelAdapter, config: HeartbeatConfig) -> str | None:
-        """Resolve session key from heartbeat config.
+    def _resolve_heartbeat_session_key(channel: Any, config: HeartbeatConfig) -> str | None:
+        """Resolve session key from heartbeat config."""
+        return HeartbeatExecutor._resolve_heartbeat_session_key(channel, config)
 
-        Uses ``target_id`` (preferred) with fallback to legacy ``target_chat_id``/``target_channel_id``.
-
-        Args:
-            channel: The channel adapter instance to build the session key against.
-            config: The heartbeat configuration specifying channel name and target ID.
-
-        Returns:
-            A session key string, or None if no supported routing config is found.
-        """
-        target = next(
-            (v for v in (config.target_id, config.target_chat_id, config.target_channel_id) if v is not None),
-            None,
-        )
-        if target:
-            return channel.build_session_key(target)
-        return None
-
-    def _parse_active_hours(self, active_hours: str | None) -> tuple[time, time] | None:
-        """Parse active hours string like '08:00-22:00' into start/end times.
-
-        Args:
-            active_hours: String in format "HH:MM-HH:MM" or None.
-
-        Returns:
-            Tuple of (start_time, end_time) or None if always active.
-
-        Raises:
-            ValueError: If the format is invalid.
-        """
-        if not active_hours:
-            return None
-
-        try:
-            start_str, end_str = active_hours.split("-")
-            start_hour, start_min = map(int, start_str.strip().split(":"))
-            end_hour, end_min = map(int, end_str.strip().split(":"))
-
-            start_time = time(start_hour, start_min)
-            end_time = time(end_hour, end_min)
-
-            return (start_time, end_time)
-        except (ValueError, AttributeError) as e:
-            raise ValueError(f"Invalid active_hours format: {active_hours}. Expected 'HH:MM-HH:MM'") from e
+    def _parse_active_hours(self, active_hours: str | None) -> Any:
+        """Parse active hours string like '08:00-22:00' into start/end times."""
+        return self._preflight.parse_active_hours(active_hours)
 
     def _is_within_active_hours(self) -> bool:
-        """Check if current time is within active hours window.
-
-        Returns:
-            True if within active hours or if no active hours are set (always active).
-        """
-        if self._active_hours is None:
-            return True  # Always active if no hours specified
-
+        """Check if current time is within active hours window."""
         current_time = workspace_now(self._timezone).time()
-        start_time, end_time = self._active_hours
-
-        # Handle case where active hours span midnight
-        if start_time <= end_time:
-            # Normal case: 08:00-22:00
-            return start_time <= current_time <= end_time
-        else:
-            # Midnight span: 22:00-08:00
-            return current_time >= start_time or current_time <= end_time
+        return self._preflight.is_within_active_hours(self._active_hours, current_time)
 
     def _is_heartbeat_ok(self, response: str) -> bool:
-        """Check if response indicates no action needed.
-
-        Args:
-            response: Agent response text.
-
-        Returns:
-            True if response contains HEARTBEAT_OK (case-insensitive).
-        """
-        return "HEARTBEAT_OK" in response.upper()
+        """Check if response indicates no action needed."""
+        return self._preflight.is_heartbeat_ok(response)
 
     def _build_task_summary(self, tasks: list[dict[str, Any]]) -> str | None:
-        """Build a compact task summary from TASKS.yaml data.
-
-        Thin wrapper around build_task_summary from prompts.heartbeat.
-
-        Args:
-            tasks: List of task dictionaries (already filtered to active tasks).
-
-        Returns:
-            Formatted task summary string, or None if no tasks.
-        """
-        return build_task_summary(tasks)
+        """Build a compact task summary from TASKS.yaml data."""
+        return self._prompt_builder.build_task_summary(tasks)
 
     def _build_heartbeat_prompt(self, task_summary: str | None = None) -> str:
-        """Build the heartbeat prompt with current timestamp and optional task summary.
-
-        Args:
-            task_summary: Optional compact task summary to inject into the prompt.
-
-        Returns:
-            Formatted heartbeat prompt string.
-        """
+        """Build the heartbeat prompt with current timestamp and optional task summary."""
         timestamp = workspace_now(self._timezone).isoformat()
-        prompt = HEARTBEAT_PROMPT.format(timestamp=timestamp)
-
-        if task_summary:
-            prompt += "\n" + ACTIVE_TASKS_TEMPLATE.format(task_summary=task_summary)
-
-        return prompt
+        return self._prompt_builder.build_heartbeat_prompt(timestamp, task_summary)
 
     def _should_skip_heartbeat(self) -> tuple[bool, str, str | None, int]:
-        """Pre-flight check: skip heartbeat if nothing needs attention.
-
-        Checks HEARTBEAT.md and TASKS.yaml to determine if LLM invocation
-        can be skipped, saving API costs for idle workspaces.
-
-        Returns:
-            Tuple of (should_skip, reason, task_summary, task_count).
-            task_summary is None if skipping or no active tasks, otherwise a formatted string.
-            task_count is the number of active tasks found (0 if none or on error).
-        """
-        heartbeat_md = self.workspace_path / str(HEARTBEAT_MD)
-        heartbeat_empty = True
-        if heartbeat_md.exists():
-            try:
-                content = heartbeat_md.read_text().strip()
-                heartbeat_empty = not content or content == "# Heartbeat" or len(content) < 20
-            except OSError:
-                heartbeat_empty = False  # Can't read = don't skip
-
-        tasks_file = self.workspace_path / str(TASKS_YAML)
-        active_tasks = []
-        if tasks_file.exists():
-            try:
-                with tasks_file.open() as f:
-                    data = yaml.safe_load(f)
-                tasks = data.get("tasks", []) if data else []
-                active_statuses = {"pending", "in_progress", "awaiting_check"}
-                active_tasks = [t for t in tasks if t.get("status") in active_statuses]
-            except (yaml.YAMLError, OSError) as e:
-                logger.warning(f"Failed to read TASKS.yaml during pre-flight: {e}")
-                # Can't read = don't skip, but no task summary
-                return False, "pre-flight checks passed (TASKS.yaml read error)", None, 0
-
-        if heartbeat_empty and not active_tasks:
-            return True, "no active tasks and HEARTBEAT.md is empty", None, 0
-
-        # Build task summary if we're not skipping and have active tasks
-        task_summary = self._build_task_summary(active_tasks) if active_tasks else None
-        return False, "pre-flight checks passed", task_summary, len(active_tasks)
+        """Pre-flight check: skip heartbeat if nothing needs attention."""
+        return self._preflight.should_skip_heartbeat()
 
     def _record_heartbeat_event(
         self,
@@ -255,53 +112,20 @@ class HeartbeatScheduler:
         response: str | None = None,
         tools_used: list[str] | None = None,
     ) -> None:
-        """Append heartbeat event to workspace JSONL log.
-
-        Args:
-            outcome: Event outcome (ran, skipped, heartbeat_ok, error).
-            reason: Reason for skip or additional context.
-            duration_ms: Execution duration in milliseconds.
-            error: Error message if applicable.
-            input_tokens: Input token count from invocation.
-            output_tokens: Output token count from invocation.
-            total_tokens: Total token count from invocation.
-            llm_calls: Number of LLM calls made.
-            task_count: Number of active tasks when heartbeat ran.
-            response: Full agent response text.
-            tools_used: List of tool names invoked during the heartbeat.
-        """
-        log_path = self.workspace_path / str(HEARTBEAT_LOG_JSONL)
-        event: dict[str, Any] = {
-            "timestamp": datetime.now(UTC).isoformat(),
-            "workspace": self.workspace_name,
-            "outcome": outcome,
-        }
-        if reason:
-            event["reason"] = reason
-        if duration_ms is not None:
-            event["duration_ms"] = round(duration_ms, 1)
-        if error:
-            event["error"] = error
-        if input_tokens is not None:
-            event["input_tokens"] = input_tokens
-        if output_tokens is not None:
-            event["output_tokens"] = output_tokens
-        if total_tokens is not None:
-            event["total_tokens"] = total_tokens
-        if llm_calls is not None:
-            event["llm_calls"] = llm_calls
-        if task_count is not None:
-            event["task_count"] = task_count
-        if tools_used:
-            event["tools_used"] = tools_used
-        if response:
-            event["response"] = response
-
-        try:
-            with log_path.open("a", encoding="utf-8") as f:
-                f.write(json.dumps(event) + "\n")
-        except OSError as e:
-            logger.warning(f"Failed to write heartbeat log: {e}")
+        """Append heartbeat event to workspace JSONL log."""
+        self._executor.record_heartbeat_event(
+            outcome=outcome,
+            reason=reason,
+            duration_ms=duration_ms,
+            error=error,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=total_tokens,
+            llm_calls=llm_calls,
+            task_count=task_count,
+            response=response,
+            tools_used=tools_used,
+        )
 
     async def start(self) -> None:
         """Start the heartbeat scheduler with interval trigger."""
@@ -338,15 +162,13 @@ class HeartbeatScheduler:
 
     async def _run_heartbeat(self) -> None:
         """Execute a heartbeat check with pre-flight skip and event logging."""
-        import time as time_module
-
         # Check active hours
         if not self._is_within_active_hours():
             logger.debug(
                 f"Heartbeat skipped for '{self.workspace_name}' "
                 f"(outside active hours: {self.config.active_hours})"
             )
-            self._record_heartbeat_event("skipped", reason="outside active hours")
+            self._executor.record_heartbeat_event("skipped", reason="outside active hours")
             return
 
         # Pre-flight check (returns task count alongside summary)
@@ -354,254 +176,15 @@ class HeartbeatScheduler:
 
         if should_skip:
             logger.info(f"Heartbeat skipped for '{self.workspace_name}': {reason}")
-            self._record_heartbeat_event("skipped", reason=reason, task_count=0)
+            self._executor.record_heartbeat_event("skipped", reason=reason, task_count=0)
             return
 
-        logger.info(f"Running heartbeat check for workspace: {self.workspace_name}")
-        set_invocation_origin(f"heartbeat:{self.workspace_name}")
-
-        # Set up channel context so send_message/send_file work during heartbeat execution
-        heartbeat_channel = self.channels.get(self.config.target_channel)
-        heartbeat_session_key = (
-            self._resolve_heartbeat_session_key(heartbeat_channel, self.config)
-            if heartbeat_channel
-            else None
+        await self._executor.run_heartbeat(
+            preflight=self._preflight,
+            prompt_builder=self._prompt_builder,
+            timezone=self._timezone,
+            task_summary=task_summary,
+            task_count=task_count,
+            agent_factory=self.agent_factory,
+            channels=self.channels,
         )
-        if heartbeat_channel and heartbeat_session_key:
-            set_channel_context(heartbeat_channel, heartbeat_session_key)
-
-        start_time = time_module.monotonic()
-
-        try:
-            # Resolve max_output_tokens: heartbeat config takes precedence over
-            # the workspace-level default already baked into the factory's
-            # extra_model_kwargs. Passing it here as extra_overrides lets the
-            # heartbeat-specific cap win.
-            extra_overrides: dict[str, Any] = {}
-            if self.config.max_output_tokens is not None:
-                extra_overrides["max_tokens"] = self.config.max_output_tokens
-
-            agent_runner = (
-                self.agent_factory(extra_overrides=extra_overrides)
-                if extra_overrides
-                else self.agent_factory()
-            )
-            heartbeat_prompt = self._build_heartbeat_prompt(task_summary=task_summary)
-            response = await agent_runner.run(message=heartbeat_prompt)
-            duration_ms = (time_module.monotonic() - start_time) * 1000
-
-            # Extract metrics and activity from agent runner
-            metrics = agent_runner.last_metrics
-
-            # Log a warning when the output cap was hit — response is likely truncated
-            cap = agent_runner.max_output_tokens
-            if isinstance(cap, int) and metrics and isinstance(metrics.output_tokens, int):
-                if metrics.output_tokens >= cap:
-                    logger.warning(
-                        f"Heartbeat output token cap reached: "
-                        f"{metrics.output_tokens}/{cap} tokens "
-                        f"— response likely truncated (workspace: {self.workspace_name})"
-                    )
-            input_tokens = metrics.input_tokens if metrics else None
-            output_tokens = metrics.output_tokens if metrics else None
-            total_tokens = metrics.total_tokens if metrics else None
-            llm_calls = metrics.llm_calls if metrics else None
-            tools_used = agent_runner.last_tools_used or None
-
-            # Write session log (for all outcomes - audit trail)
-            session_path: str | None = None
-            if self._session_logger:
-                try:
-                    session_path = self._session_logger.write_session(
-                        name="heartbeat",
-                        prompt=heartbeat_prompt,
-                        response=response,
-                        tools_used=agent_runner.last_tools_used or [],
-                        metrics=agent_runner.last_metrics,
-                        duration_ms=duration_ms,
-                    )
-                except Exception as e:
-                    logger.warning(f"Failed to write heartbeat session log: {e}")
-
-            # Check for acknowledge_event tool call (takes precedence over HEARTBEAT_OK)
-            if self._ack_tool:
-                ack = self._ack_tool.get_pending_ack()
-                if ack:
-                    logger.info(
-                        f"Heartbeat acknowledged for '{self.workspace_name}': {ack.reason}"
-                    )
-                    self._record_heartbeat_event(
-                        "acknowledged",
-                        reason=ack.reason,
-                        duration_ms=duration_ms,
-                        input_tokens=input_tokens,
-                        output_tokens=output_tokens,
-                        total_tokens=total_tokens,
-                        llm_calls=llm_calls,
-                        task_count=task_count,
-                        response=response,
-                        tools_used=tools_used,
-                    )
-                    if self._token_logger and metrics:
-                        self._token_logger.log(
-                            metrics=metrics,
-                            workspace=self.workspace_name,
-                            invocation_type="heartbeat",
-                            session_key=None,
-                        )
-                    return
-
-            if self.config.suppress_ok and self._is_heartbeat_ok(response):
-                logger.debug(f"Heartbeat OK for workspace: {self.workspace_name} (suppressed)")
-                self._record_heartbeat_event(
-                    "heartbeat_ok",
-                    duration_ms=duration_ms,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    total_tokens=total_tokens,
-                    llm_calls=llm_calls,
-                    task_count=task_count,
-                    response=response,
-                    tools_used=tools_used,
-                )
-
-                # Log to token_usage.jsonl if available
-                if self._token_logger and metrics:
-                    self._token_logger.log(
-                        metrics=metrics,
-                        workspace=self.workspace_name,
-                        invocation_type="heartbeat",
-                        session_key=None,
-                    )
-                return
-
-            if not heartbeat_channel:
-                logger.error(
-                    f"Heartbeat channel not found: {self.config.target_channel} "
-                    f"(workspace: {self.workspace_name})"
-                )
-                self._record_heartbeat_event(
-                    "error",
-                    error="channel not found",
-                    duration_ms=duration_ms,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    total_tokens=total_tokens,
-                    llm_calls=llm_calls,
-                    task_count=task_count,
-                    response=response,
-                    tools_used=tools_used,
-                )
-
-                # Log to token_usage.jsonl even on error
-                if self._token_logger and metrics:
-                    self._token_logger.log(
-                        metrics=metrics,
-                        workspace=self.workspace_name,
-                        invocation_type="heartbeat",
-                        session_key=None,
-                    )
-                return
-
-            if heartbeat_session_key:
-                # Delivery routing
-                delivery = self.config.delivery
-
-                # Channel delivery ("channel" or "both")
-                if delivery in ("channel", "both"):
-                    await heartbeat_channel.send_message(session_key=heartbeat_session_key, content=response)
-                    logger.info(f"Heartbeat notification sent to {self.config.target_channel}/{heartbeat_session_key}")
-
-                # Agent queue injection ("agent" or "both")
-                if delivery in ("agent", "both") and self._result_callback and session_path:
-                    try:
-                        # Build injection content with truncation
-                        output = response
-                        if len(output) > INJECTION_TRUNCATION_LIMIT:
-                            output = output[:INJECTION_TRUNCATION_LIMIT]
-                            injection_content = HEARTBEAT_RESULT_TRUNCATED_TEMPLATE.format(
-                                output=output, session_path=session_path,
-                            )
-                        else:
-                            injection_content = HEARTBEAT_RESULT_TEMPLATE.format(
-                                output=output, session_path=session_path,
-                            )
-                        await self._result_callback(heartbeat_session_key, injection_content)
-                        logger.info(f"Heartbeat result injected into agent queue for {heartbeat_session_key}")
-                    except Exception as e:
-                        logger.warning(f"Failed to inject heartbeat result: {e}")
-
-                self._record_heartbeat_event(
-                    "ran",
-                    duration_ms=duration_ms,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    total_tokens=total_tokens,
-                    llm_calls=llm_calls,
-                    task_count=task_count,
-                    response=response,
-                    tools_used=tools_used,
-                )
-
-                # Log to token_usage.jsonl
-                if self._token_logger and metrics:
-                    self._token_logger.log(
-                        metrics=metrics,
-                        workspace=self.workspace_name,
-                        invocation_type="heartbeat",
-                        session_key=heartbeat_session_key,
-                    )
-            else:
-                # No routing configured (no target ID or unsupported channel)
-                delivery = self.config.delivery
-                if delivery in ("agent", "both") and self._result_callback:
-                    logger.warning(
-                        f"Heartbeat delivery configured for agent injection but no session_key available "
-                        f"(workspace: {self.workspace_name}, delivery: {delivery})"
-                    )
-                else:
-                    logger.warning(
-                        f"Heartbeat response generated but no routing configured "
-                        f"(workspace: {self.workspace_name}, response length: {len(response)})"
-                    )
-
-                self._record_heartbeat_event(
-                    "ran",
-                    reason="no routing configured",
-                    duration_ms=duration_ms,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    total_tokens=total_tokens,
-                    llm_calls=llm_calls,
-                    task_count=task_count,
-                    response=response,
-                    tools_used=tools_used,
-                )
-
-                # Log to token_usage.jsonl
-                if self._token_logger and metrics:
-                    self._token_logger.log(
-                        metrics=metrics,
-                        workspace=self.workspace_name,
-                        invocation_type="heartbeat",
-                        session_key=None,
-                    )
-
-        except Exception as e:
-            duration_ms = (time_module.monotonic() - start_time) * 1000
-            logger.error(
-                f"Heartbeat check failed for workspace '{self.workspace_name}': {e}",
-                exc_info=True,
-            )
-            self._record_heartbeat_event(
-                "error",
-                error=str(e),
-                duration_ms=duration_ms,
-                task_count=task_count,
-            )
-        finally:
-            clear_channel_context()
-            # Clear any stale acknowledge state so a failed run cannot bleed
-            # into the next heartbeat cycle.
-            if self._ack_tool:
-                self._ack_tool.reset()

--- a/openpaw/runtime/scheduling/heartbeat_executor.py
+++ b/openpaw/runtime/scheduling/heartbeat_executor.py
@@ -1,0 +1,405 @@
+"""Heartbeat execution logic for OpenPaw."""
+
+import json
+import logging
+from collections.abc import Awaitable, Callable, Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from openpaw.agent.session_logger import SessionLogger
+from openpaw.builtins.tools._channel_context import (
+    clear_channel_context,
+    set_channel_context,
+    set_invocation_origin,
+)
+from openpaw.channels.base import ChannelAdapter
+from openpaw.core.config import HeartbeatConfig
+from openpaw.core.paths import HEARTBEAT_LOG_JSONL
+from openpaw.core.prompts.system_events import (
+    HEARTBEAT_RESULT_TEMPLATE,
+    HEARTBEAT_RESULT_TRUNCATED_TEMPLATE,
+    INJECTION_TRUNCATION_LIMIT,
+)
+from openpaw.core.timezone import workspace_now
+
+logger = logging.getLogger(__name__)
+
+
+class HeartbeatExecutor:
+    """Executes heartbeat checks and records events."""
+
+    def __init__(
+        self,
+        workspace_path: Path,
+        workspace_name: str,
+        config: HeartbeatConfig,
+        token_logger: Any | None,
+        result_callback: Callable[[str, str], Awaitable[None]] | None,
+        session_logger: SessionLogger | None,
+        ack_tool: Any | None,
+    ):
+        self.workspace_path = workspace_path
+        self.workspace_name = workspace_name
+        self.config = config
+        self._token_logger = token_logger
+        self._result_callback = result_callback
+        self._session_logger = session_logger
+        self._ack_tool = ack_tool
+
+    async def run_heartbeat(
+        self,
+        preflight: Any,
+        prompt_builder: Any,
+        timezone: str,
+        task_summary: str | None,
+        task_count: int,
+        agent_factory: Callable[..., Any],
+        channels: Mapping[str, Any],
+    ) -> None:
+        """Execute a heartbeat check with full delivery and logging logic.
+
+        Args:
+            preflight: HeartbeatPreflight instance for pre-flight checks.
+            prompt_builder: HeartbeatPromptBuilder instance for prompt construction.
+            timezone: Workspace timezone string.
+            task_summary: Optional task summary string.
+            task_count: Number of active tasks.
+            agent_factory: Factory function to create fresh agent instances.
+            channels: Dictionary mapping channel types to channel instances.
+        """
+        import time as time_module
+
+        logger.info(f"Running heartbeat check for workspace: {self.workspace_name}")
+        set_invocation_origin(f"heartbeat:{self.workspace_name}")
+
+        # Set up channel context so send_message/send_file work during heartbeat execution
+        heartbeat_channel = channels.get(self.config.target_channel)
+        heartbeat_session_key = (
+            self._resolve_heartbeat_session_key(heartbeat_channel, self.config)
+            if heartbeat_channel
+            else None
+        )
+        if heartbeat_channel and heartbeat_session_key:
+            set_channel_context(heartbeat_channel, heartbeat_session_key)
+
+        start_time = time_module.monotonic()
+
+        try:
+            # Resolve max_output_tokens: heartbeat config takes precedence over
+            # the workspace-level default already baked into the factory's
+            # extra_model_kwargs. Passing it here as extra_overrides lets the
+            # heartbeat-specific cap win.
+            extra_overrides: dict[str, Any] = {}
+            if self.config.max_output_tokens is not None:
+                extra_overrides["max_tokens"] = self.config.max_output_tokens
+
+            agent_runner = (
+                agent_factory(extra_overrides=extra_overrides)
+                if extra_overrides
+                else agent_factory()
+            )
+            heartbeat_prompt = prompt_builder.build_heartbeat_prompt(
+                workspace_now(timezone).isoformat(), task_summary
+            )
+            response = await agent_runner.run(message=heartbeat_prompt)
+            duration_ms = (time_module.monotonic() - start_time) * 1000
+
+            # Extract metrics and activity from agent runner
+            metrics = agent_runner.last_metrics
+
+            # Log a warning when the output cap was hit — response is likely truncated
+            cap = agent_runner.max_output_tokens
+            if isinstance(cap, int) and metrics and isinstance(metrics.output_tokens, int):
+                if metrics.output_tokens >= cap:
+                    logger.warning(
+                        f"Heartbeat output token cap reached: "
+                        f"{metrics.output_tokens}/{cap} tokens "
+                        f"— response likely truncated (workspace: {self.workspace_name})"
+                    )
+            input_tokens = metrics.input_tokens if metrics else None
+            output_tokens = metrics.output_tokens if metrics else None
+            total_tokens = metrics.total_tokens if metrics else None
+            llm_calls = metrics.llm_calls if metrics else None
+            tools_used = agent_runner.last_tools_used or None
+
+            # Write session log (for all outcomes - audit trail)
+            session_path: str | None = None
+            if self._session_logger:
+                try:
+                    session_path = self._session_logger.write_session(
+                        name="heartbeat",
+                        prompt=heartbeat_prompt,
+                        response=response,
+                        tools_used=agent_runner.last_tools_used or [],
+                        metrics=agent_runner.last_metrics,
+                        duration_ms=duration_ms,
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to write heartbeat session log: {e}")
+
+            # Check for acknowledge_event tool call (takes precedence over HEARTBEAT_OK)
+            if self._ack_tool:
+                ack = self._ack_tool.get_pending_ack()
+                if ack:
+                    logger.info(
+                        f"Heartbeat acknowledged for '{self.workspace_name}': {ack.reason}"
+                    )
+                    self.record_heartbeat_event(
+                        "acknowledged",
+                        reason=ack.reason,
+                        duration_ms=duration_ms,
+                        input_tokens=input_tokens,
+                        output_tokens=output_tokens,
+                        total_tokens=total_tokens,
+                        llm_calls=llm_calls,
+                        task_count=task_count,
+                        response=response,
+                        tools_used=tools_used,
+                    )
+                    if self._token_logger and metrics:
+                        self._token_logger.log(
+                            metrics=metrics,
+                            workspace=self.workspace_name,
+                            invocation_type="heartbeat",
+                            session_key=None,
+                        )
+                    return
+
+            if self.config.suppress_ok and preflight.is_heartbeat_ok(response):
+                logger.debug(f"Heartbeat OK for workspace: {self.workspace_name} (suppressed)")
+                self.record_heartbeat_event(
+                    "heartbeat_ok",
+                    duration_ms=duration_ms,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    total_tokens=total_tokens,
+                    llm_calls=llm_calls,
+                    task_count=task_count,
+                    response=response,
+                    tools_used=tools_used,
+                )
+
+                # Log to token_usage.jsonl if available
+                if self._token_logger and metrics:
+                    self._token_logger.log(
+                        metrics=metrics,
+                        workspace=self.workspace_name,
+                        invocation_type="heartbeat",
+                        session_key=None,
+                    )
+                return
+
+            if not heartbeat_channel:
+                logger.error(
+                    f"Heartbeat channel not found: {self.config.target_channel} "
+                    f"(workspace: {self.workspace_name})"
+                )
+                self.record_heartbeat_event(
+                    "error",
+                    error="channel not found",
+                    duration_ms=duration_ms,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    total_tokens=total_tokens,
+                    llm_calls=llm_calls,
+                    task_count=task_count,
+                    response=response,
+                    tools_used=tools_used,
+                )
+
+                # Log to token_usage.jsonl even on error
+                if self._token_logger and metrics:
+                    self._token_logger.log(
+                        metrics=metrics,
+                        workspace=self.workspace_name,
+                        invocation_type="heartbeat",
+                        session_key=None,
+                    )
+                return
+
+            if heartbeat_session_key:
+                # Delivery routing
+                delivery = self.config.delivery
+
+                # Channel delivery ("channel" or "both")
+                if delivery in ("channel", "both"):
+                    await heartbeat_channel.send_message(session_key=heartbeat_session_key, content=response)
+                    logger.info(f"Heartbeat notification sent to {self.config.target_channel}/{heartbeat_session_key}")
+
+                # Agent queue injection ("agent" or "both")
+                if delivery in ("agent", "both") and self._result_callback and session_path:
+                    try:
+                        # Build injection content with truncation
+                        output = response
+                        if len(output) > INJECTION_TRUNCATION_LIMIT:
+                            output = output[:INJECTION_TRUNCATION_LIMIT]
+                            injection_content = HEARTBEAT_RESULT_TRUNCATED_TEMPLATE.format(
+                                output=output, session_path=session_path,
+                            )
+                        else:
+                            injection_content = HEARTBEAT_RESULT_TEMPLATE.format(
+                                output=output, session_path=session_path,
+                            )
+                        await self._result_callback(heartbeat_session_key, injection_content)
+                        logger.info(f"Heartbeat result injected into agent queue for {heartbeat_session_key}")
+                    except Exception as e:
+                        logger.warning(f"Failed to inject heartbeat result: {e}")
+
+                self.record_heartbeat_event(
+                    "ran",
+                    duration_ms=duration_ms,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    total_tokens=total_tokens,
+                    llm_calls=llm_calls,
+                    task_count=task_count,
+                    response=response,
+                    tools_used=tools_used,
+                )
+
+                # Log to token_usage.jsonl
+                if self._token_logger and metrics:
+                    self._token_logger.log(
+                        metrics=metrics,
+                        workspace=self.workspace_name,
+                        invocation_type="heartbeat",
+                        session_key=heartbeat_session_key,
+                    )
+            else:
+                # No routing configured (no target ID or unsupported channel)
+                delivery = self.config.delivery
+                if delivery in ("agent", "both") and self._result_callback:
+                    logger.warning(
+                        f"Heartbeat delivery configured for agent injection but no session_key available "
+                        f"(workspace: {self.workspace_name}, delivery: {delivery})"
+                    )
+                else:
+                    logger.warning(
+                        f"Heartbeat response generated but no routing configured "
+                        f"(workspace: {self.workspace_name}, response length: {len(response)})"
+                    )
+
+                self.record_heartbeat_event(
+                    "ran",
+                    reason="no routing configured",
+                    duration_ms=duration_ms,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    total_tokens=total_tokens,
+                    llm_calls=llm_calls,
+                    task_count=task_count,
+                    response=response,
+                    tools_used=tools_used,
+                )
+
+                # Log to token_usage.jsonl
+                if self._token_logger and metrics:
+                    self._token_logger.log(
+                        metrics=metrics,
+                        workspace=self.workspace_name,
+                        invocation_type="heartbeat",
+                        session_key=None,
+                    )
+
+        except Exception as e:
+            duration_ms = (time_module.monotonic() - start_time) * 1000
+            logger.error(
+                f"Heartbeat check failed for workspace '{self.workspace_name}': {e}",
+                exc_info=True,
+            )
+            self.record_heartbeat_event(
+                "error",
+                error=str(e),
+                duration_ms=duration_ms,
+                task_count=task_count,
+            )
+        finally:
+            clear_channel_context()
+            # Clear any stale acknowledge state so a failed run cannot bleed
+            # into the next heartbeat cycle.
+            if self._ack_tool:
+                self._ack_tool.reset()
+
+    def record_heartbeat_event(
+        self,
+        outcome: str,
+        reason: str | None = None,
+        duration_ms: float | None = None,
+        error: str | None = None,
+        input_tokens: int | None = None,
+        output_tokens: int | None = None,
+        total_tokens: int | None = None,
+        llm_calls: int | None = None,
+        task_count: int | None = None,
+        response: str | None = None,
+        tools_used: list[str] | None = None,
+    ) -> None:
+        """Append heartbeat event to workspace JSONL log.
+
+        Args:
+            outcome: Event outcome (ran, skipped, heartbeat_ok, error).
+            reason: Reason for skip or additional context.
+            duration_ms: Execution duration in milliseconds.
+            error: Error message if applicable.
+            input_tokens: Input token count from invocation.
+            output_tokens: Output token count from invocation.
+            total_tokens: Total token count from invocation.
+            llm_calls: Number of LLM calls made.
+            task_count: Number of active tasks when heartbeat ran.
+            response: Full agent response text.
+            tools_used: List of tool names invoked during the heartbeat.
+        """
+        log_path = self.workspace_path / str(HEARTBEAT_LOG_JSONL)
+        event: dict[str, Any] = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "workspace": self.workspace_name,
+            "outcome": outcome,
+        }
+        if reason:
+            event["reason"] = reason
+        if duration_ms is not None:
+            event["duration_ms"] = round(duration_ms, 1)
+        if error:
+            event["error"] = error
+        if input_tokens is not None:
+            event["input_tokens"] = input_tokens
+        if output_tokens is not None:
+            event["output_tokens"] = output_tokens
+        if total_tokens is not None:
+            event["total_tokens"] = total_tokens
+        if llm_calls is not None:
+            event["llm_calls"] = llm_calls
+        if task_count is not None:
+            event["task_count"] = task_count
+        if tools_used:
+            event["tools_used"] = tools_used
+        if response:
+            event["response"] = response
+
+        try:
+            with log_path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(event) + "\n")
+        except OSError as e:
+            logger.warning(f"Failed to write heartbeat log: {e}")
+
+    @staticmethod
+    def _resolve_heartbeat_session_key(channel: ChannelAdapter, config: HeartbeatConfig) -> str | None:
+        """Resolve session key from heartbeat config.
+
+        Uses ``target_id`` (preferred) with fallback to legacy ``target_chat_id``/``target_channel_id``.
+
+        Args:
+            channel: The channel adapter instance to build the session key against.
+            config: The heartbeat configuration specifying channel name and target ID.
+
+        Returns:
+            A session key string, or None if no supported routing config is found.
+        """
+        target = next(
+            (v for v in (config.target_id, config.target_chat_id, config.target_channel_id) if v is not None),
+            None,
+        )
+        if target:
+            return channel.build_session_key(target)
+        return None

--- a/openpaw/runtime/scheduling/heartbeat_preflight.py
+++ b/openpaw/runtime/scheduling/heartbeat_preflight.py
@@ -1,0 +1,127 @@
+"""Heartbeat preflight checks for OpenPaw."""
+
+import logging
+from datetime import time
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+from openpaw.core.paths import HEARTBEAT_MD, TASKS_YAML
+from openpaw.core.prompts.heartbeat import build_task_summary
+
+logger = logging.getLogger(__name__)
+
+
+class HeartbeatPreflight:
+    """Pre-flight checks to determine if a heartbeat should be skipped."""
+
+    def __init__(self, workspace_path: Path, timezone: str):
+        self.workspace_path = workspace_path
+        self.timezone = timezone
+
+    @staticmethod
+    def parse_active_hours(active_hours: str | None) -> tuple[time, time] | None:
+        """Parse active hours string like '08:00-22:00' into start/end times.
+
+        Args:
+            active_hours: String in format "HH:MM-HH:MM" or None.
+
+        Returns:
+            Tuple of (start_time, end_time) or None if always active.
+
+        Raises:
+            ValueError: If the format is invalid.
+        """
+        if not active_hours:
+            return None
+
+        try:
+            start_str, end_str = active_hours.split("-")
+            start_hour, start_min = map(int, start_str.strip().split(":"))
+            end_hour, end_min = map(int, end_str.strip().split(":"))
+
+            start_time = time(start_hour, start_min)
+            end_time = time(end_hour, end_min)
+
+            return (start_time, end_time)
+        except (ValueError, AttributeError) as e:
+            raise ValueError(f"Invalid active_hours format: {active_hours}. Expected 'HH:MM-HH:MM'") from e
+
+    @staticmethod
+    def is_within_active_hours(
+        active_hours: tuple[time, time] | None, current_time: time
+    ) -> bool:
+        """Check if current time is within active hours window.
+
+        Args:
+            active_hours: Parsed active hours tuple or None.
+            current_time: Current time to check.
+
+        Returns:
+            True if within active hours or if no active hours are set (always active).
+        """
+        if active_hours is None:
+            return True  # Always active if no hours specified
+
+        start_time, end_time = active_hours
+
+        # Handle case where active hours span midnight
+        if start_time <= end_time:
+            # Normal case: 08:00-22:00
+            return start_time <= current_time <= end_time
+        else:
+            # Midnight span: 22:00-08:00
+            return current_time >= start_time or current_time <= end_time
+
+    @staticmethod
+    def is_heartbeat_ok(response: str) -> bool:
+        """Check if response indicates no action needed.
+
+        Args:
+            response: Agent response text.
+
+        Returns:
+            True if response contains HEARTBEAT_OK (case-insensitive).
+        """
+        return "HEARTBEAT_OK" in response.upper()
+
+    def should_skip_heartbeat(self) -> tuple[bool, str, str | None, int]:
+        """Pre-flight check: skip heartbeat if nothing needs attention.
+
+        Checks HEARTBEAT.md and TASKS.yaml to determine if LLM invocation
+        can be skipped, saving API costs for idle workspaces.
+
+        Returns:
+            Tuple of (should_skip, reason, task_summary, task_count).
+            task_summary is None if skipping or no active tasks, otherwise a formatted string.
+            task_count is the number of active tasks found (0 if none or on error).
+        """
+        heartbeat_md = self.workspace_path / str(HEARTBEAT_MD)
+        heartbeat_empty = True
+        if heartbeat_md.exists():
+            try:
+                content = heartbeat_md.read_text().strip()
+                heartbeat_empty = not content or content == "# Heartbeat" or len(content) < 20
+            except OSError:
+                heartbeat_empty = False  # Can't read = don't skip
+
+        tasks_file = self.workspace_path / str(TASKS_YAML)
+        active_tasks = []
+        if tasks_file.exists():
+            try:
+                with tasks_file.open() as f:
+                    data = yaml.safe_load(f)
+                tasks = data.get("tasks", []) if data else []
+                active_statuses = {"pending", "in_progress", "awaiting_check"}
+                active_tasks = [t for t in tasks if t.get("status") in active_statuses]
+            except (yaml.YAMLError, OSError) as e:
+                logger.warning(f"Failed to read TASKS.yaml during pre-flight: {e}")
+                # Can't read = don't skip, but no task summary
+                return False, "pre-flight checks passed (TASKS.yaml read error)", None, 0
+
+        if heartbeat_empty and not active_tasks:
+            return True, "no active tasks and HEARTBEAT.md is empty", None, 0
+
+        # Build task summary if we're not skipping and have active tasks
+        task_summary = build_task_summary(active_tasks) if active_tasks else None
+        return False, "pre-flight checks passed", task_summary, len(active_tasks)

--- a/openpaw/runtime/scheduling/heartbeat_prompt.py
+++ b/openpaw/runtime/scheduling/heartbeat_prompt.py
@@ -1,0 +1,45 @@
+"""Heartbeat prompt builder for OpenPaw."""
+
+from typing import Any
+
+from openpaw.core.prompts.heartbeat import (
+    ACTIVE_TASKS_TEMPLATE,
+    HEARTBEAT_PROMPT,
+    build_task_summary,
+)
+
+
+class HeartbeatPromptBuilder:
+    """Builds heartbeat prompts and task summaries."""
+
+    @staticmethod
+    def build_heartbeat_prompt(timestamp: str, task_summary: str | None = None) -> str:
+        """Build the heartbeat prompt with current timestamp and optional task summary.
+
+        Args:
+            timestamp: ISO-formatted timestamp string.
+            task_summary: Optional compact task summary to inject into the prompt.
+
+        Returns:
+            Formatted heartbeat prompt string.
+        """
+        prompt = HEARTBEAT_PROMPT.format(timestamp=timestamp)
+
+        if task_summary:
+            prompt += "\n" + ACTIVE_TASKS_TEMPLATE.format(task_summary=task_summary)
+
+        return prompt
+
+    @staticmethod
+    def build_task_summary(tasks: list[dict[str, Any]]) -> str | None:
+        """Build a compact task summary from TASKS.yaml data.
+
+        Thin wrapper around build_task_summary from prompts.heartbeat.
+
+        Args:
+            tasks: List of task dictionaries (already filtered to active tasks).
+
+        Returns:
+            Formatted task summary string, or None if no tasks.
+        """
+        return build_task_summary(tasks)


### PR DESCRIPTION
## Summary

Decomposes the final two large files in Phase B:

- `cron.py` (669 → 195 lines)
- `heartbeat.py` (607 → 190 lines)

## New Files

- `cron_executor.py` — CronExecutor: execute_cron, execute_dynamic_task, log_cron_event
- `cron_job_manager.py` — CronJobManager: add/remove/reload jobs, dynamic task lifecycle
- `heartbeat_preflight.py` — HeartbeatPreflight: active hours, skip logic, heartbeat_ok check
- `heartbeat_prompt.py` — HeartbeatPromptBuilder: prompt + task summary
- `heartbeat_executor.py` — HeartbeatExecutor: run_heartbeat, event logging

## Facades

Both CronScheduler and HeartbeatScheduler remain as thin facades that delegate to the new sub-components. All existing private methods are preserved for backward compatibility with tests.

## Metrics

| Metric | Before | After |
|--------|--------|-------|
| Files >700 lines | 8 | 3 |
| Files >500 lines | 17 | 6-7 |

## Verification

- 2,969 tests passing ✅
- Ruff clean ✅
- Mypy: no new errors in scheduling files (24 pre-existing in other files) ✅

---

*Phase B is now complete with this MR.*
