### PR TITLE
fix: remove per-run status update budget cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **`status_updates.max_updates_per_run`** configuration field has been removed. The per-agent-run budget cap (default `10`) silently dropped status updates after the budget was exhausted, which produced a "frozen status" UX during tool-heavy runs (e.g., browser sessions with 30+ tool calls). `min_interval_seconds` remains the active throttle; the agent loop's own recursion ceiling caps total iterations.
+
 ### Fixed
 
 - Resolved all outstanding mypy errors across the codebase (40 errors → 0). The bulk were in `openpaw/builtins/tools/browser/session.py` from a prior browser refactor where Playwright lifecycle fields were initialized to `None` without `Optional` annotations.

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -836,7 +836,6 @@ status_updates:
   tool_complete: false       # Report per-tool completion (default: false)
   subagent_spawned: true     # Report sub-agent dispatch (default: true)
   min_interval_seconds: 3    # Min seconds between auto-updates (default: 3)
-  max_updates_per_run: 10    # Max auto-updates per run (default: 10)
   edit_in_place: true        # Edit single message in place (default: true)
 ```
 
@@ -846,7 +845,6 @@ status_updates:
 - **Run-aware labels**: First run shows `"Starting work..."`, subsequent runs show `"Continuing work..."`.
 - **System events skip**: Cron, heartbeat, and sub-agent completion events do not trigger status updates to avoid mid-task confusion.
 - Time-based throttle: `min_interval_seconds` between auto-detected status messages
-- Budget-based throttle: `max_updates_per_run` total auto-updates per agent invocation
 - Deduplication: if the same tool set is detected twice, only report once
 - Agent-driven `report_progress` tool calls bypass all throttling
 - Resets between agent runs (each user message starts a fresh count)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -530,7 +530,6 @@ status_updates:
   tool_complete: false       # Report after each tool execution
   subagent_spawned: true     # Report when sub-agent is dispatched
   min_interval_seconds: 3    # Minimum seconds between auto-updates
-  max_updates_per_run: 10    # Maximum auto-updates per agent run
   edit_in_place: true        # Edit single message in place (default: true)
   typing_indicator: true      # Send typing indicator while agent is processing
   reactions: true            # Add emoji reactions to the user's original message
@@ -549,8 +548,6 @@ status_updates:
 **subagent_spawned** — Send `"Dispatched sub-agent: label"` when `spawn_agent` is called. Default: `true`.
 
 **min_interval_seconds** — Minimum seconds between auto-detected status updates. Prevents spam during rapid tool-call sequences. Default: `3`.
-
-**max_updates_per_run** — Maximum number of auto-detected status updates per agent invocation. Default: `10`.
 
 **edit_in_place** — When `true` (default), the first status update sends a new message, and subsequent updates edit the same message in place. This prevents chat clutter. The status message is deleted after the agent run completes. When `false`, each update sends a separate message.
 

--- a/openpaw/agent/middleware/status_update.py
+++ b/openpaw/agent/middleware/status_update.py
@@ -130,7 +130,6 @@ class StatusUpdateMiddleware(AgentMiddleware):
 
     Throttling:
     - Time-based: min_interval_seconds between auto-detected updates.
-    - Budget-based: max_updates_per_run total auto-updates per agent invocation.
     - Deduplication: if the same set of tools is detected twice, only report once.
     - Agent-driven report_progress bypasses all throttling.
 
@@ -151,7 +150,6 @@ class StatusUpdateMiddleware(AgentMiddleware):
         self._channel: Any | None = None
         self._session_key: str | None = None
         self._last_update_time: float = 0.0
-        self._updates_sent: int = 0
         self._last_reported_tools: frozenset[str] = frozenset()
         self._status_message_id: str | None = None
         self._steer_notified: bool = False
@@ -184,7 +182,6 @@ class StatusUpdateMiddleware(AgentMiddleware):
         self._run_count = run_count
         self._is_system_batch = is_system_batch
         self._last_update_time = 0.0
-        self._updates_sent = 0
         self._last_reported_tools = frozenset()
         self._status_message_id = None
         self._steer_notified = False
@@ -196,7 +193,6 @@ class StatusUpdateMiddleware(AgentMiddleware):
         self._run_count = 1
         self._is_system_batch = False
         self._last_update_time = 0.0
-        self._updates_sent = 0
         self._last_reported_tools = frozenset()
         self._status_message_id = None
         self._steer_notified = False
@@ -499,13 +495,6 @@ class StatusUpdateMiddleware(AgentMiddleware):
             if not channel or not session_key:
                 return
 
-        # Budget throttle
-        if not force and self._updates_sent >= self._config.max_updates_per_run:
-            logger.debug(
-                "Status update throttled (budget exhausted): %s", text
-            )
-            return
-
         # Time throttle
         now = time.monotonic()
         if not force and now - self._last_update_time < self._config.min_interval_seconds:
@@ -524,7 +513,6 @@ class StatusUpdateMiddleware(AgentMiddleware):
                     session_key, self._status_message_id, text
                 )
                 if edited:
-                    self._updates_sent += 1
                     self._last_update_time = now
                     logger.debug("Status message edited: %s", text)
                     await self._retrigger_typing(channel, session_key)
@@ -534,7 +522,6 @@ class StatusUpdateMiddleware(AgentMiddleware):
 
             # Send new message
             sent_message = await channel.send_message(session_key, text)
-            self._updates_sent += 1
             self._last_update_time = now
             if sent_message and hasattr(sent_message, "id"):
                 self._status_message_id = str(sent_message.id)

--- a/openpaw/core/config/models/status_updates.py
+++ b/openpaw/core/config/models/status_updates.py
@@ -42,9 +42,6 @@ class StatusUpdatesConfig(BaseModel):
     min_interval_seconds: int = Field(
         default=1, ge=0, description="Minimum seconds between auto-detected status updates"
     )
-    max_updates_per_run: int = Field(
-        default=10, ge=0, description="Maximum auto-detected updates per agent run"
-    )
     template: str = Field(
         default="[{event}] {message}", description="Optional format template for status messages"
     )

--- a/tests/test_status_update_middleware.py
+++ b/tests/test_status_update_middleware.py
@@ -54,7 +54,6 @@ def _make_config(
     run_interrupted: bool = True,
     collect_queued: bool = True,
     min_interval_seconds: int = 0,
-    max_updates_per_run: int = 10,
     edit_in_place: bool = True,
     use_emojis: bool = False,
     typing_indicator: bool = True,
@@ -71,7 +70,6 @@ def _make_config(
         run_interrupted=run_interrupted,
         collect_queued=collect_queued,
         min_interval_seconds=min_interval_seconds,
-        max_updates_per_run=max_updates_per_run,
         edit_in_place=edit_in_place,
         use_emojis=use_emojis,
         typing_indicator=typing_indicator,
@@ -433,23 +431,6 @@ async def test_throttling_time_based():
 
 
 @pytest.mark.asyncio
-async def test_throttling_budget_based():
-    channel = MockChannel()
-    mw = _make_middleware(
-        config=_make_config(max_updates_per_run=2),
-        channel=channel,
-    )
-
-    await mw._send_status("Update 1")
-    await mw._send_status("Update 2")
-    await mw._send_status("Update 3")
-
-    # In edit-in-place mode: 1 sent, 1 edited, 1 throttled
-    assert len(channel.sent_messages) == 1
-    assert len(channel.edited_messages) == 1
-
-
-@pytest.mark.asyncio
 async def test_throttling_time_allows_after_interval():
     channel = MockChannel()
     mw = _make_middleware(
@@ -473,7 +454,6 @@ async def test_throttling_time_allows_after_interval():
 def test_reset_clears_counters():
     channel = MockChannel()
     mw = _make_middleware(channel=channel)
-    mw._updates_sent = 5
     mw._last_update_time = time.monotonic()
     mw._last_reported_tools = frozenset(["read_file"])
     mw._status_message_id = "msg123"
@@ -482,7 +462,6 @@ def test_reset_clears_counters():
 
     assert mw._channel is None
     assert mw._session_key is None
-    assert mw._updates_sent == 0
     assert mw._last_update_time == 0.0
     assert mw._last_reported_tools == frozenset()
     assert mw._status_message_id is None
@@ -593,7 +572,6 @@ class TestStatusUpdatesConfig:
         assert config.run_interrupted is True
         assert config.collect_queued is True
         assert config.min_interval_seconds == 1
-        assert config.max_updates_per_run == 10
         assert config.template == "[{event}] {message}"
         assert config.edit_in_place is True
         assert config.typing_indicator is True
@@ -615,7 +593,6 @@ class TestStatusUpdatesConfig:
             run_interrupted=False,
             collect_queued=False,
             min_interval_seconds=0,
-            max_updates_per_run=5,
             template="{message}",
             edit_in_place=False,
             typing_indicator=False,
@@ -632,7 +609,6 @@ class TestStatusUpdatesConfig:
         assert config.run_interrupted is False
         assert config.collect_queued is False
         assert config.min_interval_seconds == 0
-        assert config.max_updates_per_run == 5
         assert config.template == "{message}"
         assert config.edit_in_place is False
         assert config.typing_indicator is False
@@ -642,10 +618,6 @@ class TestStatusUpdatesConfig:
     def test_min_interval_bounds(self):
         with pytest.raises(Exception):
             StatusUpdatesConfig(min_interval_seconds=-1)
-
-    def test_max_updates_bounds(self):
-        with pytest.raises(Exception):
-            StatusUpdatesConfig(max_updates_per_run=-1)
 
     def test_percent_bounds(self):
         with pytest.raises(Exception):

--- a/tests/workspace/test_message_processor_reactions.py
+++ b/tests/workspace/test_message_processor_reactions.py
@@ -123,7 +123,6 @@ def _make_status_update_middleware(
     config.tool_calls_detected = True
     config.subagent_spawned = True
     config.min_interval_seconds = 0
-    config.max_updates_per_run = 10
     config.edit_in_place = True
     middleware = MagicMock()
     middleware._config = config


### PR DESCRIPTION
## Summary

\`max_updates_per_run\` defaulted to 10, which silently dropped every status update past the 10th in any single agent run. Tool-heavy sessions — particularly browser automation with 30+ tool calls — hit the cap within the first ~5 tool invocations, leaving the user-visible status message frozen for the rest of the run.

## Stage signal that surfaced it

Stage log from \`ai-runner\` (single agent run, 30 browser tool calls):

\`\`\`
19:47:18  Agent run starting
19:47:20  browser_navigate     ← tool #1
19:47:29  browser_snapshot     ← tool #2
19:47:32  browser_click        ← tool #3
19:47:35  browser_snapshot     ← tool #4   ← status froze around here
19:47:38  browser_click
...
19:48:42  Agent run complete   (30 tools total)
\`\`\`

With both \`tool_calls_detected\` and \`tool_start\` defaults enabled (intentional — that's the live progress story), each tool fires ~2 status updates. Add the initial \"🚀 Starting work…\" and the budget is exhausted around the 4th/5th tool. The agent's tool calls continue working normally; only the user-facing status message stops updating.

## Fix

Remove the budget cap entirely. \`min_interval_seconds\` (default 1s) is sufficient to rate-limit spam at ~60 messages/min, and the agent loop's own recursion ceiling caps total iterations. The budget added no protection beyond what those two mechanisms already provide.

- Drop \`StatusUpdatesConfig.max_updates_per_run\` field
- Drop \`_updates_sent\` counter and budget check from \`StatusUpdateMiddleware\`
- Update tests (delete 2 budget-specific tests; strip budget references from shared helpers)
- Update \`docs/builtins.md\` and \`docs/configuration.md\`
- Add a \`Removed\` entry to CHANGELOG under \`[0.4.2]\` (tag not pushed yet)

## Test plan

- [x] \`poetry run pytest -q\` — 3057 passed (was 3059; -2 from deleted budget tests)
- [x] \`poetry run mypy openpaw/\` — clean (hard gate)
- [x] \`poetry run ruff check openpaw/\` — clean
- [x] \`grep -rn 'max_updates_per_run\\|_updates_sent' openpaw/ tests/ docs/\` — zero hits
- [ ] User re-validates on \`ai-runner\` stage after merge — same multi-tool browser session should now show live status updates throughout

## Notes

- Pre-1.0 / patch release: removing a config field is acceptable, called out in the CHANGELOG \`Removed\` section under \`[0.4.2]\`.
- Diff is pure deletion: 7 files, +2 / -50 (the +2 is the CHANGELOG entry).