### PR TITLE
feat: per-sub-agent status messages (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Per-sub-agent status messages** — Each spawned sub-agent now gets its own Hermes-style status message that is created on dispatch, edited as the sub-agent runs each tool, and finalized to `✅ Completed`, `❌ Failed`, or `🚫 Cancelled` on completion. Gives the user real-time visibility into long-running team members. New `SubAgentToolMiddleware` is injected into each sub-agent's runner; events bridge back to the parent `StatusUpdateMiddleware` via a `status_callback` on `SubAgentRunner`. (#144)
+- **`StatusUpdatesConfig.subagent_status`** (default `true`) and **`subagent_status_cleanup`** (`"edit"` / `"delete"`, default `"edit"`) configuration fields to control per-sub-agent status behavior.
 - **Automatic status updates** — `StatusUpdateMiddleware` reports agent start, tool usage, and sub-agent dispatch to the user channel with configurable throttling.
 - **Edit-in-place status pattern** — Status updates edit a single message in place instead of sending multiple messages. Supports `edit_message`/`delete_message` on Telegram and Discord. Configurable via `status_updates.edit_in_place` (default: `true`).
 - **Run-aware status labels** — First user-message run shows `"Starting work..."`, subsequent runs show `"Continuing work..."`. System events (cron, heartbeat, sub-agent completions) skip the status update to avoid mid-task confusion.

--- a/openpaw/agent/middleware/__init__.py
+++ b/openpaw/agent/middleware/__init__.py
@@ -21,6 +21,7 @@ from openpaw.agent.middleware.status_reminder import (
     inject_framework_instruction,
 )
 from openpaw.agent.middleware.status_update import StatusUpdateMiddleware
+from openpaw.agent.middleware.subagent_status import SubAgentToolMiddleware
 from openpaw.agent.middleware.tool_timeout import ToolTimeoutMiddleware
 
 __all__ = [
@@ -31,6 +32,7 @@ __all__ = [
     "THINKING_TAG_PATTERN",
     "StatusReminderMiddleware",
     "StatusUpdateMiddleware",
+    "SubAgentToolMiddleware",
     "ThinkingTokenMiddleware",
     "ToolTimeoutMiddleware",
     "build_post_model_hook",

--- a/openpaw/agent/middleware/status_update.py
+++ b/openpaw/agent/middleware/status_update.py
@@ -155,9 +155,9 @@ class StatusUpdateMiddleware(AgentMiddleware):
         self._last_reported_tools: frozenset[str] = frozenset()
         self._status_message_id: str | None = None
         self._steer_notified: bool = False
-        # Per-sub-agent status tracking: subagent_id -> (message_id, label).
+        # Per-sub-agent status tracking: subagent_id -> (msg_id, label, channel, session_key).
         # Not cleared on reset() — sub-agents may outlive the main agent run.
-        self._subagent_status_ids: dict[str, tuple[str, str]] = {}
+        self._subagent_status_ids: dict[str, tuple[str, str, Any, str]] = {}
 
     def set_context(
         self,
@@ -236,7 +236,7 @@ class StatusUpdateMiddleware(AgentMiddleware):
         try:
             sent = await channel.send_message(session_key, text)
             if sent and hasattr(sent, "id"):
-                self._subagent_status_ids[subagent_id] = (str(sent.id), label)
+                self._subagent_status_ids[subagent_id] = (str(sent.id), label, channel, session_key)
                 logger.debug("Created sub-agent status for %s: msg=%s", subagent_id, sent.id)
         except Exception as e:
             logger.debug("Failed to create sub-agent status: %s", e)
@@ -256,11 +256,7 @@ class StatusUpdateMiddleware(AgentMiddleware):
         entry = self._subagent_status_ids.get(subagent_id)
         if not entry:
             return
-        msg_id, label = entry
-        channel = self._channel
-        session_key = self._session_key
-        if not channel or not session_key:
-            return
+        msg_id, label, channel, session_key = entry
         status_line = f"{emoji} {status}" if emoji and self._config.use_emojis else status
         text = f"🤖 Sub-agent: {label}\n{status_line}"
         try:
@@ -283,12 +279,7 @@ class StatusUpdateMiddleware(AgentMiddleware):
         entry = self._subagent_status_ids.pop(subagent_id, None)
         if not entry:
             return
-        msg_id, label = entry
-        channel = self._channel
-        session_key = self._session_key
-        if not channel or not session_key:
-            # Entry already popped — no channel to update, but dict is clean.
-            return
+        msg_id, label, channel, session_key = entry
 
         _outcome_emoji = {"completed": "✅", "failed": "❌", "cancelled": "🚫"}
         outcome_emoji = _outcome_emoji.get(outcome, "⚠️")

--- a/openpaw/agent/middleware/status_update.py
+++ b/openpaw/agent/middleware/status_update.py
@@ -155,6 +155,9 @@ class StatusUpdateMiddleware(AgentMiddleware):
         self._last_reported_tools: frozenset[str] = frozenset()
         self._status_message_id: str | None = None
         self._steer_notified: bool = False
+        # Per-sub-agent status tracking: subagent_id -> (message_id, label).
+        # Not cleared on reset() — sub-agents may outlive the main agent run.
+        self._subagent_status_ids: dict[str, tuple[str, str]] = {}
 
     def set_context(
         self,
@@ -215,6 +218,95 @@ class StatusUpdateMiddleware(AgentMiddleware):
             self._status_message_id = None
         except Exception as e:
             logger.debug("Failed to delete status message: %s", e)
+
+    async def create_subagent_status(self, subagent_id: str, label: str) -> None:
+        """Send a new status message for a sub-agent and store its message ID.
+
+        Args:
+            subagent_id: Unique identifier for the sub-agent request.
+            label: Display name shown in the status header.
+        """
+        if not self._config.enabled or not self._config.subagent_status:
+            return
+        channel = self._channel
+        session_key = self._session_key
+        if not channel or not session_key:
+            return
+        text = f"🤖 Sub-agent: {label}\n🟡 Starting work..."
+        try:
+            sent = await channel.send_message(session_key, text)
+            if sent and hasattr(sent, "id"):
+                self._subagent_status_ids[subagent_id] = (str(sent.id), label)
+                logger.debug("Created sub-agent status for %s: msg=%s", subagent_id, sent.id)
+        except Exception as e:
+            logger.debug("Failed to create sub-agent status: %s", e)
+
+    async def update_subagent_status(
+        self, subagent_id: str, status: str, emoji: str | None = None
+    ) -> None:
+        """Edit a sub-agent's status message in place.
+
+        Args:
+            subagent_id: Unique identifier for the sub-agent request.
+            status: Status text to display below the header line.
+            emoji: Optional emoji prefix for the status line.
+        """
+        if not self._config.enabled or not self._config.subagent_status:
+            return
+        entry = self._subagent_status_ids.get(subagent_id)
+        if not entry:
+            return
+        msg_id, label = entry
+        channel = self._channel
+        session_key = self._session_key
+        if not channel or not session_key:
+            return
+        status_line = f"{emoji} {status}" if emoji and self._config.use_emojis else status
+        text = f"🤖 Sub-agent: {label}\n{status_line}"
+        try:
+            await channel.edit_message(session_key, msg_id, text)
+            logger.debug("Updated sub-agent status for %s: %s", subagent_id, status)
+        except Exception as e:
+            logger.debug("Failed to update sub-agent status: %s", e)
+
+    async def finalize_subagent_status(
+        self, subagent_id: str, outcome: str
+    ) -> None:
+        """Edit or delete a sub-agent's status message at lifecycle end.
+
+        Args:
+            subagent_id: Unique identifier for the sub-agent request.
+            outcome: One of "completed", "failed", or "cancelled".
+        """
+        if not self._config.enabled or not self._config.subagent_status:
+            return
+        entry = self._subagent_status_ids.pop(subagent_id, None)
+        if not entry:
+            return
+        msg_id, label = entry
+        channel = self._channel
+        session_key = self._session_key
+        if not channel or not session_key:
+            # Entry already popped — no channel to update, but dict is clean.
+            return
+
+        _outcome_emoji = {"completed": "✅", "failed": "❌", "cancelled": "🚫"}
+        outcome_emoji = _outcome_emoji.get(outcome, "⚠️")
+        outcome_label = outcome.capitalize()
+
+        if self._config.subagent_status_cleanup == "delete":
+            try:
+                await channel.delete_message(session_key, msg_id)
+                logger.debug("Deleted sub-agent status for %s", subagent_id)
+            except Exception as e:
+                logger.debug("Failed to delete sub-agent status: %s", e)
+        else:
+            text = f"🤖 Sub-agent: {label}\n{outcome_emoji} {outcome_label}"
+            try:
+                await channel.edit_message(session_key, msg_id, text)
+                logger.debug("Finalized sub-agent status for %s: %s", subagent_id, outcome)
+            except Exception as e:
+                logger.debug("Failed to finalize sub-agent status: %s", e)
 
     async def abefore_agent(
         self, state: Any, runtime: Any

--- a/openpaw/agent/middleware/subagent_status.py
+++ b/openpaw/agent/middleware/subagent_status.py
@@ -1,0 +1,61 @@
+"""Per-sub-agent tool-event middleware.
+
+Fires a status callback on every tool invocation inside a sub-agent's runner
+so the parent's StatusUpdateMiddleware can edit the sub-agent's status message
+in real time.
+"""
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from langchain.agents.middleware.types import AgentMiddleware
+
+from openpaw.agent.middleware.status_update import _resolve_emoji
+
+logger = logging.getLogger(__name__)
+
+# Signature: (subagent_id, event, text, emoji) -> None
+StatusCallbackT = Callable[[str, str, str, str | None], Awaitable[None]]
+
+
+class SubAgentToolMiddleware(AgentMiddleware):
+    """Minimal middleware that fires a status callback on each tool invocation.
+
+    Attached to a sub-agent's AgentRunner before _build_agent() so that
+    tool-start events are forwarded to the parent WorkspaceRunner's
+    StatusUpdateMiddleware.
+    """
+
+    def __init__(self, subagent_id: str, callback: StatusCallbackT) -> None:
+        """Initialize the middleware.
+
+        Args:
+            subagent_id: Unique identifier of the sub-agent request.
+            callback: Async callable invoked on each tool start.
+        """
+        self._subagent_id = subagent_id
+        self._callback = callback
+
+    async def awrap_tool_call(self, request: Any, handler: Any) -> Any:
+        """Fire the status callback before delegating to the next handler.
+
+        Args:
+            request: ToolCallRequest with tool_call dict.
+            handler: Async callable that executes the tool.
+
+        Returns:
+            Tool result from the handler.
+        """
+        tool_name = request.tool_call.get("name", "unknown")
+        emoji = _resolve_emoji([tool_name])
+        try:
+            await self._callback(
+                self._subagent_id,
+                "tool",
+                f"Running tool: {tool_name}...",
+                emoji,
+            )
+        except Exception as e:
+            logger.debug("SubAgentToolMiddleware callback error: %s", e)
+        return await handler(request)

--- a/openpaw/core/config/models/status_updates.py
+++ b/openpaw/core/config/models/status_updates.py
@@ -66,5 +66,14 @@ class StatusUpdatesConfig(BaseModel):
     use_emojis: bool = Field(
         default=True, description="Prefix status messages with relevant emojis"
     )
+    subagent_status: bool = Field(
+        default=True,
+        description="Send a separate status message per spawned sub-agent",
+    )
+    subagent_status_cleanup: str = Field(
+        default="edit",
+        pattern="^(edit|delete)$",
+        description="How to finalize sub-agent status messages: 'edit' to final state or 'delete'",
+    )
 
     model_config = {"extra": "allow"}

--- a/openpaw/runtime/subagent/runner.py
+++ b/openpaw/runtime/subagent/runner.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 from openpaw.agent import AgentRunner
 from openpaw.agent.metrics import TokenUsageLogger
+from openpaw.agent.middleware.subagent_status import StatusCallbackT, SubAgentToolMiddleware
 from openpaw.agent.session_logger import SessionLogger
 from openpaw.channels.base import ChannelAdapter
 from openpaw.model.subagent import SubAgentRequest, SubAgentResult, SubAgentStatus
@@ -79,6 +80,7 @@ class SubAgentRunner:
         session_logger: SessionLogger | None = None,
         profile_resolver: SpawnProfileResolver | None = None,
         agent_factory_instance: AgentFactory | None = None,
+        status_callback: StatusCallbackT | None = None,
     ):
         """Initialize the sub-agent runner.
 
@@ -97,6 +99,9 @@ class SubAgentRunner:
                 model overrides, tool filtering, and system prompt injection.
             agent_factory_instance: Optional AgentFactory used to create profiled agents
                 via create_profiled_agent(). Required when profiles specify model overrides.
+            status_callback: Optional callback for per-sub-agent status updates.
+                Signature: (subagent_id, event, text, emoji) -> None.
+                Events: "start", "tool", "completed", "failed", "cancelled".
         """
         self._agent_factory = agent_factory
         self._store = store
@@ -108,6 +113,7 @@ class SubAgentRunner:
         self._session_logger = session_logger
         self._profile_resolver = profile_resolver
         self._agent_factory_instance = agent_factory_instance
+        self._status_callback = status_callback
         self._semaphore = asyncio.Semaphore(max_concurrent)
         self._active_tasks: dict[str, asyncio.Task[Any]] = {}
 
@@ -128,6 +134,28 @@ class SubAgentRunner:
             channels=channels,
             result_callback=result_callback,
         )
+
+    async def _fire_status(
+        self,
+        subagent_id: str,
+        event: str,
+        text: str,
+        emoji: str | None = None,
+    ) -> None:
+        """Fire the status_callback, suppressing all errors.
+
+        Args:
+            subagent_id: Unique identifier for the sub-agent request.
+            event: Lifecycle event name ("start", "tool", "completed", "failed", "cancelled").
+            text: Human-readable status text.
+            emoji: Optional emoji prefix.
+        """
+        if not self._status_callback:
+            return
+        try:
+            await self._status_callback(subagent_id, event, text, emoji)
+        except Exception as e:
+            logger.debug("status_callback error for %s (%s): %s", subagent_id, event, e)
 
     async def spawn(self, request: SubAgentRequest) -> str:
         """Spawn a new sub-agent to handle a request.
@@ -316,10 +344,23 @@ class SubAgentRunner:
                         request.id, SubAgentStatus.FAILED, completed_at=datetime.now(UTC)
                     )
                     await self._store.save_result(result)
+                    # Fire status callback before notify so the user sees the outcome
+                    await self._fire_status(request.id, "failed", "Profile not found", "❌")
                     if request.notify:
                         await self._notifier.send_notification(request, result)
                     logger.warning(f"Sub-agent {request.id} failed: {e}")
                     return
+
+                # Inject per-sub-agent tool middleware when a callback is configured.
+                # Must be injected before profiler calls _build_agent() — but profiler
+                # has already called it. Append to _middleware and rebuild the agent.
+                if self._status_callback:
+                    tool_mw = SubAgentToolMiddleware(request.id, self._status_callback)
+                    runner._middleware.append(tool_mw)
+                    runner._agent = runner._build_agent()
+
+                # Fire "start" event after the runner is ready
+                await self._fire_status(request.id, "start", request.label)
 
                 # Start periodic progress timer if configured.
                 # The task is cancelled in the finally block regardless of outcome.
@@ -340,6 +381,16 @@ class SubAgentRunner:
                         progress_task.cancel()
                         with contextlib.suppress(asyncio.CancelledError):
                             await progress_task
+
+                # Determine terminal event from result status
+                if result is not None:
+                    stored = await self._store.get(request.id)
+                    if stored and stored.status == SubAgentStatus.TIMED_OUT:
+                        await self._fire_status(request.id, "failed", "Timed out", "❌")
+                    elif result.error:
+                        await self._fire_status(request.id, "failed", "Failed", "❌")
+                    else:
+                        await self._fire_status(request.id, "completed", "Completed", "✅")
 
                 # Send notification if requested (skip if result is None, which
                 # indicates cancelled-after-completion)
@@ -381,6 +432,10 @@ class SubAgentRunner:
                     )
 
             logger.info(f"Sub-agent {request.id} was cancelled")
+
+            # Fire cancelled status before re-raise — mirrors the existing notifier pattern
+            with contextlib.suppress(Exception):
+                await self._fire_status(request.id, "cancelled", "Cancelled", "🚫")
 
             # Notify parent — must happen before re-raise; suppress secondary CancelledError
             if request.notify:
@@ -425,6 +480,9 @@ class SubAgentRunner:
                     )
 
             logger.error(f"Sub-agent {request.id} failed: {e}", exc_info=True)
+
+            # Fire failed status before notification
+            await self._fire_status(request.id, "failed", "Failed", "❌")
 
             # Notify parent of failure
             if request.notify:

--- a/openpaw/workspace/runner.py
+++ b/openpaw/workspace/runner.py
@@ -566,9 +566,6 @@ class WorkspaceRunner:
                 return
             if not mw._config.enabled or not mw._config.subagent_status:
                 return
-            # No channel context during cron/heartbeat sub-agent runs
-            if not mw._channel or not mw._session_key:
-                return
             if event == "start":
                 await mw.create_subagent_status(subagent_id, text)
             elif event == "tool":

--- a/openpaw/workspace/runner.py
+++ b/openpaw/workspace/runner.py
@@ -551,6 +551,31 @@ class WorkspaceRunner:
         subagent_session_logger = SessionLogger(
             self._workspace.path, session_type="subagent"
         )
+
+        # Closure bridges sub-agent lifecycle events to StatusUpdateMiddleware.
+        # Reads self._status_update_middleware lazily so it works even if
+        # middleware is built after this closure is created.
+        async def _subagent_status_callback(
+            subagent_id: str,
+            event: str,
+            text: str,
+            emoji: str | None,
+        ) -> None:
+            mw = self._status_update_middleware
+            if mw is None:
+                return
+            if not mw._config.enabled or not mw._config.subagent_status:
+                return
+            # No channel context during cron/heartbeat sub-agent runs
+            if not mw._channel or not mw._session_key:
+                return
+            if event == "start":
+                await mw.create_subagent_status(subagent_id, text)
+            elif event == "tool":
+                await mw.update_subagent_status(subagent_id, text, emoji)
+            elif event in ("completed", "failed", "cancelled"):
+                await mw.finalize_subagent_status(subagent_id, event)
+
         self._subagent_runner = SubAgentRunner(
             agent_factory=self._agent_factory.get_agent_factory_closure(),
             store=self._subagent_store,
@@ -562,6 +587,7 @@ class WorkspaceRunner:
             session_logger=subagent_session_logger,
             profile_resolver=profile_resolver,
             agent_factory_instance=self._agent_factory,
+            status_callback=_subagent_status_callback,
         )
         self._tool_connector.connect_spawn_tool(self._subagent_runner)
         self._tool_connector.connect_channel_history_tool(self._checkpointer)

--- a/tests/subagent/test_runner_status_callback.py
+++ b/tests/subagent/test_runner_status_callback.py
@@ -1,0 +1,360 @@
+"""Tests for SubAgentRunner status_callback lifecycle events."""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from openpaw.agent.metrics import InvocationMetrics
+from openpaw.agent.runner import AgentRunner
+from openpaw.channels.base import ChannelAdapter
+from openpaw.model.subagent import SubAgentRequest, SubAgentStatus
+from openpaw.runtime.subagent.runner import SubAgentRunner
+from openpaw.stores.subagent import SubAgentStore
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_store():
+    store = Mock(spec=SubAgentStore)
+    store.update_status = AsyncMock()
+    store.save_result = AsyncMock()
+    store.get = AsyncMock(return_value=None)
+    store.get_result = AsyncMock(return_value=None)
+    store.list_active = AsyncMock(return_value=[])
+    store.list_recent = AsyncMock(return_value=[])
+    return store
+
+
+@pytest.fixture
+def mock_channel():
+    channel = Mock(spec=ChannelAdapter)
+    channel.send_message = AsyncMock()
+    return channel
+
+
+@pytest.fixture
+def success_runner():
+    runner = Mock(spec=AgentRunner)
+    runner.run = AsyncMock(return_value="done")
+    runner.additional_tools = []
+    runner._build_agent = Mock(return_value=Mock())
+    runner._agent = Mock()
+    runner._middleware = []
+    runner._log_label = "test"
+    runner.last_metrics = InvocationMetrics(
+        input_tokens=10, output_tokens=5, total_tokens=15, llm_calls=1
+    )
+    runner._last_tools_used = []
+    runner._current_tool_name = None
+    return runner
+
+
+@pytest.fixture
+def failing_runner():
+    runner = Mock(spec=AgentRunner)
+    runner.run = AsyncMock(side_effect=RuntimeError("boom"))
+    runner.additional_tools = []
+    runner._build_agent = Mock(return_value=Mock())
+    runner._agent = Mock()
+    runner._middleware = []
+    runner._log_label = "test"
+    runner.last_metrics = None
+    runner._last_tools_used = []
+    runner._current_tool_name = None
+    return runner
+
+
+def _make_request(
+    request_id: str = "req-1",
+    label: str = "researcher",
+    notify: bool = False,
+) -> SubAgentRequest:
+    return SubAgentRequest(
+        id=request_id,
+        task="Do research",
+        label=label,
+        status=SubAgentStatus.RUNNING,
+        session_key="telegram:12345",
+        timeout_minutes=30,
+        notify=notify,
+    )
+
+
+def _make_runner(
+    agent_runner_fixture,
+    mock_store,
+    mock_channel,
+    status_callback=None,
+) -> SubAgentRunner:
+    return SubAgentRunner(
+        agent_factory=lambda: agent_runner_fixture,
+        store=mock_store,
+        channels={"telegram": mock_channel},
+        workspace_name="test",
+        max_concurrent=4,
+        status_callback=status_callback,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Status callback — start event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_callback_fires_start_on_spawn(
+    success_runner, mock_store, mock_channel
+):
+    events: list[tuple] = []
+
+    async def callback(subagent_id, event, text, emoji):
+        events.append((subagent_id, event, text, emoji))
+
+    runner = _make_runner(success_runner, mock_store, mock_channel, callback)
+    request = _make_request()
+    await runner._execute_subagent(request)
+
+    start_events = [e for e in events if e[1] == "start"]
+    assert len(start_events) == 1
+    assert start_events[0][0] == "req-1"
+    assert start_events[0][2] == "researcher"
+
+
+# ---------------------------------------------------------------------------
+# Status callback — completed event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_callback_fires_completed_on_success(
+    success_runner, mock_store, mock_channel
+):
+    events: list[tuple] = []
+
+    async def callback(subagent_id, event, text, emoji):
+        events.append((subagent_id, event, text, emoji))
+
+    runner = _make_runner(success_runner, mock_store, mock_channel, callback)
+    request = _make_request()
+    await runner._execute_subagent(request)
+
+    terminal = [e for e in events if e[1] in ("completed", "failed", "cancelled")]
+    assert len(terminal) == 1
+    assert terminal[0][1] == "completed"
+    assert terminal[0][0] == "req-1"
+
+
+# ---------------------------------------------------------------------------
+# Status callback — failed event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_callback_fires_failed_on_exception(
+    failing_runner, mock_store, mock_channel
+):
+    events: list[tuple] = []
+
+    async def callback(subagent_id, event, text, emoji):
+        events.append((subagent_id, event, text, emoji))
+
+    runner = _make_runner(failing_runner, mock_store, mock_channel, callback)
+    request = _make_request()
+    await runner._execute_subagent(request)
+
+    terminal = [e for e in events if e[1] in ("completed", "failed", "cancelled")]
+    assert len(terminal) == 1
+    assert terminal[0][1] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# Status callback — cancelled event (before re-raise)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_callback_fires_cancelled_before_reraise(
+    mock_store, mock_channel
+):
+    events: list[tuple] = []
+
+    async def callback(subagent_id, event, text, emoji):
+        events.append((subagent_id, event, text, emoji))
+
+    slow_runner = Mock(spec=AgentRunner)
+
+    async def slow_run(message):
+        await asyncio.sleep(10)
+        return "never"
+
+    slow_runner.run = AsyncMock(side_effect=slow_run)
+    slow_runner.additional_tools = []
+    slow_runner._build_agent = Mock(return_value=Mock())
+    slow_runner._agent = Mock()
+    slow_runner._middleware = []
+    slow_runner._log_label = "test"
+    slow_runner.last_metrics = None
+    slow_runner._last_tools_used = []
+    slow_runner._current_tool_name = None
+
+    runner = _make_runner(slow_runner, mock_store, mock_channel, callback)
+    request = _make_request()
+
+    task = asyncio.create_task(runner._execute_subagent(request))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    cancelled_events = [e for e in events if e[1] == "cancelled"]
+    assert len(cancelled_events) == 1
+    assert cancelled_events[0][0] == "req-1"
+
+
+# ---------------------------------------------------------------------------
+# Status callback — profile not found fires failed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_callback_fires_failed_on_profile_not_found(
+    mock_store, mock_channel
+):
+    from openpaw.runtime.subagent.profiler import ProfileNotFoundError
+
+    events: list[tuple] = []
+
+    async def callback(subagent_id, event, text, emoji):
+        events.append((subagent_id, event, text, emoji))
+
+    dummy_runner = Mock(spec=AgentRunner)
+    dummy_runner.additional_tools = []
+    dummy_runner._middleware = []
+    dummy_runner._log_label = "test"
+
+    runner_inst = SubAgentRunner(
+        agent_factory=lambda: dummy_runner,
+        store=mock_store,
+        channels={"telegram": mock_channel},
+        workspace_name="test",
+        max_concurrent=4,
+        status_callback=callback,
+    )
+    # Force profiler to raise ProfileNotFoundError
+    runner_inst._profiler.setup = Mock(
+        side_effect=ProfileNotFoundError("missing-profile")
+    )
+
+    request = SubAgentRequest(
+        id="req-pnf",
+        task="task",
+        label="label",
+        status=SubAgentStatus.RUNNING,
+        session_key="telegram:12345",
+        timeout_minutes=30,
+        notify=False,
+        profile="missing-profile",
+    )
+    await runner_inst._execute_subagent(request)
+
+    failed_events = [e for e in events if e[1] == "failed"]
+    assert len(failed_events) == 1
+    assert failed_events[0][0] == "req-pnf"
+
+
+# ---------------------------------------------------------------------------
+# Status callback — None is safe (no-op)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_status_callback_runs_fine(success_runner, mock_store, mock_channel):
+    """SubAgentRunner with status_callback=None should work without errors."""
+    runner = _make_runner(success_runner, mock_store, mock_channel, status_callback=None)
+    request = _make_request()
+
+    # Should not raise
+    await runner._execute_subagent(request)
+
+    status_calls = mock_store.update_status.call_args_list
+    assert any(c[0][1] == SubAgentStatus.COMPLETED for c in status_calls)
+
+
+# ---------------------------------------------------------------------------
+# Status callback — config disabled via WorkspaceRunner closure pattern
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_callback_errors_are_suppressed(success_runner, mock_store, mock_channel):
+    """Exceptions in the callback must not propagate into the sub-agent run."""
+
+    async def bad_callback(subagent_id, event, text, emoji):
+        raise RuntimeError("callback exploded")
+
+    runner = _make_runner(success_runner, mock_store, mock_channel, bad_callback)
+    request = _make_request()
+
+    # Should not raise despite the callback crashing
+    await runner._execute_subagent(request)
+
+    status_calls = mock_store.update_status.call_args_list
+    assert any(c[0][1] == SubAgentStatus.COMPLETED for c in status_calls)
+
+
+# ---------------------------------------------------------------------------
+# Multiple concurrent sub-agents — callbacks are isolated by subagent_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_subagents_receive_separate_ids(
+    mock_store, mock_channel
+):
+    ids_seen: set[str] = set()
+
+    async def callback(subagent_id, event, text, emoji):
+        ids_seen.add(subagent_id)
+
+    async def quick_run(message):
+        await asyncio.sleep(0.01)
+        return "done"
+
+    def make_agent():
+        r = Mock(spec=AgentRunner)
+        r.run = AsyncMock(side_effect=quick_run)
+        r.additional_tools = []
+        r._build_agent = Mock(return_value=Mock())
+        r._agent = Mock()
+        r._middleware = []
+        r._log_label = "test"
+        r.last_metrics = InvocationMetrics(
+            input_tokens=1, output_tokens=1, total_tokens=2, llm_calls=1
+        )
+        r._last_tools_used = []
+        r._current_tool_name = None
+        return r
+
+    runner = SubAgentRunner(
+        agent_factory=make_agent,
+        store=mock_store,
+        channels={"telegram": mock_channel},
+        workspace_name="test",
+        max_concurrent=4,
+        status_callback=callback,
+    )
+
+    req1 = _make_request("req-A", "alpha")
+    req2 = _make_request("req-B", "beta")
+
+    await asyncio.gather(
+        runner._execute_subagent(req1),
+        runner._execute_subagent(req2),
+    )
+
+    assert "req-A" in ids_seen
+    assert "req-B" in ids_seen

--- a/tests/test_status_update_middleware.py
+++ b/tests/test_status_update_middleware.py
@@ -1021,3 +1021,255 @@ async def test_emoji_map_returns_default_for_unknown_tool():
         "telegram:123456",
         "🔧 Using tools: unknown_tool...",
     )
+
+
+# ---------------------------------------------------------------------------
+# Sub-agent status methods
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_subagent_status_sends_message_and_stores_id():
+    channel = MockChannel()
+    mw = _make_middleware(channel=channel)
+
+    await mw.create_subagent_status("req-1", "researcher")
+
+    assert len(channel.sent_messages) == 1
+    content = channel.sent_messages[0][1]
+    assert "researcher" in content
+    assert "req-1" in mw._subagent_status_ids
+    msg_id, label = mw._subagent_status_ids["req-1"]
+    assert msg_id == "1"
+    assert label == "researcher"
+
+
+@pytest.mark.asyncio
+async def test_create_subagent_status_noop_when_disabled():
+    channel = MockChannel()
+    mw = _make_middleware(config=_make_config(enabled=False), channel=channel)
+
+    await mw.create_subagent_status("req-1", "researcher")
+
+    assert len(channel.sent_messages) == 0
+    assert "req-1" not in mw._subagent_status_ids
+
+
+@pytest.mark.asyncio
+async def test_create_subagent_status_noop_when_subagent_status_false():
+    channel = MockChannel()
+    cfg = _make_config()
+    cfg2 = cfg.model_copy(update={"subagent_status": False})
+    mw = _make_middleware(config=cfg2, channel=channel)
+
+    await mw.create_subagent_status("req-1", "researcher")
+
+    assert len(channel.sent_messages) == 0
+
+
+@pytest.mark.asyncio
+async def test_create_subagent_status_noop_without_channel_context():
+    mw = _make_middleware()
+    # No channel set
+
+    await mw.create_subagent_status("req-1", "researcher")
+
+    assert "req-1" not in mw._subagent_status_ids
+
+
+@pytest.mark.asyncio
+async def test_update_subagent_status_edits_correct_message():
+    channel = MockChannel()
+    mw = _make_middleware(channel=channel)
+
+    await mw.create_subagent_status("req-1", "researcher")
+    await mw.update_subagent_status("req-1", "Running tool: brave_search...")
+
+    assert len(channel.edited_messages) == 1
+    assert channel.edited_messages[0][1] == "1"
+    assert "brave_search" in channel.edited_messages[0][2]
+
+
+@pytest.mark.asyncio
+async def test_update_subagent_status_noop_for_unknown_id():
+    channel = MockChannel()
+    mw = _make_middleware(channel=channel)
+
+    await mw.update_subagent_status("unknown-id", "Running tool: read_file...")
+
+    assert len(channel.edited_messages) == 0
+
+
+@pytest.mark.asyncio
+async def test_update_subagent_status_noop_when_disabled():
+    channel = MockChannel()
+    mw = _make_middleware(config=_make_config(enabled=False), channel=channel)
+    mw._subagent_status_ids["req-1"] = ("msg-99", "researcher")
+
+    await mw.update_subagent_status("req-1", "Running tool: read_file...")
+
+    assert len(channel.edited_messages) == 0
+
+
+@pytest.mark.asyncio
+async def test_finalize_subagent_status_edit_mode_on_completed():
+    channel = MockChannel()
+    mw = _make_middleware(channel=channel)
+
+    await mw.create_subagent_status("req-1", "researcher")
+    await mw.finalize_subagent_status("req-1", "completed")
+
+    assert len(channel.edited_messages) == 1
+    content = channel.edited_messages[0][2]
+    assert "✅" in content
+    assert "req-1" not in mw._subagent_status_ids
+
+
+@pytest.mark.asyncio
+async def test_finalize_subagent_status_edit_mode_on_failed():
+    channel = MockChannel()
+    mw = _make_middleware(channel=channel)
+
+    await mw.create_subagent_status("req-1", "researcher")
+    await mw.finalize_subagent_status("req-1", "failed")
+
+    assert len(channel.edited_messages) == 1
+    content = channel.edited_messages[0][2]
+    assert "❌" in content
+    assert "req-1" not in mw._subagent_status_ids
+
+
+@pytest.mark.asyncio
+async def test_finalize_subagent_status_edit_mode_on_cancelled():
+    channel = MockChannel()
+    mw = _make_middleware(channel=channel)
+
+    await mw.create_subagent_status("req-1", "researcher")
+    await mw.finalize_subagent_status("req-1", "cancelled")
+
+    assert len(channel.edited_messages) == 1
+    content = channel.edited_messages[0][2]
+    assert "🚫" in content
+    assert "req-1" not in mw._subagent_status_ids
+
+
+@pytest.mark.asyncio
+async def test_finalize_subagent_status_delete_mode():
+    channel = MockChannel()
+    cfg = _make_config()
+    cfg2 = cfg.model_copy(update={"subagent_status_cleanup": "delete"})
+    mw = _make_middleware(config=cfg2, channel=channel)
+
+    await mw.create_subagent_status("req-1", "researcher")
+    await mw.finalize_subagent_status("req-1", "completed")
+
+    assert len(channel.deleted_messages) == 1
+    assert channel.deleted_messages[0][1] == "1"
+    assert "req-1" not in mw._subagent_status_ids
+
+
+@pytest.mark.asyncio
+async def test_finalize_subagent_status_noop_for_unknown_id():
+    channel = MockChannel()
+    mw = _make_middleware(channel=channel)
+
+    await mw.finalize_subagent_status("unknown-id", "completed")
+
+    assert len(channel.edited_messages) == 0
+    assert len(channel.deleted_messages) == 0
+
+
+@pytest.mark.asyncio
+async def test_finalize_subagent_status_noop_when_subagent_status_false():
+    channel = MockChannel()
+    cfg = _make_config()
+    cfg2 = cfg.model_copy(update={"subagent_status": False})
+    mw = _make_middleware(config=cfg2, channel=channel)
+    mw._subagent_status_ids["req-1"] = ("msg-1", "researcher")
+
+    await mw.finalize_subagent_status("req-1", "completed")
+
+    assert len(channel.edited_messages) == 0
+    # ID stays because the method no-opped before cleanup
+    assert "req-1" in mw._subagent_status_ids
+
+
+@pytest.mark.asyncio
+async def test_concurrent_subagents_have_separate_message_ids():
+    channel = MockChannel()
+    mw = _make_middleware(channel=channel)
+
+    await mw.create_subagent_status("req-1", "researcher")
+    await mw.create_subagent_status("req-2", "writer")
+
+    assert len(channel.sent_messages) == 2
+    msg_id_1, _ = mw._subagent_status_ids["req-1"]
+    msg_id_2, _ = mw._subagent_status_ids["req-2"]
+    assert msg_id_1 != msg_id_2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_subagents_edits_do_not_cross():
+    channel = MockChannel()
+    mw = _make_middleware(channel=channel)
+
+    await mw.create_subagent_status("req-1", "researcher")
+    await mw.create_subagent_status("req-2", "writer")
+
+    await mw.update_subagent_status("req-1", "Running tool: brave_search...")
+    await mw.update_subagent_status("req-2", "Running tool: read_file...")
+
+    # Each edit targets its own message ID
+    assert channel.edited_messages[0][1] == "1"
+    assert channel.edited_messages[1][1] == "2"
+    assert channel.edited_messages[0][1] != channel.edited_messages[1][1]
+
+
+def test_reset_does_not_clear_subagent_status_ids():
+    """Sub-agent status IDs survive reset() — sub-agents may outlive the main run."""
+    channel = MockChannel()
+    mw = _make_middleware(channel=channel)
+    mw._subagent_status_ids["req-1"] = ("msg-42", "researcher")
+
+    mw.reset()
+
+    assert mw._subagent_status_ids == {"req-1": ("msg-42", "researcher")}
+
+
+def test_subagent_status_config_defaults():
+    config = StatusUpdatesConfig()
+    assert config.subagent_status is True
+    assert config.subagent_status_cleanup == "edit"
+
+
+def test_subagent_status_config_custom():
+    config = StatusUpdatesConfig(subagent_status=False, subagent_status_cleanup="delete")
+    assert config.subagent_status is False
+    assert config.subagent_status_cleanup == "delete"
+
+
+def test_subagent_status_cleanup_invalid_value():
+    with pytest.raises(Exception):
+        StatusUpdatesConfig(subagent_status_cleanup="archive")
+
+
+@pytest.mark.asyncio
+async def test_finalize_removes_entry_even_without_channel_context():
+    """Entry is popped from _subagent_status_ids even when channel is None after reset()."""
+    channel = MockChannel()
+    mw = _make_middleware(channel=channel)
+
+    await mw.create_subagent_status("sub-1", "researcher")
+    assert "sub-1" in mw._subagent_status_ids
+
+    mw.reset()
+    # Channel and session_key are now None, but the dict entry remains.
+    assert mw._channel is None
+    assert mw._session_key is None
+    assert "sub-1" in mw._subagent_status_ids
+
+    await mw.finalize_subagent_status("sub-1", "completed")
+
+    assert "sub-1" not in mw._subagent_status_ids
+    assert len(channel.edited_messages) == 0
+    assert len(channel.deleted_messages) == 0

--- a/tests/test_status_update_middleware.py
+++ b/tests/test_status_update_middleware.py
@@ -1039,7 +1039,7 @@ async def test_create_subagent_status_sends_message_and_stores_id():
     content = channel.sent_messages[0][1]
     assert "researcher" in content
     assert "req-1" in mw._subagent_status_ids
-    msg_id, label = mw._subagent_status_ids["req-1"]
+    msg_id, label, _ch, _sk = mw._subagent_status_ids["req-1"]
     assert msg_id == "1"
     assert label == "researcher"
 
@@ -1104,7 +1104,7 @@ async def test_update_subagent_status_noop_for_unknown_id():
 async def test_update_subagent_status_noop_when_disabled():
     channel = MockChannel()
     mw = _make_middleware(config=_make_config(enabled=False), channel=channel)
-    mw._subagent_status_ids["req-1"] = ("msg-99", "researcher")
+    mw._subagent_status_ids["req-1"] = ("msg-99", "researcher", channel, "telegram:123456")
 
     await mw.update_subagent_status("req-1", "Running tool: read_file...")
 
@@ -1185,7 +1185,7 @@ async def test_finalize_subagent_status_noop_when_subagent_status_false():
     cfg = _make_config()
     cfg2 = cfg.model_copy(update={"subagent_status": False})
     mw = _make_middleware(config=cfg2, channel=channel)
-    mw._subagent_status_ids["req-1"] = ("msg-1", "researcher")
+    mw._subagent_status_ids["req-1"] = ("msg-1", "researcher", channel, "telegram:123456")
 
     await mw.finalize_subagent_status("req-1", "completed")
 
@@ -1203,8 +1203,8 @@ async def test_concurrent_subagents_have_separate_message_ids():
     await mw.create_subagent_status("req-2", "writer")
 
     assert len(channel.sent_messages) == 2
-    msg_id_1, _ = mw._subagent_status_ids["req-1"]
-    msg_id_2, _ = mw._subagent_status_ids["req-2"]
+    msg_id_1 = mw._subagent_status_ids["req-1"][0]
+    msg_id_2 = mw._subagent_status_ids["req-2"][0]
     assert msg_id_1 != msg_id_2
 
 
@@ -1229,11 +1229,13 @@ def test_reset_does_not_clear_subagent_status_ids():
     """Sub-agent status IDs survive reset() — sub-agents may outlive the main run."""
     channel = MockChannel()
     mw = _make_middleware(channel=channel)
-    mw._subagent_status_ids["req-1"] = ("msg-42", "researcher")
+    mw._subagent_status_ids["req-1"] = ("msg-42", "researcher", channel, "telegram:123456")
 
     mw.reset()
 
-    assert mw._subagent_status_ids == {"req-1": ("msg-42", "researcher")}
+    assert "req-1" in mw._subagent_status_ids
+    assert mw._subagent_status_ids["req-1"][0] == "msg-42"
+    assert mw._subagent_status_ids["req-1"][1] == "researcher"
 
 
 def test_subagent_status_config_defaults():
@@ -1255,7 +1257,11 @@ def test_subagent_status_cleanup_invalid_value():
 
 @pytest.mark.asyncio
 async def test_finalize_removes_entry_even_without_channel_context():
-    """Entry is popped from _subagent_status_ids even when channel is None after reset()."""
+    """Entry is popped and status updated even when self._channel is None after reset().
+
+    The fix stores (channel, session_key) in the tuple at create time, so finalize
+    uses the stored refs rather than the cleared self._channel / self._session_key.
+    """
     channel = MockChannel()
     mw = _make_middleware(channel=channel)
 
@@ -1270,6 +1276,55 @@ async def test_finalize_removes_entry_even_without_channel_context():
 
     await mw.finalize_subagent_status("sub-1", "completed")
 
+    # Entry is cleaned up.
     assert "sub-1" not in mw._subagent_status_ids
-    assert len(channel.edited_messages) == 0
-    assert len(channel.deleted_messages) == 0
+    # Stored channel refs allow the edit to proceed despite reset() clearing self._channel.
+    assert len(channel.edited_messages) == 1
+    assert "✅" in channel.edited_messages[0][2]
+
+
+@pytest.mark.asyncio
+async def test_finalize_works_after_reset_clears_channel():
+    """finalize_subagent_status uses stored (channel, session_key) after reset()."""
+    channel = MockChannel()
+    mw = _make_middleware(channel=channel)
+
+    await mw.create_subagent_status("sub-1", "researcher")
+    stored_msg_id = mw._subagent_status_ids["sub-1"][0]
+    stored_session_key = mw._subagent_status_ids["sub-1"][3]
+
+    mw.reset()
+    assert mw._channel is None
+    assert mw._session_key is None
+
+    await mw.finalize_subagent_status("sub-1", "completed")
+
+    assert "sub-1" not in mw._subagent_status_ids
+    assert len(channel.edited_messages) == 1
+    edit_session_key, edit_msg_id, edit_content = channel.edited_messages[0]
+    assert edit_session_key == stored_session_key
+    assert edit_msg_id == stored_msg_id
+    assert "✅" in edit_content
+
+
+@pytest.mark.asyncio
+async def test_update_works_after_reset_clears_channel():
+    """update_subagent_status uses stored (channel, session_key) after reset()."""
+    channel = MockChannel()
+    mw = _make_middleware(channel=channel)
+
+    await mw.create_subagent_status("sub-1", "researcher")
+    stored_msg_id = mw._subagent_status_ids["sub-1"][0]
+    stored_session_key = mw._subagent_status_ids["sub-1"][3]
+
+    mw.reset()
+    assert mw._channel is None
+    assert mw._session_key is None
+
+    await mw.update_subagent_status("sub-1", "Running tool: shell", "💻")
+
+    assert len(channel.edited_messages) == 1
+    edit_session_key, edit_msg_id, edit_content = channel.edited_messages[0]
+    assert edit_session_key == stored_session_key
+    assert edit_msg_id == stored_msg_id
+    assert "Running tool: shell" in edit_content


### PR DESCRIPTION
## Summary

Each spawned sub-agent now gets its own Hermes-style status message that is created on dispatch, edited as the sub-agent runs each tool, and finalized to ✅ Completed / ❌ Failed / 🚫 Cancelled. Gives the user real-time visibility into long-running team members instead of staring at silence while sub-agents run 10+ minutes.

### Architecture
- `SubAgentToolMiddleware` (new, ~60 LOC) is injected into each sub-agent's `AgentRunner` and forwards each tool call to the parent's `StatusUpdateMiddleware` via a `status_callback` on `SubAgentRunner`.
- Sub-agent lifecycle events (`start`, `completed`, `failed`, `cancelled`) are fired from `SubAgentRunner._execute_subagent` directly. Terminal events use `SubAgentStatus.TIMED_OUT` enum (not error-string matching).
- Bridge closure lives in `WorkspaceRunner.start()` and routes events to the middleware.
- Per-sub-agent `(channel, session_key)` are captured at create time and stored alongside the message id, so sub-agents that outlive the parent's `MessageProcessor` turn still get their status updated and finalized.

### Config
Two new fields on `StatusUpdatesConfig`:
- `subagent_status: bool = True`
- `subagent_status_cleanup: "edit" | "delete" = "edit"`

Closes #144

## Test plan

- [x] Full suite: 3059 passed (3029 baseline + 30 new)
- [x] code-reviewer: approved after 2 blockers fixed (dict entry leak, error-string fragility)
- [x] Stage validation #1 on `krieger` workspace — per-tool status updates streamed in real time for two concurrent sub-agents
- [x] Stage validation #2 — confirmed sub-agents that complete after the parent agent turn ends still finalize correctly (✅) — fix in `7d157b7`
- [ ] Optional: `subagent_status_cleanup: "delete"` mode covered by unit tests; not stage-validated end-to-end (low-risk, single code branch)