### PR TITLE
cleanup: rename edit_in_place config field (remove internal codename)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Automatic status updates** — `StatusUpdateMiddleware` reports agent start, tool usage, and sub-agent dispatch to the user channel with configurable throttling.
-- **Hermes pattern** — Status updates edit a single message in place instead of sending multiple messages. Supports `edit_message`/`delete_message` on Telegram and Discord. Configurable via `status_updates.hermes_mode` (default: `true`).
+- **Edit-in-place status pattern** — Status updates edit a single message in place instead of sending multiple messages. Supports `edit_message`/`delete_message` on Telegram and Discord. Configurable via `status_updates.edit_in_place` (default: `true`).
 - **Run-aware status labels** — First user-message run shows `"Starting work..."`, subsequent runs show `"Continuing work..."`. System events (cron, heartbeat, sub-agent completions) skip the status update to avoid mid-task confusion.
 - **`report_progress` builtin tool** — Agent-driven structured progress reporting with `status`, `detail`, and optional `percentage` (0-100).
-- **`StatusUpdatesConfig`** configuration model with workspace-level toggles (`agent_start`, `tool_calls_detected`, `tool_start`, `tool_complete`, `subagent_spawned`, `hermes_mode`) and throttling (`min_interval_seconds`, `max_updates_per_run`).
+- **`StatusUpdatesConfig`** configuration model with workspace-level toggles (`agent_start`, `tool_calls_detected`, `tool_start`, `tool_complete`, `subagent_spawned`, `edit_in_place`) and throttling (`min_interval_seconds`, `max_updates_per_run`).
 - **Typing indicators** — `status_updates.typing_indicator` (default: `true`) sends a channel typing indicator while the agent is processing.
 - **Emoji reactions** — `status_updates.reactions` (default: `true`) adds an emoji reaction to the user's original message to indicate the agent is working. Reactions are removed when the agent finishes.
 - **Emoji-enriched status updates** — `status_updates.use_emojis` (default: `true`) prefixes auto-generated status messages with relevant emoji (e.g., `⚙️` for tool calls, `🚀` for starting work, `🤖` for sub-agent dispatch).
 - **Optional `emoji` parameter for `report_progress`** — Agents can pass a custom emoji to `report_progress` to prefix the status message with a visual indicator.
-- **Steer-mode-aware status notifications** — `StatusUpdateMiddleware` now detects `STEER`, `INTERRUPT`, and `COLLECT` mode events and sends user-facing emoji-prefixed notifications via the existing Hermes message. Messages: `🔄 Redirecting to your new message...`, `🛑 Stopping current run — processing your new message`, `📨 New messages received — bundling...`. Configurable via `steer_redirected`, `run_interrupted`, and `collect_queued` (default: `true`).
+- **Steer-mode-aware status notifications** — `StatusUpdateMiddleware` now detects `STEER`, `INTERRUPT`, and `COLLECT` mode events and sends user-facing emoji-prefixed notifications via the existing status message. Messages: `🔄 Redirecting to your new message...`, `🛑 Stopping current run — processing your new message`, `📨 New messages received — bundling...`. Configurable via `steer_redirected`, `run_interrupted`, and `collect_queued` (default: `true`).
 - Background task supervisor in `WorkspaceRunner` that monitors queue processor health, restarts crashed tasks, and sends direct crash notifications to active sessions.
 - Entry/exit logging to critical async paths (`AgentRunner.run`, `SubAgentRunner._execute_subagent`, `SubAgentProfiler.setup`, `MessageProcessor.process_messages`, `LaneQueue.process`).
 - Enriched subagent timeout/error notifications with last tool context and tools used list.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,7 +86,7 @@ The LangGraph execution layer. `AgentRunner` wraps `create_react_agent()`, compo
 
 - `QueueAwareToolMiddleware` — calls `queue_manager.peek_pending()` before each tool call; in steer mode injects pending messages as next input; in interrupt mode raises `InterruptSignalError`
 - `ApprovalToolMiddleware` — checks whether the target tool is gated; if so, raises `ApprovalRequiredError` and stores a `PendingApproval`
-- `StatusUpdateMiddleware` — emits automatic status messages to the user channel via `abefore_agent`, `aafter_model`, and `awrap_tool_call` hooks. Reports agent start, tool usage, and sub-agent dispatch with throttling to prevent spam. Uses the Hermes pattern by default: a single status message is edited in place rather than sending multiple messages. Supports `edit_message`/`delete_message` on the channel adapter for in-place updates. Skips status updates for system events (cron, heartbeat, sub-agent completions) to avoid mid-task confusion.
+- `StatusUpdateMiddleware` — emits automatic status messages to the user channel via `abefore_agent`, `aafter_model`, and `awrap_tool_call` hooks. Reports agent start, tool usage, and sub-agent dispatch with throttling to prevent spam. Uses the edit-in-place status pattern by default: a single status message is edited in place rather than sending multiple messages. Supports `edit_message`/`delete_message` on the channel adapter for in-place updates. Skips status updates for system events (cron, heartbeat, sub-agent completions) to avoid mid-task confusion.
 
 **`agent/tools/`** provides `FilesystemTools` — eight sandboxed operations (`ls`, `read_file`, `write_file`, `overwrite_file`, `edit_file`, `glob_files`, `grep_files`, `file_info`) restricted to the workspace root. `sandbox.py` exports `resolve_sandboxed_path()`, which rejects absolute paths, `~`, `..`, and `.openpaw/` access. This function is shared by `SendFileTool` and inbound processors for defense-in-depth validation.
 
@@ -139,9 +139,9 @@ File-backed persistence using threading locks and atomic writes (write to a tmp 
 
 External communication adapters. `ChannelAdapter` is the abstract base all adapters implement. The `create_channel()` factory in `factory.py` decouples `WorkspaceRunner` from concrete channel types — adding a new platform requires a new adapter file and a factory registration, nothing else.
 
-The Telegram adapter handles sender allowlisting, voice/audio (delegated to `WhisperProcessor`), documents (delegated to `DoclingProcessor`), photo uploads, and inline keyboard callbacks for approval gates. Supports message editing and deletion for the Hermes status update pattern.
+The Telegram adapter handles sender allowlisting, voice/audio (delegated to `WhisperProcessor`), documents (delegated to `DoclingProcessor`), photo uploads, and inline keyboard callbacks for approval gates. Supports message editing and deletion for the edit-in-place status pattern.
 
-The Discord adapter handles guild/DM routing, slash command registration, and rich approval UI with Approve/Deny buttons. Supports message editing and deletion for the Hermes status update pattern.
+The Discord adapter handles guild/DM routing, slash command registration, and rich approval UI with Approve/Deny buttons. Supports message editing and deletion for the edit-in-place status pattern.
 
 The `commands/` subdirectory contains `CommandRouter` and handler classes for all framework commands.
 

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -837,12 +837,12 @@ status_updates:
   subagent_spawned: true     # Report sub-agent dispatch (default: true)
   min_interval_seconds: 3    # Min seconds between auto-updates (default: 3)
   max_updates_per_run: 10    # Max auto-updates per run (default: 10)
-  hermes_mode: true          # Edit single message in place (default: true)
+  edit_in_place: true        # Edit single message in place (default: true)
 ```
 
 **Behavior:**
 
-- **Hermes pattern** (default): A single status message is maintained and edited in place. First update sends a new message; subsequent updates edit the same message. The message is deleted after the agent run completes.
+- **Edit-in-place pattern** (default): A single status message is maintained and edited in place. First update sends a new message; subsequent updates edit the same message. The message is deleted after the agent run completes.
 - **Run-aware labels**: First run shows `"Starting work..."`, subsequent runs show `"Continuing work..."`.
 - **System events skip**: Cron, heartbeat, and sub-agent completion events do not trigger status updates to avoid mid-task confusion.
 - Time-based throttle: `min_interval_seconds` between auto-detected status messages

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -531,7 +531,7 @@ status_updates:
   subagent_spawned: true     # Report when sub-agent is dispatched
   min_interval_seconds: 3    # Minimum seconds between auto-updates
   max_updates_per_run: 10    # Maximum auto-updates per agent run
-  hermes_mode: true          # Edit single message in place (default: true)
+  edit_in_place: true        # Edit single message in place (default: true)
   typing_indicator: true      # Send typing indicator while agent is processing
   reactions: true            # Add emoji reactions to the user's original message
   use_emojis: true           # Prefix status messages with relevant emojis
@@ -552,7 +552,7 @@ status_updates:
 
 **max_updates_per_run** — Maximum number of auto-detected status updates per agent invocation. Default: `10`.
 
-**hermes_mode** — When `true` (default), the first status update sends a new message, and subsequent updates edit the same message in place. This prevents chat clutter. The status message is deleted after the agent run completes. When `false`, each update sends a separate message.
+**edit_in_place** — When `true` (default), the first status update sends a new message, and subsequent updates edit the same message in place. This prevents chat clutter. The status message is deleted after the agent run completes. When `false`, each update sends a separate message.
 
 **typing_indicator** — When `true` (default), the framework sends a typing indicator (e.g., "typing..." on Telegram or "Agent is typing..." on Discord) while the agent is actively processing. Cleared when the agent completes or sends a real message.
 

--- a/openpaw/agent/middleware/status_update.py
+++ b/openpaw/agent/middleware/status_update.py
@@ -8,7 +8,7 @@ Hooks into LangGraph's AgentMiddleware protocol to emit status messages:
 Throttling prevents spam during rapid tool-call sequences. Agent-driven
 report_progress tool calls bypass throttling.
 
-Hermes Pattern (default):
+Edit-in-place pattern (default):
 - Sends one initial status message
 - Edits that same message on subsequent updates
 - Deletes the status message when the agent run completes
@@ -134,8 +134,8 @@ class StatusUpdateMiddleware(AgentMiddleware):
     - Deduplication: if the same set of tools is detected twice, only report once.
     - Agent-driven report_progress bypasses all throttling.
 
-    Hermes Pattern:
-    - When hermes_mode is True (default), a single status message is maintained
+    Edit-in-place pattern:
+    - When edit_in_place is True (default), a single status message is maintained
       and edited in place. This prevents chat clutter.
     - When False, each update sends a separate message (legacy behavior).
     """
@@ -307,7 +307,7 @@ class StatusUpdateMiddleware(AgentMiddleware):
         """Intercept tool execution to report sub-agent dispatch and per-tool status.
 
         Also detects steer and interrupt signals to send user-facing status
-        notifications via the existing Hermes message.
+        notifications via the existing status message.
 
         Args:
             request: ToolCallRequest with tool_call (name, args, id).
@@ -392,8 +392,8 @@ class StatusUpdateMiddleware(AgentMiddleware):
     ) -> None:
         """Send or edit a status message to the channel with throttling.
 
-        In Hermes mode (default), the first status message is sent normally and
-        subsequent updates edit that same message. In non-Hermes mode, each
+        In edit-in-place mode (default), the first status message is sent normally
+        and subsequent updates edit that same message. In legacy mode, each
         update sends a separate message.
 
         Args:
@@ -430,8 +430,8 @@ class StatusUpdateMiddleware(AgentMiddleware):
             text = f"{emoji} {text}"
 
         try:
-            if self._config.hermes_mode and self._status_message_id:
-                # Hermes: edit existing message
+            if self._config.edit_in_place and self._status_message_id:
+                # Edit-in-place: edit existing message
                 edited = await channel.edit_message(
                     session_key, self._status_message_id, text
                 )

--- a/openpaw/cli_init/templates.py
+++ b/openpaw/cli_init/templates.py
@@ -218,7 +218,7 @@ def _build_agent_yaml(name: str, channel: str | None, model: str | None) -> str:
         "  tool_calls_detected: true",
         "  tool_start: true",
         "  subagent_spawned: true",
-        "  hermes_mode: true",
+        "  edit_in_place: true",
     ]
 
     return "\n".join(lines) + "\n"

--- a/openpaw/core/config/models/status_updates.py
+++ b/openpaw/core/config/models/status_updates.py
@@ -48,9 +48,9 @@ class StatusUpdatesConfig(BaseModel):
     template: str = Field(
         default="[{event}] {message}", description="Optional format template for status messages"
     )
-    hermes_mode: bool = Field(
+    edit_in_place: bool = Field(
         default=True,
-        description="Edit a single status message instead of sending multiple messages",
+        description="Edit a single status message in place instead of sending multiple messages",
     )
     typing_indicator: bool = Field(
         default=True,

--- a/tests/test_status_update_middleware.py
+++ b/tests/test_status_update_middleware.py
@@ -55,7 +55,7 @@ def _make_config(
     collect_queued: bool = True,
     min_interval_seconds: int = 0,
     max_updates_per_run: int = 10,
-    hermes_mode: bool = True,
+    edit_in_place: bool = True,
     use_emojis: bool = False,
     typing_indicator: bool = True,
     reactions: bool = True,
@@ -72,7 +72,7 @@ def _make_config(
         collect_queued=collect_queued,
         min_interval_seconds=min_interval_seconds,
         max_updates_per_run=max_updates_per_run,
-        hermes_mode=hermes_mode,
+        edit_in_place=edit_in_place,
         use_emojis=use_emojis,
         typing_indicator=typing_indicator,
         reactions=reactions,
@@ -263,7 +263,7 @@ async def test_aafter_model_reports_different_tool_set():
     state2 = {"messages": [_ai_with_tool_calls("write_file")]}
     await mw.aafter_model(state2, None)
 
-    # In hermes mode: 1 sent, 1 edited
+    # In edit-in-place mode: 1 sent, 1 edited
     assert len(channel.sent_messages) == 1
     assert len(channel.edited_messages) == 1
 
@@ -353,7 +353,7 @@ async def test_awrap_tool_call_reports_tool_start_with_spawn_agent_args():
         return MagicMock()
 
     await mw.awrap_tool_call(req, handler)
-    # In hermes mode: subagent_spawned sent first, then tool_start edits it
+    # In edit-in-place mode: subagent_spawned sent first, then tool_start edits it
     assert len(channel.sent_messages) == 1
     assert len(channel.edited_messages) == 1
     assert channel.sent_messages[0] == (
@@ -391,7 +391,7 @@ async def test_awrap_tool_call_reports_both_start_and_complete():
         return MagicMock()
 
     await mw.awrap_tool_call(req, handler)
-    # In hermes mode: first sent, second edited
+    # In edit-in-place mode: first sent, second edited
     assert len(channel.sent_messages) == 1
     assert len(channel.edited_messages) == 1
     assert channel.sent_messages[0] == ("telegram:123456", "Running tool: read_file...")
@@ -428,7 +428,7 @@ async def test_throttling_time_based():
     await mw._send_status("First update")
     await mw._send_status("Second update")
 
-    # In hermes mode: 1 sent, 1 throttled
+    # In edit-in-place mode: 1 sent, 1 throttled
     assert len(channel.sent_messages) == 1
 
 
@@ -444,7 +444,7 @@ async def test_throttling_budget_based():
     await mw._send_status("Update 2")
     await mw._send_status("Update 3")
 
-    # In hermes mode: 1 sent, 1 edited, 1 throttled
+    # In edit-in-place mode: 1 sent, 1 edited, 1 throttled
     assert len(channel.sent_messages) == 1
     assert len(channel.edited_messages) == 1
 
@@ -460,7 +460,7 @@ async def test_throttling_time_allows_after_interval():
     await mw._send_status("First update")
     await mw._send_status("Second update")
 
-    # In hermes mode: 1 sent, 1 edited
+    # In edit-in-place mode: 1 sent, 1 edited
     assert len(channel.sent_messages) == 1
     assert len(channel.edited_messages) == 1
 
@@ -489,12 +489,12 @@ def test_reset_clears_counters():
 
 
 # ---------------------------------------------------------------------------
-# Hermes mode
+# Edit-in-place mode
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_hermes_mode_edits_single_message():
+async def test_edit_in_place_mode_edits_single_message():
     channel = MockChannel()
     mw = _make_middleware(channel=channel)
 
@@ -515,7 +515,7 @@ async def test_hermes_mode_edits_single_message():
 
 
 @pytest.mark.asyncio
-async def test_hermes_mode_falls_back_to_new_message_on_edit_failure():
+async def test_edit_in_place_mode_falls_back_to_new_message_on_edit_failure():
     channel = MockChannel()
     # Make edit fail
     async def failing_edit(session_key: str, message_id: str, content: str) -> bool:
@@ -535,9 +535,9 @@ async def test_hermes_mode_falls_back_to_new_message_on_edit_failure():
 
 
 @pytest.mark.asyncio
-async def test_hermes_mode_disabled_sends_separate_messages():
+async def test_edit_in_place_mode_disabled_sends_separate_messages():
     channel = MockChannel()
-    mw = _make_middleware(config=_make_config(hermes_mode=False), channel=channel)
+    mw = _make_middleware(config=_make_config(edit_in_place=False), channel=channel)
 
     await mw._send_status("Starting work...")
     await mw._send_status("Using tools: read_file...")
@@ -595,7 +595,7 @@ class TestStatusUpdatesConfig:
         assert config.min_interval_seconds == 1
         assert config.max_updates_per_run == 10
         assert config.template == "[{event}] {message}"
-        assert config.hermes_mode is True
+        assert config.edit_in_place is True
         assert config.typing_indicator is True
         assert config.reactions is True
         assert config.use_emojis is True
@@ -617,7 +617,7 @@ class TestStatusUpdatesConfig:
             min_interval_seconds=0,
             max_updates_per_run=5,
             template="{message}",
-            hermes_mode=False,
+            edit_in_place=False,
             typing_indicator=False,
             reactions=False,
             use_emojis=False,
@@ -634,7 +634,7 @@ class TestStatusUpdatesConfig:
         assert config.min_interval_seconds == 0
         assert config.max_updates_per_run == 5
         assert config.template == "{message}"
-        assert config.hermes_mode is False
+        assert config.edit_in_place is False
         assert config.typing_indicator is False
         assert config.reactions is False
         assert config.use_emojis is False
@@ -713,7 +713,7 @@ async def test_awrap_tool_call_detects_steer_skip_with_existing_status():
 
     result = await mw.awrap_tool_call(req, handler)
     assert result.content == STEER_SKIP_MESSAGE
-    # In hermes mode: steer notification edits the existing message
+    # In edit-in-place mode: steer notification edits the existing message
     assert len(channel.sent_messages) == 1
     assert len(channel.edited_messages) == 1
     assert channel.edited_messages[0] == (
@@ -763,7 +763,7 @@ async def test_awrap_tool_call_detects_interrupt_with_existing_status():
     with pytest.raises(InterruptSignalError):
         await mw.awrap_tool_call(req, handler)
 
-    # In hermes mode: interrupt notification edits the existing message
+    # In edit-in-place mode: interrupt notification edits the existing message
     assert len(channel.sent_messages) == 1
     assert len(channel.edited_messages) == 1
     assert channel.edited_messages[0] == (
@@ -930,7 +930,7 @@ async def test_emoji_disabled_when_use_emojis_false():
     await mw.abefore_agent({}, None)
     await mw.aafter_model(state, None)
 
-    # In hermes mode: first sent, second edited
+    # In edit-in-place mode: first sent, second edited
     assert len(channel.sent_messages) == 1
     assert len(channel.edited_messages) == 1
     assert channel.sent_messages[0] == ("telegram:123456", "Starting work...")

--- a/tests/workspace/test_message_processor_reactions.py
+++ b/tests/workspace/test_message_processor_reactions.py
@@ -124,7 +124,7 @@ def _make_status_update_middleware(
     config.subagent_spawned = True
     config.min_interval_seconds = 0
     config.max_updates_per_run = 10
-    config.hermes_mode = True
+    config.edit_in_place = True
     middleware = MagicMock()
     middleware._config = config
     return middleware


### PR DESCRIPTION
## Summary

- Renames the `hermes_mode` config field on `StatusUpdatesConfig` to `edit_in_place` across all source, tests, and documentation
- Replaces internal codename prose in comments, docstrings, and docs with descriptive terminology ("edit-in-place pattern")
- No behavior changes — purely a naming/wording cleanup

## Files changed

| File | Change |
|---|---|
| `openpaw/core/config/models/status_updates.py` | Field renamed to `edit_in_place` |
| `openpaw/agent/middleware/status_update.py` | Field usage + comments updated |
| `openpaw/cli_init/templates.py` | Template YAML key updated |
| `tests/test_status_update_middleware.py` | Test names, params, assertions, comments |
| `tests/workspace/test_message_processor_reactions.py` | One field assignment |
| `docs/architecture.md` | Pattern name updated |
| `docs/configuration.md` | Config key + prose |
| `docs/builtins.md` | Config key + prose |
| `CHANGELOG.md` | Config key references in feature bullets |

## Test plan

- [x] 57 tests passing (`tests/test_status_update_middleware.py` + `tests/workspace/test_message_processor_reactions.py`)
- [x] Zero remaining internal codename references (`grep -ri "hermes"` returns empty)