### PR TITLE
fix: send steer redirect notification once per event (#146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `StatusUpdateMiddleware` now sends the steer redirect notification exactly once per steer event instead of re-editing the status message for every skipped tool. Adds a `_steer_notified` guard that is reset in `set_context()` and `reset()` so subsequent runs can notify again. (#146)
 - Fixed `AttributeError: 'CronToolBuiltin' object has no attribute '_add_to_live_scheduler'` in `FollowupScheduler` and `MessageProcessor` — both callers now use the standalone `_add_to_live_scheduler(scheduler, task)` bridge function from `scheduler_bridge.py` instead of calling a non-existent instance method. This was crashing the queue processor on delayed followup scheduling.
 - `LaneQueue.process()` now catches handler exceptions and continues the loop, preventing a single handler crash from killing the entire message pipeline.
 - `SubAgentStore` converted to async-safe operations with `asyncio.to_thread()`, preventing synchronous YAML I/O from blocking the event loop.

--- a/openpaw/agent/middleware/status_update.py
+++ b/openpaw/agent/middleware/status_update.py
@@ -154,6 +154,7 @@ class StatusUpdateMiddleware(AgentMiddleware):
         self._updates_sent: int = 0
         self._last_reported_tools: frozenset[str] = frozenset()
         self._status_message_id: str | None = None
+        self._steer_notified: bool = False
 
     def set_context(
         self,
@@ -183,6 +184,7 @@ class StatusUpdateMiddleware(AgentMiddleware):
         self._updates_sent = 0
         self._last_reported_tools = frozenset()
         self._status_message_id = None
+        self._steer_notified = False
 
     def reset(self) -> None:
         """Reset per-invocation state. Called by MessageProcessor after each run."""
@@ -194,6 +196,7 @@ class StatusUpdateMiddleware(AgentMiddleware):
         self._updates_sent = 0
         self._last_reported_tools = frozenset()
         self._status_message_id = None
+        self._steer_notified = False
 
     async def delete_status(self) -> None:
         """Delete the tracked status message if one exists.
@@ -365,13 +368,15 @@ class StatusUpdateMiddleware(AgentMiddleware):
                 status += f" ({tool_detail})"
             await self._send_status(status, emoji=complete_emoji)
 
-        # Detect steer skip and notify user
+        # Detect steer skip and notify user (fire exactly once per steer event)
         if (
             self._config.steer_redirected
             and isinstance(result, ToolMessage)
             and result.content == STEER_SKIP_MESSAGE
+            and not self._steer_notified
         ):
             await self._send_status(STEER_USER_NOTIFICATION, force=True)
+            self._steer_notified = True
 
         return result
 

--- a/tests/test_status_update_middleware.py
+++ b/tests/test_status_update_middleware.py
@@ -841,6 +841,76 @@ async def test_steer_notification_bypasses_throttle():
 
 
 @pytest.mark.asyncio
+async def test_awrap_tool_call_steer_notification_fires_exactly_once():
+    """Steer notification is sent only once even when multiple tools are skipped."""
+    from langchain_core.messages import ToolMessage
+
+    from openpaw.core.prompts.system_events import STEER_SKIP_MESSAGE, STEER_USER_NOTIFICATION
+
+    channel = MockChannel()
+    mw = _make_middleware(
+        config=_make_config(steer_redirected=True, enabled=True),
+        channel=channel,
+    )
+
+    async def handler(request: Any) -> Any:
+        return ToolMessage(content=STEER_SKIP_MESSAGE, tool_call_id="call_1")
+
+    # Invoke awrap_tool_call three times simulating three skipped tools in one turn
+    await mw.awrap_tool_call(_make_tool_request("tool_a"), handler)
+    await mw.awrap_tool_call(_make_tool_request("tool_b"), handler)
+    await mw.awrap_tool_call(_make_tool_request("tool_c"), handler)
+
+    # Count all channel interactions that contain the steer notification text
+    steer_count = sum(
+        1 for (_, content) in channel.sent_messages if STEER_USER_NOTIFICATION in content
+    ) + sum(
+        1 for (_, _, content) in channel.edited_messages if STEER_USER_NOTIFICATION in content
+    )
+    assert steer_count == 1, f"Expected 1 steer notification, got {steer_count}"
+    assert mw._steer_notified is True
+
+
+@pytest.mark.asyncio
+async def test_steer_notified_resets_after_reset():
+    """_steer_notified is False after reset(), allowing subsequent runs to notify again."""
+    from langchain_core.messages import ToolMessage
+
+    from openpaw.core.prompts.system_events import STEER_SKIP_MESSAGE, STEER_USER_NOTIFICATION
+
+    channel = MockChannel()
+    mw = _make_middleware(
+        config=_make_config(steer_redirected=True, enabled=True),
+        channel=channel,
+    )
+
+    async def handler(request: Any) -> Any:
+        return ToolMessage(content=STEER_SKIP_MESSAGE, tool_call_id="call_1")
+
+    # First run: notification fires
+    await mw.awrap_tool_call(_make_tool_request("tool_a"), handler)
+    assert mw._steer_notified is True
+
+    # Reset simulates end of agent run
+    mw.reset()
+    assert mw._steer_notified is False
+
+    # Set context for second run
+    mw.set_context(channel, "telegram:123456")
+    assert mw._steer_notified is False
+
+    # Second run: notification fires again
+    await mw.awrap_tool_call(_make_tool_request("tool_a"), handler)
+
+    steer_count = sum(
+        1 for (_, content) in channel.sent_messages if STEER_USER_NOTIFICATION in content
+    ) + sum(
+        1 for (_, _, content) in channel.edited_messages if STEER_USER_NOTIFICATION in content
+    )
+    assert steer_count == 2, f"Expected 2 steer notifications across two runs, got {steer_count}"
+
+
+@pytest.mark.asyncio
 async def test_send_forced_status_bypasses_throttle():
     channel = MockChannel()
     mw = _make_middleware(


### PR DESCRIPTION
## Summary

- `StatusUpdateMiddleware` was re-editing the "🔄 Redirecting…" status message once per skipped tool when a STEER event landed mid-turn. Now fires exactly once per steer event.
- Adds a `_steer_notified` guard, initialized in `__init__`, reset in both `set_context()` and `reset()` so subsequent runs can notify again.
- Two new tests cover the one-shot suppression and the reset path.

Closes #146

## Test plan

- [x] Full suite: 3029 passed (3027 baseline + 2 new)
- [x] Stage validation on `krieger` workspace — interrupted a multi-tool turn, observed a single "🔄 Redirecting…" with no flicker
- [x] code-reviewer: approved