### PR TITLE
release: bump version to 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Per-sub-agent status messages** — Each spawned sub-agent now gets its own Hermes-style status message that is created on dispatch, edited as the sub-agent runs each tool, and finalized to `✅ Completed`, `❌ Failed`, or `🚫 Cancelled` on completion. Gives the user real-time visibility into long-running team members. New `SubAgentToolMiddleware` is injected into each sub-agent's runner; events bridge back to the parent `StatusUpdateMiddleware` via a `status_callback` on `SubAgentRunner`. (#144)
+### Changed
+
+### Removed
+
+### Fixed
+
+## [0.4.2] - 2026-06-10
+
+### Added
+
+- **Per-sub-agent status messages** — Each spawned sub-agent now gets its own live status message that is created on dispatch, edited as the sub-agent runs each tool, and finalized to `✅ Completed`, `❌ Failed`, or `🚫 Cancelled` on completion. Gives the user real-time visibility into long-running team members. New `SubAgentToolMiddleware` is injected into each sub-agent's runner; events bridge back to the parent `StatusUpdateMiddleware` via a `status_callback` on `SubAgentRunner`. (#144)
 - **`StatusUpdatesConfig.subagent_status`** (default `true`) and **`subagent_status_cleanup`** (`"edit"` / `"delete"`, default `"edit"`) configuration fields to control per-sub-agent status behavior.
 - **Automatic status updates** — `StatusUpdateMiddleware` reports agent start, tool usage, and sub-agent dispatch to the user channel with configurable throttling.
-- **Edit-in-place status pattern** — Status updates edit a single message in place instead of sending multiple messages. Supports `edit_message`/`delete_message` on Telegram and Discord. Configurable via `status_updates.edit_in_place` (default: `true`).
+- **Live in-place status pattern** — Status updates edit a single message in place instead of sending multiple messages. Supports `edit_message`/`delete_message` on Telegram and Discord. Configurable via `status_updates.edit_in_place` (default: `true`).
 - **Run-aware status labels** — First user-message run shows `"Starting work..."`, subsequent runs show `"Continuing work..."`. System events (cron, heartbeat, sub-agent completions) skip the status update to avoid mid-task confusion.
 - **`report_progress` builtin tool** — Agent-driven structured progress reporting with `status`, `detail`, and optional `percentage` (0-100).
 - **`StatusUpdatesConfig`** configuration model with workspace-level toggles (`agent_start`, `tool_calls_detected`, `tool_start`, `tool_complete`, `subagent_spawned`, `edit_in_place`) and throttling (`min_interval_seconds`, `max_updates_per_run`).
@@ -34,11 +44,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `min_interval_seconds` default lowered from `3` to `1` to allow `tool_start` messages to get through during multi-step operations.
 - `tool_start` now defaults to `true` so granular status details are visible without manual configuration.
 - Interrupt mode fallback notification now uses emoji-prefixed `🛑 Stopping current run — processing your new message` instead of bracketed `[Run interrupted — processing new message]`, making it unmistakably user-facing.
+- `BrowserSession` typed with explicit `Playwright | Browser | BrowserContext | Page` annotations and `_require_page()` / `_require_context()` accessors. Calling a browser tool before launch now raises a clear `RuntimeError("Browser not launched")` instead of an opaque `AttributeError` on `None`.
+- Develop CI mypy step is now a hard gate. Previously the step was annotated `continue-on-error: true`, which silently allowed type regressions onto develop and would have failed the publish workflow at tag-push time.
 
 ### Removed
 
 ### Fixed
 
+- Resolved all outstanding mypy errors across the codebase (40 errors → 0). The bulk were in `openpaw/builtins/tools/browser/session.py` from a prior browser refactor where Playwright lifecycle fields were initialized to `None` without `Optional` annotations.
 - `StatusUpdateMiddleware` now sends the steer redirect notification exactly once per steer event instead of re-editing the status message for every skipped tool. Adds a `_steer_notified` guard that is reset in `set_context()` and `reset()` so subsequent runs can notify again. (#146)
 - Fixed `AttributeError: 'CronToolBuiltin' object has no attribute '_add_to_live_scheduler'` in `FollowupScheduler` and `MessageProcessor` — both callers now use the standalone `_add_to_live_scheduler(scheduler, task)` bridge function from `scheduler_bridge.py` instead of calling a non-existent instance method. This was crashing the queue processor on delayed followup scheduling.
 - `LaneQueue.process()` now catches handler exceptions and continues the loop, preventing a single handler crash from killing the entire message pipeline.
@@ -115,6 +128,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Various race conditions in approval gate resolution and sub-agent cancellation.
 - Path traversal protection hardened across filesystem tools and inbound processors.
 
-[Unreleased]: https://github.com/johnsosoka/OpenPaw/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/johnsosoka/OpenPaw/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/johnsosoka/OpenPaw/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/johnsosoka/openpaw/releases/tag/v0.4.1
 [0.4.0]: https://github.com/johnsosoka/openpaw/releases/tag/v0.4.0

--- a/openpaw/__init__.py
+++ b/openpaw/__init__.py
@@ -1,9 +1,4 @@
-"""OpenPaw - Multi-Channel AI Agent Framework built on LangGraph.
+"""OpenPaw - AI Agent Framework with DeepAgents and Multi-Channel Support."""
 
-Each agent runs in an isolated workspace with its own identity, tools,
-conversation history, and scheduled tasks. Supports Telegram, Discord, and
-stdio channels out of the box.
-"""
-
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openpaw-ai"
-version = "0.4.1"
+version = "0.4.2"
 description = "OpenPaw - Multi-Channel AI Agent Framework with LangGraph"
 authors = [
     {name = "John Sosoka"}
@@ -121,7 +121,7 @@ warn_unused_ignores = false
 
 [tool.poetry]
 name = "openpaw-ai"
-version = "0.4.1"
+version = "0.4.2"
 description = "OpenPaw - Multi-Channel AI Agent Framework with LangGraph"
 authors = ["John Sosoka"]
 packages = [{include = "openpaw"}]


### PR DESCRIPTION
## Summary

Prepare the v0.4.2 release: "status updates & agent insights" — patch release that ships per-sub-agent live status messages, the run-aware in-place status pattern for the primary agent, mid-run notifications for steer/interrupt/collect, typing indicators, emoji reactions, the README refresh, and a strict-mypy + CI gate hardening pass.

## What's in this PR

- Bump `pyproject.toml` `0.4.1` → `0.4.2` (both `[project]` and `[tool.poetry]` entries)
- Sync `openpaw/__init__.py` `__version__` via `scripts/sync_version.py`
- Finalize `CHANGELOG.md`:
  - Move the `[Unreleased]` section into a dated `[0.4.2] - 2026-06-10` section
  - Add a fresh empty `[Unreleased]` skeleton
  - Add the strict-mypy / CI gate hardening entries (Changed + Fixed)
  - Update compare links

## Test plan

- [x] `poetry run mypy openpaw/` — 0 errors
- [x] `poetry run ruff check openpaw/` — clean
- [x] `poetry run pytest -q` — 3059 passed
- [x] `scripts/sync_version.py --check` — versions match
- [ ] User regression testing on develop after merge
- [ ] Tag `v0.4.2` from `main` after `develop` → `main` PR merges; publish workflow handles TestPyPI → manual approval → prod PyPI

## Notes

No code changes — version metadata + CHANGELOG only.