### PR TITLE
feat: native moonshot + first-class ollama providers (0.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.4.3] - 2026-06-13
+
+> **BREAKING:** Workspaces using the pre-0.4.3 Moonshot configuration shape
+> (`provider: openai` with `base_url: https://api.moonshot.ai/v1`, or any
+> `extra_body.thinking` block) will now fail to load. Switch to the native
+> `moonshot` provider — see migration note below.
+
+### Added
+
+- **Native `moonshot` provider** for Kimi models via the [langchain-moonshot](https://pypi.org/project/langchain-moonshot/) package. New top-level `thinking: bool` field on the workspace model config replaces the old `extra_body.thinking` workaround. Temperature is auto-corrected to `0.6` / `1.0` based on `thinking` when the framework default (`0.7`) reaches the provider — the override is logged as a `WARNING` so users who deliberately set `0.7` see the substitution. Reasoning content is now separated by ChatMoonshot rather than emitted as inline `<think>` tags. Install with `pip install 'openpaw-ai[moonshot]'`.
+- **First-class `ollama` provider** for local models via the official [langchain-ollama](https://pypi.org/project/langchain-ollama/) package. No API key required; talks to a local Ollama server (default `http://localhost:11434`). Supports `bind_tools` on tool-capable models (llama3.1, qwen2.5, mistral-nemo, gemma3:27b, etc.). Install with `pip install 'openpaw-ai[ollama]'`.
+- **`thinking: bool | None`** field on `WorkspaceModelConfig` — opt-in reasoning mode for providers that support it natively.
+- **`base_url`** promoted from extras to a typed field on `WorkspaceModelConfig` for clearer schema and validation.
+- New `tests/test_native_providers.py` covers ChatMoonshot wiring (thinking flag, temperature auto-correct, ImportError) and ChatOllama wiring (no api_key, ollama-specific kwargs, no retries, ImportError) plus provider catalog integration for both.
+
+### Changed
+
+- `create_chat_model()` consolidated to `openpaw/agent/model_factory.py`. The duplicate copy in `openpaw/agent/runner.py` has been removed; `AgentRunner` now imports from `model_factory`. External imports of `create_chat_model`, `THINKING_MODELS`, `BEDROCK_TOOL_NAME_PATTERN`, `MAX_TOOL_NAME_LENGTH`, and `validate_tool_names` from `openpaw.agent.runner` still work via re-export.
+- `AgentRunner._validate_tool_names` now delegates to the shared `validate_tool_names` helper in `model_factory`, removing duplicated tool-name validation logic.
+- `THINKING_MODELS` trimmed to the single verified Bedrock-routed Kimi entry (`moonshot.kimi-k2-thinking`). The native `moonshot:` provider returns reasoning content via `additional_kwargs`, so it does not need regex stripping by `ThinkingTokenMiddleware`.
+- Provider catalog example in `config.example.yaml` updated to show native `moonshot` and `ollama` entries.
+- `docs/concepts.md` and `docs/architecture.md` rewritten to describe the native dispatch path through `create_chat_model()` instead of the retired `init_chat_model("openai:kimi-k2.5", ...)` route.
+
+### Removed
+
+- **Legacy Moonshot-via-OpenAI-compat shape** is no longer accepted. Configurations with `provider: openai` + `base_url: https://api.moonshot.ai/v1`, or an `extra_body.thinking` block **under the `openai` provider specifically**, now raise a `ValueError` at workspace load time pointing at the new shape. Anthropic's native extended-thinking via `extra_body.thinking` is unaffected — the validator is scoped to `provider == "openai"` only. **Migration:**
+  ```yaml
+  # Before (0.4.2 and earlier)
+  model:
+    provider: openai
+    model: kimi-k2.5
+    api_key: ${MOONSHOT_API_KEY}
+    base_url: https://api.moonshot.ai/v1
+    temperature: 0.6
+    extra_body:
+      thinking:
+        type: disabled
+
+  # After (0.4.3)
+  model:
+    provider: moonshot
+    model: kimi-k2.5
+    api_key: ${MOONSHOT_API_KEY}
+    thinking: false
+  ```
+
+### Fixed
+
 ## [0.4.2] - 2026-06-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`thinking: bool | None`** field on `WorkspaceModelConfig` — opt-in reasoning mode for providers that support it natively.
 - **`base_url`** promoted from extras to a typed field on `WorkspaceModelConfig` for clearer schema and validation.
 - New `tests/test_native_providers.py` covers ChatMoonshot wiring (thinking flag, temperature auto-correct, ImportError) and ChatOllama wiring (no api_key, ollama-specific kwargs, no retries, ImportError) plus provider catalog integration for both.
+- `openpaw init` workspace scaffolder learned `moonshot` and `ollama` providers. `openpaw init my_agent --model moonshot:kimi-k2.5` scaffolds a config with `thinking: false` + `temperature: 0.6`; `--model ollama:llama3.1` scaffolds keyless with `base_url: http://localhost:11434` and `num_ctx: 16384`. New tests in `tests/cli_init/test_scaffolder.py` round-trip the generated YAML through `WorkspaceConfig` to ensure it boots cleanly.
 
 ### Changed
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -36,6 +36,8 @@ lanes:
 #   xai:grok-3-mini
 #   fireworks:accounts/fireworks/models/deepseek-v3p1
 #   bedrock_converse:moonshot.kimi-k2-thinking
+#   moonshot:kimi-k2.5                      # requires `pip install 'openpaw-ai[moonshot]'`
+#   ollama:llama3.1                         # requires `pip install 'openpaw-ai[ollama]'`
 agent:
   model: anthropic:claude-sonnet-4-20250514
   max_turns: 50
@@ -62,10 +64,10 @@ agent:
 #     api_key: ${ANTHROPIC_API_KEY}
 #   openai:
 #     api_key: ${OPENAI_API_KEY}
-#   moonshot:
-#     type: openai                    # LangChain backend class to use
-#     api_key: ${MOONSHOT_API_KEY}
-#     base_url: https://api.moonshot.ai/v1
+#   moonshot:                         # Native Kimi via ChatMoonshot
+#     api_key: ${MOONSHOT_API_KEY}    # (install with: pip install 'openpaw-ai[moonshot]')
+#   ollama:                           # Local models via Ollama server
+#     base_url: http://localhost:11434  # (install with: pip install 'openpaw-ai[ollama]')
 #   xai:
 #     api_key: ${XAI_API_KEY}
 #   fireworks:
@@ -268,12 +270,36 @@ builtins:
 #     model: moonshot.kimi-k2-thinking
 #     region: us-east-1
 #
-# OpenAI-compatible (custom base_url):
+# Moonshot (native ChatMoonshot — requires `pip install 'openpaw-ai[moonshot]'`):
 #   model:
-#     provider: openai
+#     provider: moonshot
 #     model: kimi-k2.5
 #     api_key: ${MOONSHOT_API_KEY}
-#     base_url: https://api.moonshot.ai/v1
+#     thinking: false           # true = reasoning mode (auto-sets temperature=1.0)
+#                               # false = standard mode (auto-sets temperature=0.6)
+#
+# Ollama (local models — requires `pip install 'openpaw-ai[ollama]'`
+# and a running Ollama server):
+#   model:
+#     provider: ollama
+#     model: llama3.1           # any locally-pulled model name; tool-calling models
+#                               # include llama3.1, llama3-groq-tool-use, qwen2.5,
+#                               # mistral-nemo, gemma3:27b-instruct-q4_K_M
+#     base_url: http://localhost:11434
+#     num_ctx: 8192             # Ollama context window (optional)
+#     num_predict: 2048         # Max tokens to generate (optional)
+#     keep_alive: 5m            # How long the model stays loaded (optional)
+#
+# OpenAI-compatible (Together, Groq, etc. — custom base_url):
+#   model:
+#     provider: openai
+#     model: meta-llama/Llama-3-70b-chat-hf
+#     api_key: ${TOGETHER_API_KEY}
+#     base_url: https://api.together.xyz/v1
+#
+# Note: as of 0.4.3 the legacy pattern of pointing the 'openai' provider at
+# https://api.moonshot.ai/v1 with `extra_body.thinking` is no longer supported.
+# Use the native `moonshot` provider above instead.
 # ──────────────────────────────────────────────────────────────────────────────
 
 # Per-workspace channel settings (typically in agent.yaml, not here)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -217,7 +217,7 @@ Global defaults merge with workspace overrides, environment variables expand, an
 
 The merge is a deep dictionary merge: nested keys in `agent.yaml` override only the fields they specify; everything else inherits from `config.yaml`. A workspace that sets only `model.temperature` inherits the global model provider, API key, and all channel settings.
 
-`${VAR}` substitution runs after merging. Any unresolved reference fails fast at startup with an error naming the missing variable and its source file. Provider catalog entries under `providers:` in `config.yaml` let multiple workspaces share connection details. The shorthand `model: moonshot:kimi-k2.5` triggers resolution: `moonshot` maps to `type: openai`, `api_key`, and `base_url` in the catalog, producing a call to `init_chat_model("openai:kimi-k2.5", ...)` with those values. The user-visible display string stays `moonshot:kimi-k2.5` in `/status` output.
+`${VAR}` substitution runs after merging. Any unresolved reference fails fast at startup with an error naming the missing variable and its source file. Provider catalog entries under `providers:` in `config.yaml` let multiple workspaces share connection details. The shorthand `model: moonshot:kimi-k2.5` triggers resolution against the catalog and then dispatches to the native `ChatMoonshot` provider in `openpaw.agent.model_factory.create_chat_model()`. Catalog entries with a `type:` override (e.g. `type: bedrock_converse`) are remapped before dispatch — the original name stays the user-visible display string in `/status` output.
 
 See [Configuration](configuration.md) for the full field reference and provider catalog examples.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -525,10 +525,10 @@ providers:
     api_key: ${ANTHROPIC_API_KEY}
   openai:
     api_key: ${OPENAI_API_KEY}
-  moonshot:
-    type: openai                          # Uses OpenAI-compatible API
+  moonshot:                                # Native Kimi via langchain-moonshot
     api_key: ${MOONSHOT_API_KEY}
-    base_url: https://api.moonshot.ai/v1
+  ollama:                                  # Local models via Ollama server
+    base_url: http://localhost:11434
 ```
 
 With the catalog defined, individual workspaces reference providers by name using a simple `provider:model` shorthand:
@@ -536,14 +536,14 @@ With the catalog defined, individual workspaces reference providers by name usin
 ```yaml
 # agent.yaml (workspace)
 model: moonshot:kimi-k2.5
-temperature: 0.6
+thinking: false       # native top-level field (auto-sets temperature to 0.6)
 ```
 
-When the workspace starts, the framework resolves "moonshot" against the catalog, retrieves the API key and base URL, and passes them to the model — no duplication required. Adding a new workspace that uses the same provider takes one line instead of five.
+When the workspace starts, the framework resolves "moonshot" against the catalog, retrieves the API key, and instantiates `ChatMoonshot` — no duplication required. Adding a new workspace that uses the same provider takes one line instead of five.
 
 The catalog also powers the `/model` command. When you switch models at runtime with `/model moonshot:kimi-k2.5`, the framework resolves the provider name through the catalog and applies the correct connection details automatically.
 
-The provider catalog supports all connection types that OpenPaw understands: Anthropic, OpenAI, xAI (Grok), Fireworks.ai (DeepSeek, Llama, Qwen), AWS Bedrock, and any OpenAI-compatible API endpoint. For Bedrock, there is no API key field — the framework uses your configured AWS credentials instead. The catalog handles that detail automatically based on the provider type.
+The provider catalog supports all connection types that OpenPaw understands: Anthropic, OpenAI, xAI (Grok), Fireworks.ai (DeepSeek, Llama, Qwen), AWS Bedrock, Moonshot (Kimi), Ollama (local), and any OpenAI-compatible API endpoint. For Bedrock, there is no API key field — the framework uses your configured AWS credentials instead. For Ollama, there is no API key field at all. The catalog handles those details automatically based on the provider type.
 
 See [Configuration](configuration.md) for the full provider catalog reference, all supported provider types, and AWS Bedrock configuration.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -733,22 +733,98 @@ aws configure
 
 ---
 
+### Moonshot (Kimi)
+
+Native [Moonshot API](https://platform.moonshot.ai) support via the optional
+`langchain-moonshot` package — install with `pip install 'openpaw-ai[moonshot]'`.
+
+**Configuration:**
+
+```yaml
+model:
+  provider: moonshot
+  model: kimi-k2.5
+  api_key: ${MOONSHOT_API_KEY}
+  thinking: false   # true = reasoning mode, false = standard mode
+```
+
+**Thinking mode and temperature:**
+
+`kimi-k2.5` enforces a hard temperature constraint:
+
+- `thinking: true` requires `temperature: 1.0`
+- `thinking: false` requires `temperature: 0.6`
+
+If you leave `temperature` at the framework default (`0.7`), OpenPaw
+auto-corrects it to match `thinking`. If you set `temperature` explicitly and
+it conflicts, ChatMoonshot raises a `400` at request time — set the matching
+value or remove the override.
+
+**Available models:**
+- `kimi-k2.5` — reasoning, tool calling, vision
+- `moonshot-v1-32k-vision-preview` — multimodal
+
+**Migration from 0.4.2 and earlier:** the old pattern of routing through the
+`openai` provider with `base_url: https://api.moonshot.ai/v1` (plus
+`extra_body: { thinking: { type: disabled } }`) was removed in 0.4.3. OpenPaw
+will refuse to load that shape at workspace-load time and point you at this
+native configuration.
+
+---
+
+### Ollama (local models)
+
+Run any [Ollama](https://ollama.com)-hosted model locally via the optional
+`langchain-ollama` package — install with `pip install 'openpaw-ai[ollama]'`.
+Requires a running Ollama server (default: `http://localhost:11434`).
+
+**Configuration:**
+
+```yaml
+model:
+  provider: ollama
+  model: llama3.1
+  base_url: http://localhost:11434   # optional, defaults shown
+  num_ctx: 8192                      # context window (optional)
+  num_predict: 2048                  # max output tokens (optional)
+  keep_alive: 5m                     # how long the model stays loaded (optional)
+```
+
+**Tool-calling capable models** (required for agents that use tools):
+
+- `llama3.1`, `llama3.2`, `llama3.3`
+- `llama3-groq-tool-use`
+- `qwen2.5`, `qwen3`
+- `mistral-nemo`, `mistral-small`
+- `gemma3:27b-instruct-q4_K_M`, `gemma4:31b-it-q4_K_M`
+
+Models not in this list may still work for basic chat but cannot drive an
+agent's tool loop.
+
+**No API key:** Ollama is keyless. Any `api_key` value is ignored.
+
+**Retries:** `max_retries` is forced to `0` for the Ollama provider since the
+server is local; transient retries don't help and they hide real failures.
+
+---
+
 ### OpenAI-Compatible APIs
 
-Any OpenAI-compatible provider can be used by specifying `base_url` in the workspace model config. Extra kwargs beyond the standard set (`provider`, `model`, `api_key`, `temperature`, `max_turns`, `timeout_seconds`, `region`) are passed through to `init_chat_model()`.
-
-**Example (Moonshot Kimi K2.5):**
+Any OpenAI-compatible provider (Together AI, Groq, etc.) can be used by
+specifying `base_url` on the `openai` provider.
 
 ```yaml
 model:
   provider: openai
-  model: kimi-k2.5
-  api_key: ${MOONSHOT_API_KEY}
-  base_url: https://api.moonshot.ai/v1
-  temperature: 1.0
+  model: meta-llama/Llama-3-70b-chat-hf
+  api_key: ${TOGETHER_API_KEY}
+  base_url: https://api.together.xyz/v1
+  temperature: 0.7
 ```
 
-This enables any provider that implements the OpenAI API interface (Moonshot, Together AI, Groq, etc.).
+> Note: as of 0.4.3 the `openai` provider refuses `base_url`s pointing at
+> `api.moonshot.ai` — use the native [Moonshot](#moonshot-kimi) provider
+> above instead.
 
 ---
 

--- a/example_agent_workspaces/research_assistant_krieger/agent.yaml
+++ b/example_agent_workspaces/research_assistant_krieger/agent.yaml
@@ -10,13 +10,24 @@ model:
   max_turns: 150
   timeout_seconds: 900
 
-# Alternative: Use OpenAI-compatible API (e.g., Moonshot Kimi K2.5)
+# Alternative: native Moonshot via langchain-moonshot
+# (requires: pip install 'openpaw-ai[moonshot]')
 # model:
-#   provider: openai
+#   provider: moonshot
 #   model: kimi-k2.5
 #   api_key: ${MOONSHOT_API_KEY}
-#   base_url: https://api.moonshot.ai/v1
-#   temperature: 0.6
+#   thinking: false        # true = reasoning mode (auto-sets temperature=1.0)
+#                          # false = standard mode (auto-sets temperature=0.6)
+#   max_turns: 150
+#   timeout_seconds: 900
+
+# Alternative: local models via Ollama
+# (requires: pip install 'openpaw-ai[ollama]' + a running Ollama server)
+# model:
+#   provider: ollama
+#   model: llama3.1
+#   base_url: http://localhost:11434
+#   num_ctx: 16384
 #   max_turns: 150
 #   timeout_seconds: 900
 

--- a/openpaw/__init__.py
+++ b/openpaw/__init__.py
@@ -1,4 +1,4 @@
 """OpenPaw - AI Agent Framework with DeepAgents and Multi-Channel Support."""
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 __all__ = ["__version__"]

--- a/openpaw/agent/model_factory.py
+++ b/openpaw/agent/model_factory.py
@@ -7,7 +7,7 @@ LangChain BaseChatModel instance.
 
 import logging
 import re
-from typing import Any
+from typing import Any, cast
 
 from langchain_core.language_models import BaseChatModel
 
@@ -168,7 +168,10 @@ def create_chat_model(
             f"Creating ChatMoonshot: model={model_name}, thinking={thinking}, "
             f"temperature={kwargs.get('temperature')}"
         )
-        return ChatMoonshot(**kwargs)
+        # cast: langchain_moonshot is an optional dep and resolves to Any when
+        # not installed (mypy strict + ignore_missing_imports). The cast is safe
+        # because ChatMoonshot inherits from BaseChatOpenAI which is a BaseChatModel.
+        return cast(BaseChatModel, ChatMoonshot(**kwargs))
 
     if provider == "ollama":
         try:
@@ -192,7 +195,8 @@ def create_chat_model(
             f"Creating ChatOllama: model={model_name}, "
             f"base_url={kwargs.get('base_url', 'default')}, kwargs={list(kwargs.keys())}"
         )
-        return ChatOllama(**kwargs)
+        # cast: optional dep — see ChatMoonshot return above for rationale.
+        return cast(BaseChatModel, ChatOllama(**kwargs))
 
     if provider == "anthropic":
         from langchain_anthropic import ChatAnthropic

--- a/openpaw/agent/model_factory.py
+++ b/openpaw/agent/model_factory.py
@@ -21,13 +21,12 @@ logger = logging.getLogger(__name__)
 logging.getLogger("openai._base_client").setLevel(logging.INFO)
 logging.getLogger("anthropic._base_client").setLevel(logging.INFO)
 
-# Models known to produce thinking tokens
+# Bedrock-routed Kimi model IDs that emit raw <think> tags in content and need
+# regex stripping by ThinkingTokenMiddleware. The native `moonshot:` provider
+# uses ChatMoonshot which separates reasoning content via additional_kwargs,
+# so it does NOT belong on this list.
 THINKING_MODELS = [
     "moonshot.kimi-k2-thinking",
-    "moonshotai.kimi-k2.5",
-    "kimi-k2-thinking",
-    "kimi-thinking",
-    "kimi-k2.5",
 ]
 
 # Bedrock tool name validation pattern (AWS requirement)
@@ -95,6 +94,33 @@ def create_chat_model(
     if provider == "openai":
         from langchain_openai import ChatOpenAI
 
+        # Hard cutover guard: the legacy "talk to Moonshot through ChatOpenAI"
+        # shape used base_url=https://api.moonshot.ai/v1 plus extra_body.thinking.
+        # 0.4.3 replaces this with a native `moonshot:` provider; refuse both
+        # legacy signals with a migration message rather than silently working.
+        base_url = kwargs.get("base_url") or kwargs.get("openai_api_base")
+        if base_url and "moonshot.ai" in str(base_url):
+            raise ValueError(
+                "Direct Moonshot access via the 'openai' provider with "
+                "base_url 'https://api.moonshot.ai/v1' was removed in 0.4.3. "
+                "Use the native 'moonshot' provider instead:\n"
+                "    model:\n"
+                "      provider: moonshot\n"
+                "      model: kimi-k2.5\n"
+                "      thinking: false   # or true\n"
+                "      api_key: ${MOONSHOT_API_KEY}"
+            )
+        if "extra_body" in kwargs and isinstance(kwargs["extra_body"], dict) and "thinking" in kwargs["extra_body"]:
+            raise ValueError(
+                "'extra_body.thinking' on the 'openai' provider was removed in 0.4.3. "
+                "Use the native 'moonshot' provider with the top-level 'thinking' field instead:\n"
+                "    model:\n"
+                "      provider: moonshot\n"
+                "      model: kimi-k2.5\n"
+                "      thinking: false   # or true\n"
+                "      api_key: ${MOONSHOT_API_KEY}"
+            )
+
         if api_key:
             kwargs["api_key"] = api_key
         if effective_retries > 0:
@@ -103,6 +129,70 @@ def create_chat_model(
         else:
             logger.info(f"Creating ChatOpenAI: model={model_name}, kwargs={list(kwargs.keys())}")
         return ChatOpenAI(**kwargs)
+
+    if provider == "moonshot":
+        try:
+            from langchain_moonshot import ChatMoonshot
+        except ImportError as exc:
+            raise ImportError(
+                "The 'moonshot' provider requires the optional langchain-moonshot package. "
+                "Install it with: pip install 'openpaw-ai[moonshot]' "
+                "(or: pip install langchain-moonshot)."
+            ) from exc
+
+        # ChatMoonshot expects bool — coerce None (the WorkspaceModelConfig default)
+        # to False so we don't trip its pydantic validation.
+        thinking = bool(kwargs.get("thinking") or False)
+        kwargs["thinking"] = thinking
+
+        # Auto-correct temperature when the caller passed the framework default
+        # (0.7) — Moonshot enforces 0.6 for thinking=False and 1.0 for thinking=True
+        # and would otherwise raise a 400 at request time. We can't reliably tell
+        # an unset value from a deliberate "0.7"; if it WAS deliberate, the WARNING
+        # makes the override visible in the logs so the user can pin temperature
+        # to the value they actually want.
+        if kwargs.get("temperature") == 0.7:
+            corrected = 1.0 if thinking else 0.6
+            logger.warning(
+                f"Moonshot: temperature 0.7 is invalid for kimi-k2.5; "
+                f"auto-correcting to {corrected} for thinking={thinking}. "
+                f"Set temperature explicitly in your model config to silence this warning."
+            )
+            kwargs["temperature"] = corrected
+
+        if api_key:
+            kwargs["api_key"] = api_key
+        if effective_retries > 0:
+            kwargs["max_retries"] = effective_retries
+        logger.info(
+            f"Creating ChatMoonshot: model={model_name}, thinking={thinking}, "
+            f"temperature={kwargs.get('temperature')}"
+        )
+        return ChatMoonshot(**kwargs)
+
+    if provider == "ollama":
+        try:
+            from langchain_ollama import ChatOllama
+        except ImportError as exc:
+            raise ImportError(
+                "The 'ollama' provider requires the optional langchain-ollama package. "
+                "Install it with: pip install 'openpaw-ai[ollama]' "
+                "(or: pip install langchain-ollama)."
+            ) from exc
+
+        # Ollama is local — no API key, and retries don't help for a connection
+        # to localhost. Drop both unless the user explicitly opted in.
+        kwargs.pop("api_key", None)
+        if effective_retries > 0:
+            logger.debug(
+                "Ignoring max_retries for ollama provider (local server, fast-fail preferred)"
+            )
+
+        logger.info(
+            f"Creating ChatOllama: model={model_name}, "
+            f"base_url={kwargs.get('base_url', 'default')}, kwargs={list(kwargs.keys())}"
+        )
+        return ChatOllama(**kwargs)
 
     if provider == "anthropic":
         from langchain_anthropic import ChatAnthropic
@@ -207,7 +297,7 @@ def create_chat_model(
 
     raise ValueError(
         f"Unsupported model provider: '{provider}'. "
-        f"Supported: openai, anthropic, bedrock_converse, xai, fireworks"
+        f"Supported: openai, anthropic, bedrock_converse, xai, fireworks, moonshot, ollama"
     )
 
 

--- a/openpaw/agent/runner.py
+++ b/openpaw/agent/runner.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-import re
 import time
 from typing import Any
 
@@ -14,6 +13,13 @@ from openpaw.agent.metrics import InvocationMetrics, extract_metrics_from_callba
 from openpaw.agent.middleware.approval import ApprovalRequiredError
 from openpaw.agent.middleware.llm_hooks import THINKING_TAG_PATTERN, ThinkingTokenMiddleware
 from openpaw.agent.middleware.queue_aware import InterruptSignalError
+from openpaw.agent.model_factory import (
+    BEDROCK_TOOL_NAME_PATTERN,
+    MAX_TOOL_NAME_LENGTH,
+    THINKING_MODELS,
+    create_chat_model,
+    validate_tool_names,
+)
 from openpaw.agent.tools.filesystem import FilesystemTools
 from openpaw.core.prompts.system_events import (
     TIMEOUT_NOTIFICATION_GENERIC,
@@ -24,201 +30,14 @@ from openpaw.core.workspace import AgentWorkspace
 
 logger = logging.getLogger(__name__)
 
-# Surface retry diagnostics from provider SDKs.
-# OpenAI SDK logs "Retrying request to %s in %f seconds" at INFO.
-# Anthropic SDK logs similar messages at INFO.
-logging.getLogger("openai._base_client").setLevel(logging.INFO)
-logging.getLogger("anthropic._base_client").setLevel(logging.INFO)
-
-# Models known to produce thinking tokens
-THINKING_MODELS = [
-    "moonshot.kimi-k2-thinking",
-    "moonshotai.kimi-k2.5",
-    "kimi-k2-thinking",
-    "kimi-thinking",
-    "kimi-k2.5",
+# Re-exported for backward compatibility with tests/external imports.
+__all__ = [
+    "AgentRunner",
+    "BEDROCK_TOOL_NAME_PATTERN",
+    "MAX_TOOL_NAME_LENGTH",
+    "THINKING_MODELS",
+    "create_chat_model",
 ]
-
-# Bedrock tool name validation pattern (AWS requirement)
-BEDROCK_TOOL_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
-MAX_TOOL_NAME_LENGTH = 64
-
-
-def create_chat_model(
-    model_str: str,
-    api_key: str | None,
-    temperature: float,
-    region: str | None = None,
-    extra_kwargs: dict[str, Any] | None = None,
-) -> BaseChatModel:
-    """Create a chat model from a provider:model string.
-
-    Standalone function usable by both AgentRunner and model validation.
-
-    Args:
-        model_str: Model identifier in "provider:model" format.
-        api_key: API key for the model provider (not used for Bedrock).
-        temperature: Model temperature setting.
-        region: AWS region for Bedrock models (e.g., us-east-1).
-        extra_kwargs: Additional kwargs to pass to the model constructor
-            (e.g., base_url for OpenAI-compatible APIs, max_retries for retry config).
-
-    Returns:
-        Configured BaseChatModel instance. For Fireworks, returns a
-        RunnableRetry wrapper when max_retries > 0 (the Fireworks SDK does not
-        implement native retry). Callers that need model attribute access (e.g.
-        ``profile``) should hold a reference to the raw model separately — see
-        ``AgentRunner._build_agent()`` for the established pattern.
-
-    Raises:
-        ValueError: If provider is not supported.
-    """
-    # Parse provider from model_str (format: "provider:model_name")
-    if ":" in model_str:
-        provider, model_name = model_str.split(":", 1)
-    else:
-        provider = "openai"
-        model_name = model_str
-
-    # Build kwargs common to all providers
-    kwargs: dict[str, Any] = {
-        "model": model_name,
-        "temperature": temperature,
-    }
-
-    # Merge extra kwargs from config (base_url, model_kwargs, extra_body, etc.)
-    if extra_kwargs:
-        kwargs.update(extra_kwargs)
-
-    # Extract max_retries before merging into provider kwargs.
-    # Different providers require different handling (see per-provider logic below).
-    max_retries: int | None = kwargs.pop("max_retries", 3)
-    effective_retries = max_retries if (max_retries and max_retries > 0) else 0
-
-    # Flatten model_kwargs into direct constructor args so that params like
-    # extra_body reach the provider class directly instead of being silently dropped
-    nested_model_kwargs = kwargs.pop("model_kwargs", None)
-    if nested_model_kwargs and isinstance(nested_model_kwargs, dict):
-        kwargs.update(nested_model_kwargs)
-
-    if provider == "openai":
-        from langchain_openai import ChatOpenAI
-
-        if api_key:
-            kwargs["api_key"] = api_key
-        if effective_retries > 0:
-            kwargs["max_retries"] = effective_retries
-            logger.info(f"Creating ChatOpenAI: model={model_name}, max_retries={effective_retries}")
-        else:
-            logger.info(f"Creating ChatOpenAI: model={model_name}, kwargs={list(kwargs.keys())}")
-        return ChatOpenAI(**kwargs)
-
-    if provider == "anthropic":
-        from langchain_anthropic import ChatAnthropic
-
-        if api_key:
-            kwargs["api_key"] = api_key
-        if effective_retries > 0:
-            kwargs["max_retries"] = effective_retries
-            logger.info(f"Creating ChatAnthropic: model={model_name}, max_retries={effective_retries}")
-        else:
-            logger.info(f"Creating ChatAnthropic: model={model_name}")
-        return ChatAnthropic(**kwargs)
-
-    if provider in ("bedrock_converse", "bedrock"):
-        from langchain_aws import ChatBedrockConverse
-
-        if region:
-            kwargs["region_name"] = region
-        # Bedrock uses AWS credentials, not api_key.
-        # boto3 manages its own retry strategy — do not pass max_retries.
-        kwargs.pop("api_key", None)
-        logger.info(f"Creating ChatBedrockConverse: model={model_name}, kwargs_keys={list(kwargs.keys())}")
-        return ChatBedrockConverse(**kwargs)
-
-    if provider == "xai":
-        from langchain_xai import ChatXAI
-
-        if api_key:
-            kwargs["xai_api_key"] = api_key
-        if effective_retries > 0:
-            kwargs["max_retries"] = effective_retries
-            logger.info(f"Creating ChatXAI: model={model_name}, max_retries={effective_retries}")
-        else:
-            logger.info(f"Creating ChatXAI: model={model_name}")
-        return ChatXAI(**kwargs)
-
-    if provider == "fireworks":
-        import httpx
-        import tenacity
-        from fireworks.client.error import FireworksError, InvalidRequestError, RateLimitError
-        from langchain_fireworks import ChatFireworks
-
-        if api_key:
-            kwargs["fireworks_api_key"] = api_key
-        logger.info(f"Creating ChatFireworks: model={model_name}")
-        model = ChatFireworks(**kwargs)
-
-        # The Fireworks SDK's _max_retries is a no-op — patch _agenerate with
-        # tenacity for real retry behavior.  This preserves bind_tools() and all
-        # model attributes (unlike .with_retry() which wraps the entire Runnable).
-        #
-        # Fireworks changed their rate limit error format (Apr 2025): the code
-        # field shifted from "too_many_requests" (transient overload) to
-        # "invalid_request_error" (hard rate limit).  Hard rate limits need much
-        # longer backoff than transient 5xx errors, so we use a composite wait
-        # strategy that applies longer delays specifically for RateLimitError.
-        if effective_retries > 0:
-            # Use more attempts for Fireworks — the default of 3 is too few when
-            # multiple workspaces share one API key (rate limits may need 30-60s
-            # to clear, and 3 retries only yields ~8s total backoff).
-            fireworks_attempts = max(effective_retries, 6)
-            logger.info(
-                f"Patching ChatFireworks._agenerate with retry "
-                f"(max_attempts={fireworks_attempts + 1}, effective_retries={effective_retries})"
-            )
-            original_agenerate = model._agenerate
-
-            def _is_retryable_fireworks_error(exc: BaseException) -> bool:
-                if isinstance(exc, InvalidRequestError):
-                    msg = str(exc).lower()
-                    if "prompt is too long" in msg or "maximum context length" in msg:
-                        return False
-                return isinstance(
-                    exc,
-                    httpx.HTTPStatusError
-                    | httpx.ConnectError
-                    | httpx.ReadTimeout
-                    | ConnectionError
-                    | TimeoutError
-                    | FireworksError,
-                )
-
-            def _fireworks_wait(retry_state: tenacity.RetryCallState) -> float:
-                """Rate-limit-aware backoff: longer delays for RateLimitError."""
-                exc = retry_state.outcome.exception() if retry_state.outcome and retry_state.outcome.failed else None
-                if isinstance(exc, RateLimitError):
-                    return tenacity.wait_exponential_jitter(initial=5, max=120)(retry_state)
-                return tenacity.wait_exponential_jitter(initial=1, max=60)(retry_state)
-
-            @tenacity.retry(
-                retry=tenacity.retry_if_exception(_is_retryable_fireworks_error),
-                stop=tenacity.stop_after_attempt(fireworks_attempts + 1),
-                wait=_fireworks_wait,
-                before_sleep=tenacity.before_sleep_log(logger, logging.WARNING),
-                reraise=True,
-            )
-            async def _agenerate_with_retry(*args: Any, **kw: Any) -> Any:
-                return await original_agenerate(*args, **kw)
-
-            model._agenerate = _agenerate_with_retry  # type: ignore[method-assign]
-
-        return model
-
-    raise ValueError(
-        f"Unsupported model provider: '{provider}'. "
-        f"Supported: openai, anthropic, bedrock_converse, xai, fireworks"
-    )
 
 
 class AgentRunner:
@@ -557,34 +376,10 @@ class AgentRunner:
     def _validate_tool_names(self, tools: list[Any]) -> None:
         """Validate tool names comply with Bedrock requirements.
 
-        AWS Bedrock requires tool names to:
-        - Match pattern [a-zA-Z0-9_-]+
-        - Be 64 characters or less
-
-        Args:
-            tools: List of tools to validate.
-
-        Raises:
-            ValueError: If any tool name is invalid.
+        Thin instance-method wrapper around the shared helper so tests / external
+        callers that monkey-patch on ``AgentRunner`` keep working.
         """
-        for tool in tools:
-            tool_name = getattr(tool, "name", None)
-            if not tool_name:
-                logger.warning(f"Tool {tool} has no name attribute, skipping validation")
-                continue
-
-            # Check length
-            if len(tool_name) > MAX_TOOL_NAME_LENGTH:
-                raise ValueError(
-                    f"Tool name '{tool_name}' exceeds max length of {MAX_TOOL_NAME_LENGTH} characters"
-                )
-
-            # Check pattern
-            if not BEDROCK_TOOL_NAME_PATTERN.match(tool_name):
-                raise ValueError(
-                    f"Tool name '{tool_name}' contains invalid characters. "
-                    f"Must match pattern: [a-zA-Z0-9_-]+"
-                )
+        validate_tool_names(tools)
 
     def _create_model(self) -> BaseChatModel:
         """Create the appropriate chat model based on provider.

--- a/openpaw/cli_init/templates.py
+++ b/openpaw/cli_init/templates.py
@@ -61,7 +61,9 @@ TEMPLATE_ENV = """\
 # ANTHROPIC_API_KEY=
 # OPENAI_API_KEY=
 # XAI_API_KEY=
+# MOONSHOT_API_KEY=
 # BRAVE_API_KEY=
+# TELEGRAM_BOT_TOKEN=
 # DISCORD_BOT_TOKEN=
 """
 
@@ -69,8 +71,10 @@ _PROVIDER_API_KEY_ENV: dict[str, str | None] = {
     "anthropic": "ANTHROPIC_API_KEY",
     "openai": "OPENAI_API_KEY",
     "xai": "XAI_API_KEY",
+    "moonshot": "MOONSHOT_API_KEY",
     "bedrock_converse": None,
     "bedrock": None,
+    "ollama": None,
 }
 
 
@@ -147,9 +151,27 @@ def _build_agent_yaml(name: str, channel: str | None, model: str | None) -> str:
         ]
         if api_key_env:
             lines.append(f"  api_key: ${{{api_key_env}}}")
-        lines += [
-            "  temperature: 0.7",
-        ]
+
+        # Provider-specific fields with sensible defaults.
+        if provider == "moonshot":
+            # kimi-k2.5 enforces temperature=0.6 (thinking off) or 1.0 (on); scaffold
+            # the matching pair so the file is valid out-of-the-box.
+            lines += [
+                "  thinking: false        # true = reasoning mode (then set temperature: 1.0)",
+                "  temperature: 0.6",
+            ]
+        elif provider == "ollama":
+            # Local server — keyless, with a non-default num_ctx since 2048 is
+            # too small for any non-trivial agent conversation.
+            lines += [
+                "  base_url: http://localhost:11434",
+                "  num_ctx: 16384",
+                "  temperature: 0.7",
+            ]
+        else:
+            lines += [
+                "  temperature: 0.7",
+            ]
 
         # For well-known native providers, hint at the shorthand alternative.
         if provider in _PROVIDER_API_KEY_ENV:

--- a/openpaw/core/config/models/workspace.py
+++ b/openpaw/core/config/models/workspace.py
@@ -17,12 +17,27 @@ from openpaw.core.config.models.status_updates import StatusUpdatesConfig
 class WorkspaceModelConfig(BaseModel):
     """LLM configuration for a workspace agent."""
 
-    provider: str | None = Field(default=None, description="Model provider (anthropic, openai, bedrock_converse, etc.)")
+    provider: str | None = Field(
+        default=None,
+        description="Model provider (anthropic, openai, bedrock_converse, moonshot, ollama, etc.)",
+    )
     model: str | None = Field(default=None, description="Model identifier")
     api_key: str | None = Field(default=None, description="API key for the model provider")
     temperature: float | None = Field(default=None, description="Model temperature")
     max_turns: int | None = Field(default=None, description="Max agent turns per run")
     region: str | None = Field(default=None, description="AWS region for Bedrock models (e.g., us-east-1)")
+    base_url: str | None = Field(
+        default=None,
+        description="Custom API endpoint URL (e.g., Ollama server). Forwarded to providers that accept base_url.",
+    )
+    thinking: bool | None = Field(
+        default=None,
+        description=(
+            "Enable native reasoning mode on supported providers. "
+            "Moonshot: maps to ChatMoonshot(thinking=...) — temperature is auto-set "
+            "to 1.0 (thinking=True) or 0.6 (thinking=False) when left at the framework default."
+        ),
+    )
     max_output_tokens: int | None = Field(
         default=None,
         description="Maximum output tokens per LLM call (None = provider default). Applied to all agent types.",
@@ -53,6 +68,36 @@ class WorkspaceModelConfig(BaseModel):
             data["provider"] = provider
             data["model"] = model_id
         return data
+
+    @model_validator(mode="after")
+    def reject_legacy_moonshot_shape(self) -> "WorkspaceModelConfig":
+        """Catch the pre-0.4.3 Moonshot-via-OpenAI-compat shape at load time.
+
+        Both retired signals only apply when ``provider == "openai"``:
+        (1) base_url pointed at ``api.moonshot.ai``, and (2) ``extra_body.thinking``.
+        Other providers (notably Anthropic) use ``extra_body.thinking`` natively
+        for extended-thinking budgets and must NOT be caught by this validator.
+        """
+        if self.provider == "openai" and self.base_url and "moonshot.ai" in self.base_url:
+            raise ValueError(
+                "The 'openai' provider with base_url 'https://api.moonshot.ai/v1' "
+                "was removed in 0.4.3. Use the native 'moonshot' provider instead:\n"
+                "    model:\n"
+                "      provider: moonshot\n"
+                "      model: kimi-k2.5\n"
+                "      thinking: false   # or true\n"
+                "      api_key: ${MOONSHOT_API_KEY}"
+            )
+        if self.provider == "openai":
+            extra_body = (self.__pydantic_extra__ or {}).get("extra_body")
+            if isinstance(extra_body, dict) and "thinking" in extra_body:
+                raise ValueError(
+                    "'extra_body.thinking' under the 'openai' provider was removed in 0.4.3. "
+                    "Use the native 'moonshot' provider with the top-level 'thinking' field instead. "
+                    "(This restriction does NOT affect Anthropic, whose extended-thinking budgets "
+                    "use the same key on a different provider.)"
+                )
+        return self
 
     model_config = {"extra": "allow"}
 

--- a/openpaw/workspace/initializer.py
+++ b/openpaw/workspace/initializer.py
@@ -223,7 +223,12 @@ class WorkspaceInitializer:
             model_str = f"{agent_config['provider']}:{agent_config['model']}"
         self._logger.info(f"Initializing agent with model: {model_str}")
 
-        # Extract extra model kwargs beyond the known set.
+        # Anything not in this set falls into extra_model_kwargs and reaches
+        # create_chat_model() as **extra_kwargs. Declared-but-unlisted fields
+        # on WorkspaceModelConfig (e.g. `thinking`, `base_url`) are intentionally
+        # excluded here so they flow through to provider-specific branches in
+        # model_factory — moving them into known_model_keys would silently break
+        # the providers that depend on them.
         known_model_keys = {
             "provider",
             "model",

--- a/poetry.lock
+++ b/poetry.lock
@@ -2439,6 +2439,40 @@ openai = ">=2.0.0,<3.0.0"
 requests = ">=2.0.0,<3.0.0"
 
 [[package]]
+name = "langchain-moonshot"
+version = "0.1.0"
+description = "An integration package connecting Moonshot AI and LangChain"
+optional = true
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
+markers = "extra == \"moonshot\" or extra == \"all-builtins\""
+files = [
+    {file = "langchain_moonshot-0.1.0-py3-none-any.whl", hash = "sha256:1f62d84ae7b0dcdd544c643778149437a632acd034c7f0e9e148f55285bf5796"},
+    {file = "langchain_moonshot-0.1.0.tar.gz", hash = "sha256:0d98b5ca0f707b631a138008087815990b8fc7e2cbc369205724ed5d322d056a"},
+]
+
+[package.dependencies]
+langchain-core = ">=1.2.21,<2.0.0"
+langchain-openai = ">=1.1.0,<2.0.0"
+
+[[package]]
+name = "langchain-ollama"
+version = "1.1.0"
+description = "An integration package connecting Ollama and LangChain"
+optional = true
+python-versions = "<4.0.0,>=3.10.0"
+groups = ["main"]
+markers = "extra == \"ollama\" or extra == \"all-builtins\""
+files = [
+    {file = "langchain_ollama-1.1.0-py3-none-any.whl", hash = "sha256:43ac83a6eacb0f43855810739794dd55019e0d9b17bdcf3ecb3b1991ac3b59dd"},
+    {file = "langchain_ollama-1.1.0.tar.gz", hash = "sha256:f776f56f6782ae4da7692579b94a6575906118318d1023b455d7207f9d059811"},
+]
+
+[package.dependencies]
+langchain-core = ">=1.2.21,<2.0.0"
+ollama = ">=0.6.1,<1.0.0"
+
+[[package]]
 name = "langchain-openai"
 version = "1.1.12"
 description = "An integration package connecting OpenAI and LangChain"
@@ -4115,6 +4149,23 @@ files = [
 Click = ">=7.0"
 pillow = "*"
 pyobjc-framework-Vision = "*"
+
+[[package]]
+name = "ollama"
+version = "0.6.2"
+description = "The official Python client for Ollama."
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"ollama\" or extra == \"all-builtins\""
+files = [
+    {file = "ollama-0.6.2-py3-none-any.whl", hash = "sha256:3ad7daab28e5a973445c36a73882a3ef698c2ebb00e21e308652741577509f7d"},
+    {file = "ollama-0.6.2.tar.gz", hash = "sha256:936d55daa684f474364c098611c933626f8d6c7d67065c5b7ae0c477b508b07f"},
+]
+
+[package.dependencies]
+httpx = ">=0.27"
+pydantic = ">=2.9"
 
 [[package]]
 name = "omegaconf"
@@ -8144,9 +8195,11 @@ files = [
 cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and python_version < \"3.14\"", "cffi (>=2.0.0b) ; platform_python_implementation != \"PyPy\" and python_version >= \"3.14\""]
 
 [extras]
-all-builtins = ["elevenlabs", "google-api-python-client", "google-auth", "httpx", "langchain-community", "openai", "sqlite-vec", "websockets"]
+all-builtins = ["elevenlabs", "google-api-python-client", "google-auth", "httpx", "langchain-community", "langchain-moonshot", "langchain-ollama", "openai", "sqlite-vec", "websockets"]
 email = ["google-api-python-client", "google-auth"]
 memory = ["sqlite-vec"]
+moonshot = ["langchain-moonshot"]
+ollama = ["langchain-ollama"]
 researcher = ["httpx", "websockets"]
 voice = ["elevenlabs", "openai"]
 web = ["langchain-community"]
@@ -8154,4 +8207,4 @@ web = ["langchain-community"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "89f8a609f80ee4a6954ec82f9de1b968b3d37f9a23aa6d9c55b9efda50360d7b"
+content-hash = "c0ecc7ab25747a119d4a2d8fccfadceeadf4bac60b4ef0787ee7035f3082aa70"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openpaw-ai"
-version = "0.4.2"
+version = "0.4.3"
 description = "OpenPaw - Multi-Channel AI Agent Framework with LangGraph"
 authors = [
     {name = "John Sosoka"}
@@ -75,6 +75,12 @@ email = [
     "google-auth (>=2.0.0)",              # Google service account auth
     "google-api-python-client (>=2.0.0)", # Gmail API client
 ]
+moonshot = [
+    "langchain-moonshot (>=0.1.0,<1.0.0)",  # Native Kimi (K2.5 etc.) via Moonshot API
+]
+ollama = [
+    "langchain-ollama (>=1.0.1,<2.0.0)",    # Local models via Ollama server
+]
 all-builtins = [
     "openai (>=1.0.0)",
     "elevenlabs (>=1.0.0)",
@@ -84,6 +90,8 @@ all-builtins = [
     "httpx (>=0.27.0)",
     "google-auth (>=2.0.0)",
     "google-api-python-client (>=2.0.0)",
+    "langchain-moonshot (>=0.1.0,<1.0.0)",
+    "langchain-ollama (>=1.0.1,<2.0.0)",
 ]
 
 
@@ -121,7 +129,7 @@ warn_unused_ignores = false
 
 [tool.poetry]
 name = "openpaw-ai"
-version = "0.4.2"
+version = "0.4.3"
 description = "OpenPaw - Multi-Channel AI Agent Framework with LangGraph"
 authors = ["John Sosoka"]
 packages = [{include = "openpaw"}]

--- a/tests/cli_init/test_scaffolder.py
+++ b/tests/cli_init/test_scaffolder.py
@@ -116,3 +116,35 @@ class TestCreateWorkspace:
     def test_returns_workspace_path(self, tmp_path: Path) -> None:
         result = _create_workspace(tmp_path, "rex", None, None)
         assert result == tmp_path / "rex"
+
+    def test_scaffolds_moonshot_workspace_with_thinking_flag(self, tmp_path: Path) -> None:
+        """`--model moonshot:kimi-k2.5` produces a valid native moonshot config."""
+        from openpaw.core.config.models import WorkspaceConfig
+
+        _create_workspace(tmp_path, "kimi_agent", None, "moonshot:kimi-k2.5")
+        text = (tmp_path / "kimi_agent" / "config" / "agent.yaml").read_text()
+        assert "provider: moonshot" in text
+        assert "model: kimi-k2.5" in text
+        assert "thinking: false" in text
+        assert "api_key: ${MOONSHOT_API_KEY}" in text
+        # Round-trip through Pydantic — catches the pre-0.4.3 legacy-rejection
+        # path so we know this scaffolded yaml will actually boot.
+        cfg = WorkspaceConfig(**yaml.safe_load(text))
+        assert cfg.model.provider == "moonshot"
+        assert cfg.model.thinking is False
+
+    def test_scaffolds_ollama_workspace_keyless(self, tmp_path: Path) -> None:
+        """`--model ollama:llama3.1` produces a keyless config with base_url + num_ctx."""
+        from openpaw.core.config.models import WorkspaceConfig
+
+        _create_workspace(tmp_path, "local_agent", None, "ollama:llama3.1")
+        text = (tmp_path / "local_agent" / "config" / "agent.yaml").read_text()
+        assert "provider: ollama" in text
+        assert "model: llama3.1" in text
+        assert "base_url: http://localhost:11434" in text
+        assert "num_ctx: 16384" in text
+        # Ollama is keyless — make sure scaffolder doesn't emit a bogus api_key line.
+        assert "api_key:" not in text
+        cfg = WorkspaceConfig(**yaml.safe_load(text))
+        assert cfg.model.provider == "ollama"
+        assert cfg.model.base_url == "http://localhost:11434"

--- a/tests/test_extra_model_kwargs.py
+++ b/tests/test_extra_model_kwargs.py
@@ -74,8 +74,13 @@ def test_extra_model_kwargs_defaults_to_empty_dict(mock_workspace: AgentWorkspac
 
 
 def test_openai_provider_creates_chat_openai(mock_workspace: AgentWorkspace) -> None:
-    """Test that openai provider instantiates ChatOpenAI with all kwargs."""
-    extra_kwargs = {"base_url": "https://api.moonshot.ai/v1", "timeout": 60}
+    """Test that openai provider instantiates ChatOpenAI with all kwargs.
+
+    Uses a generic OpenAI-compat base_url (Together, Groq, etc.). The legacy
+    Moonshot pass-through (api.moonshot.ai) is rejected in 0.4.3 — see
+    test_legacy_moonshot_openai_base_url_rejected for that path.
+    """
+    extra_kwargs = {"base_url": "https://api.together.xyz/v1", "timeout": 60}
 
     with patch(_PATCH_OPENAI) as mock_cls, \
          patch(_PATCH_FS), patch(_PATCH_AGENT):
@@ -83,8 +88,8 @@ def test_openai_provider_creates_chat_openai(mock_workspace: AgentWorkspace) -> 
 
         AgentRunner(
             workspace=mock_workspace,
-            model="openai:kimi-k2.5",
-            api_key="test-moonshot-key",
+            model="openai:gpt-4o",
+            api_key="test-key",
             temperature=0.6,
             extra_model_kwargs=extra_kwargs,
         )
@@ -92,18 +97,18 @@ def test_openai_provider_creates_chat_openai(mock_workspace: AgentWorkspace) -> 
         mock_cls.assert_called_once()
         call_kwargs = mock_cls.call_args[1]
 
-        assert call_kwargs["model"] == "kimi-k2.5"
+        assert call_kwargs["model"] == "gpt-4o"
         assert call_kwargs["temperature"] == 0.6
-        assert call_kwargs["api_key"] == "test-moonshot-key"
-        assert call_kwargs["base_url"] == "https://api.moonshot.ai/v1"
+        assert call_kwargs["api_key"] == "test-key"
+        assert call_kwargs["base_url"] == "https://api.together.xyz/v1"
         assert call_kwargs["timeout"] == 60
 
 
 def test_model_kwargs_flattened_into_direct_args(mock_workspace: AgentWorkspace) -> None:
     """Test that nested model_kwargs are flattened so extra_body reaches the provider."""
     extra_kwargs = {
-        "base_url": "https://api.moonshot.ai/v1",
-        "model_kwargs": {"extra_body": {"thinking": {"type": "disabled"}}},
+        "base_url": "https://api.together.xyz/v1",
+        "model_kwargs": {"extra_body": {"some_provider_flag": True}},
     }
 
     with patch(_PATCH_OPENAI) as mock_cls, \
@@ -112,7 +117,7 @@ def test_model_kwargs_flattened_into_direct_args(mock_workspace: AgentWorkspace)
 
         AgentRunner(
             workspace=mock_workspace,
-            model="openai:kimi-k2.5",
+            model="openai:gpt-4o",
             api_key="test-key",
             temperature=0.6,
             extra_model_kwargs=extra_kwargs,
@@ -123,8 +128,37 @@ def test_model_kwargs_flattened_into_direct_args(mock_workspace: AgentWorkspace)
 
         # extra_body should be a direct kwarg, NOT nested under model_kwargs
         assert "model_kwargs" not in call_kwargs
-        assert call_kwargs["extra_body"] == {"thinking": {"type": "disabled"}}
-        assert call_kwargs["base_url"] == "https://api.moonshot.ai/v1"
+        assert call_kwargs["extra_body"] == {"some_provider_flag": True}
+        assert call_kwargs["base_url"] == "https://api.together.xyz/v1"
+
+
+def test_legacy_moonshot_openai_base_url_rejected(mock_workspace: AgentWorkspace) -> None:
+    """Pre-0.4.3 'openai + base_url=api.moonshot.ai' raises a clear migration error."""
+    extra_kwargs = {"base_url": "https://api.moonshot.ai/v1"}
+
+    with patch(_PATCH_FS), patch(_PATCH_AGENT), \
+         pytest.raises(ValueError, match="native 'moonshot' provider"):
+        AgentRunner(
+            workspace=mock_workspace,
+            model="openai:kimi-k2.5",
+            api_key="test-key",
+            temperature=0.6,
+            extra_model_kwargs=extra_kwargs,
+        )
+
+
+def test_legacy_extra_body_thinking_rejected(mock_workspace: AgentWorkspace) -> None:
+    """Pre-0.4.3 'extra_body.thinking' under openai provider raises a migration error."""
+    extra_kwargs = {"extra_body": {"thinking": {"type": "disabled"}}}
+
+    with patch(_PATCH_FS), patch(_PATCH_AGENT), \
+         pytest.raises(ValueError, match="extra_body.thinking"):
+        AgentRunner(
+            workspace=mock_workspace,
+            model="openai:gpt-4o",
+            api_key="test-key",
+            extra_model_kwargs=extra_kwargs,
+        )
 
 
 def test_bedrock_excludes_api_key_but_includes_extra_kwargs(mock_workspace: AgentWorkspace) -> None:

--- a/tests/test_model_config_normalization.py
+++ b/tests/test_model_config_normalization.py
@@ -1,5 +1,7 @@
 """Tests for WorkspaceModelConfig provider:model auto-split."""
 
+import pytest
+
 from openpaw.core.config.models import WorkspaceModelConfig
 
 
@@ -48,18 +50,45 @@ class TestWorkspaceModelConfigNormalization:
         assert config.provider == "xai"
         assert config.model == "grok-3-mini"
 
-    def test_extra_kwargs_preserved(self):
-        """Extra kwargs (like base_url) are preserved through normalization."""
+    def test_base_url_preserved_for_non_legacy_providers(self):
+        """base_url survives normalization on providers that legitimately use it (e.g. Ollama)."""
         config = WorkspaceModelConfig(
-            model="openai:kimi-k2.5",
-            base_url="https://api.moonshot.ai/v1",
+            model="ollama:gemma4:31b-it-q4_K_M",
+            base_url="http://localhost:11434",
         )
-        assert config.provider == "openai"
-        assert config.model == "kimi-k2.5"
-        assert config.base_url == "https://api.moonshot.ai/v1"
+        assert config.provider == "ollama"
+        assert config.model == "gemma4:31b-it-q4_K_M"
+        assert config.base_url == "http://localhost:11434"
 
     def test_empty_string_provider_not_split(self):
         """Empty string provider should not trigger auto-split."""
         config = WorkspaceModelConfig(provider="", model="provider:model-id")
         assert config.provider == ""
         assert config.model == "provider:model-id"
+
+    def test_legacy_moonshot_via_openai_rejected(self):
+        """Pre-0.4.3 'openai + base_url=api.moonshot.ai' shape is hard-rejected."""
+        with pytest.raises(ValueError, match="moonshot"):
+            WorkspaceModelConfig(
+                model="openai:kimi-k2.5",
+                base_url="https://api.moonshot.ai/v1",
+            )
+
+    def test_legacy_extra_body_thinking_rejected(self):
+        """Pre-0.4.3 'extra_body.thinking' shape is hard-rejected."""
+        with pytest.raises(ValueError, match="extra_body.thinking"):
+            WorkspaceModelConfig(
+                provider="openai",
+                model="kimi-k2.5",
+                extra_body={"thinking": {"type": "disabled"}},
+            )
+
+    def test_native_moonshot_thinking_flag(self):
+        """Native moonshot provider accepts the top-level thinking flag."""
+        config = WorkspaceModelConfig(
+            model="moonshot:kimi-k2.5",
+            thinking=True,
+        )
+        assert config.provider == "moonshot"
+        assert config.model == "kimi-k2.5"
+        assert config.thinking is True

--- a/tests/test_native_providers.py
+++ b/tests/test_native_providers.py
@@ -1,0 +1,277 @@
+"""Tests for native moonshot and ollama providers in create_chat_model.
+
+These tests must run in environments WITHOUT the optional ``[moonshot]`` or
+``[ollama]`` extras installed. Each test injects a mock module into
+``sys.modules`` so that ``from langchain_moonshot import ChatMoonshot`` (or
+the ollama equivalent) inside ``create_chat_model`` succeeds with the mock
+regardless of whether the real package is present.
+"""
+
+import sys
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from openpaw.agent.model_factory import create_chat_model
+
+
+def _mock_module(class_name: str) -> tuple[MagicMock, Mock]:
+    """Build a fake module exposing a single mock class.
+
+    Returns ``(module, class_mock)`` — install the module into ``sys.modules``
+    with ``patch.dict`` and inspect calls on the class mock.
+    """
+    cls_mock = Mock()
+    cls_mock.return_value = Mock()
+    module = MagicMock()
+    setattr(module, class_name, cls_mock)
+    return module, cls_mock
+
+
+class TestMoonshotProvider:
+    """ChatMoonshot wiring (thinking flag, temperature auto-correct, ImportError)."""
+
+    def test_moonshot_provider_creates_chat_moonshot(self) -> None:
+        """`moonshot:` provider instantiates ChatMoonshot with model + api_key."""
+        module, mock_cls = _mock_module("ChatMoonshot")
+        with patch.dict(sys.modules, {"langchain_moonshot": module}):
+            create_chat_model(
+                model_str="moonshot:kimi-k2.5",
+                api_key="test-key",
+                temperature=0.6,
+                extra_kwargs={"thinking": False},
+            )
+
+        mock_cls.assert_called_once()
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["model"] == "kimi-k2.5"
+        assert kwargs["api_key"] == "test-key"
+        assert kwargs["thinking"] is False
+        assert kwargs["temperature"] == 0.6
+
+    def test_moonshot_auto_corrects_temperature_for_thinking_false(self) -> None:
+        """Framework-default temperature (0.7) auto-corrects to 0.6 when thinking=False."""
+        module, mock_cls = _mock_module("ChatMoonshot")
+        with patch.dict(sys.modules, {"langchain_moonshot": module}):
+            create_chat_model(
+                model_str="moonshot:kimi-k2.5",
+                api_key="k",
+                temperature=0.7,  # framework default — should be replaced
+                extra_kwargs={"thinking": False},
+            )
+
+        assert mock_cls.call_args[1]["temperature"] == 0.6
+
+    def test_moonshot_auto_corrects_temperature_for_thinking_true(self) -> None:
+        """Framework-default temperature (0.7) auto-corrects to 1.0 when thinking=True."""
+        module, mock_cls = _mock_module("ChatMoonshot")
+        with patch.dict(sys.modules, {"langchain_moonshot": module}):
+            create_chat_model(
+                model_str="moonshot:kimi-k2.5",
+                api_key="k",
+                temperature=0.7,
+                extra_kwargs={"thinking": True},
+            )
+
+        assert mock_cls.call_args[1]["temperature"] == 1.0
+
+    def test_moonshot_respects_explicit_temperature(self) -> None:
+        """Explicit non-default temperature is left alone (ChatMoonshot will validate)."""
+        module, mock_cls = _mock_module("ChatMoonshot")
+        with patch.dict(sys.modules, {"langchain_moonshot": module}):
+            create_chat_model(
+                model_str="moonshot:kimi-k2.5",
+                api_key="k",
+                temperature=0.5,  # explicit, non-default
+                extra_kwargs={"thinking": False},
+            )
+
+        assert mock_cls.call_args[1]["temperature"] == 0.5
+
+    def test_moonshot_forwards_max_retries(self) -> None:
+        """max_retries from extra_kwargs is forwarded to ChatMoonshot."""
+        module, mock_cls = _mock_module("ChatMoonshot")
+        with patch.dict(sys.modules, {"langchain_moonshot": module}):
+            create_chat_model(
+                model_str="moonshot:kimi-k2.5",
+                api_key="k",
+                temperature=0.7,
+                extra_kwargs={"thinking": False, "max_retries": 5},
+            )
+
+        assert mock_cls.call_args[1]["max_retries"] == 5
+
+    def test_moonshot_coerces_none_thinking_to_false(self) -> None:
+        """``thinking: None`` (WorkspaceModelConfig default) becomes False, not None."""
+        module, mock_cls = _mock_module("ChatMoonshot")
+        with patch.dict(sys.modules, {"langchain_moonshot": module}):
+            create_chat_model(
+                model_str="moonshot:kimi-k2.5",
+                api_key="k",
+                temperature=0.6,
+                extra_kwargs={"thinking": None},
+            )
+
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["thinking"] is False
+
+    def test_moonshot_missing_package_raises_clear_import_error(self) -> None:
+        """Missing langchain-moonshot raises a friendly ImportError with install hint."""
+        with patch.dict(sys.modules, {"langchain_moonshot": None}):
+            with pytest.raises(ImportError, match=r"openpaw-ai\[moonshot\]"):
+                create_chat_model(
+                    model_str="moonshot:kimi-k2.5",
+                    api_key="k",
+                    temperature=0.7,
+                    extra_kwargs={"thinking": False},
+                )
+
+
+class TestOllamaProvider:
+    """ChatOllama wiring (base_url, no api_key, retry defaults)."""
+
+    def test_ollama_provider_creates_chat_ollama(self) -> None:
+        """`ollama:` provider instantiates ChatOllama with model + base_url."""
+        module, mock_cls = _mock_module("ChatOllama")
+        with patch.dict(sys.modules, {"langchain_ollama": module}):
+            create_chat_model(
+                model_str="ollama:gemma4:31b-it-q4_K_M",
+                api_key=None,
+                temperature=0.7,
+                extra_kwargs={"base_url": "http://localhost:11434"},
+            )
+
+        mock_cls.assert_called_once()
+        kwargs = mock_cls.call_args[1]
+        # First colon splits, so model name preserves the rest.
+        assert kwargs["model"] == "gemma4:31b-it-q4_K_M"
+        assert kwargs["base_url"] == "http://localhost:11434"
+        assert kwargs["temperature"] == 0.7
+
+    def test_ollama_drops_api_key(self) -> None:
+        """Ollama is keyless — api_key must never reach the constructor."""
+        module, mock_cls = _mock_module("ChatOllama")
+        with patch.dict(sys.modules, {"langchain_ollama": module}):
+            create_chat_model(
+                model_str="ollama:llama3.1",
+                api_key="ignored-key",
+                temperature=0.7,
+                extra_kwargs={},
+            )
+
+        assert "api_key" not in mock_cls.call_args[1]
+
+    def test_ollama_forwards_ollama_specific_kwargs(self) -> None:
+        """Ollama-specific knobs (num_ctx, num_predict, keep_alive) reach the constructor."""
+        module, mock_cls = _mock_module("ChatOllama")
+        with patch.dict(sys.modules, {"langchain_ollama": module}):
+            create_chat_model(
+                model_str="ollama:llama3.1",
+                api_key=None,
+                temperature=0.7,
+                extra_kwargs={
+                    "base_url": "http://localhost:11434",
+                    "num_ctx": 8192,
+                    "num_predict": 2048,
+                    "keep_alive": "5m",
+                    "reasoning": True,
+                },
+            )
+
+        kwargs = mock_cls.call_args[1]
+        assert kwargs["num_ctx"] == 8192
+        assert kwargs["num_predict"] == 2048
+        assert kwargs["keep_alive"] == "5m"
+        assert kwargs["reasoning"] is True
+
+    def test_ollama_does_not_pass_max_retries(self) -> None:
+        """max_retries should be dropped for ollama (local server, fast-fail preferred)."""
+        module, mock_cls = _mock_module("ChatOllama")
+        with patch.dict(sys.modules, {"langchain_ollama": module}):
+            create_chat_model(
+                model_str="ollama:llama3.1",
+                api_key=None,
+                temperature=0.7,
+                extra_kwargs={"max_retries": 5},
+            )
+
+        assert "max_retries" not in mock_cls.call_args[1]
+
+    def test_ollama_missing_package_raises_clear_import_error(self) -> None:
+        """Missing langchain-ollama raises a friendly ImportError with install hint."""
+        with patch.dict(sys.modules, {"langchain_ollama": None}):
+            with pytest.raises(ImportError, match=r"openpaw-ai\[ollama\]"):
+                create_chat_model(
+                    model_str="ollama:llama3.1",
+                    api_key=None,
+                    temperature=0.7,
+                    extra_kwargs={},
+                )
+
+
+class TestProviderCatalogIntegration:
+    """End-to-end: provider catalog → resolve_provider → create_chat_model."""
+
+    def test_moonshot_catalog_entry_resolves_to_chat_moonshot(self) -> None:
+        """Catalog entry of type=moonshot routes through ChatMoonshot."""
+        from openpaw.core.config.models.base import ProviderDefinition
+        from openpaw.core.config.providers import resolve_provider
+
+        catalog = {
+            "moonshot": ProviderDefinition(type="moonshot", api_key="catalog-key"),
+        }
+        resolved = resolve_provider("moonshot:kimi-k2.5", catalog)
+
+        assert resolved.model_str == "moonshot:kimi-k2.5"
+        assert resolved.display_str == "moonshot:kimi-k2.5"
+        assert resolved.api_key == "catalog-key"
+
+        module, mock_cls = _mock_module("ChatMoonshot")
+        with patch.dict(sys.modules, {"langchain_moonshot": module}):
+            create_chat_model(
+                model_str=resolved.model_str,
+                api_key=resolved.api_key,
+                temperature=0.7,
+                extra_kwargs={**resolved.extra_kwargs, "thinking": False},
+            )
+        mock_cls.assert_called_once()
+
+    def test_ollama_catalog_entry_resolves_to_chat_ollama(self) -> None:
+        """Catalog entry of type=ollama routes through ChatOllama with base_url."""
+        from openpaw.core.config.models.base import ProviderDefinition
+        from openpaw.core.config.providers import resolve_provider
+
+        catalog = {
+            "ollama": ProviderDefinition(type="ollama", base_url="http://localhost:11434"),
+        }
+        resolved = resolve_provider("ollama:gemma4:31b-it-q4_K_M", catalog)
+
+        assert resolved.model_str == "ollama:gemma4:31b-it-q4_K_M"
+        assert resolved.extra_kwargs.get("base_url") == "http://localhost:11434"
+
+        module, mock_cls = _mock_module("ChatOllama")
+        with patch.dict(sys.modules, {"langchain_ollama": module}):
+            create_chat_model(
+                model_str=resolved.model_str,
+                api_key=None,
+                temperature=0.7,
+                extra_kwargs=resolved.extra_kwargs,
+            )
+        assert mock_cls.call_args[1]["base_url"] == "http://localhost:11434"
+
+
+class TestAnthropicExtendedThinkingNotRejected:
+    """Regression guard: the legacy validator must not block Anthropic's extra_body.thinking."""
+
+    def test_anthropic_extra_body_thinking_accepted(self) -> None:
+        """Anthropic's extended-thinking budget via extra_body.thinking is allowed."""
+        from openpaw.core.config.models.workspace import WorkspaceModelConfig
+
+        # Anthropic uses extra_body: {thinking: {type: enabled, budget_tokens: 5000}}
+        # natively. The 0.4.3 legacy guard is scoped to provider='openai' only.
+        config = WorkspaceModelConfig(
+            provider="anthropic",
+            model="claude-sonnet-4-20250514",
+            extra_body={"thinking": {"type": "enabled", "budget_tokens": 5000}},
+        )
+        assert config.provider == "anthropic"


### PR DESCRIPTION
## Summary

- **Native `moonshot` provider** via [langchain-moonshot](https://pypi.org/project/langchain-moonshot/) — replaces the OpenAI-compat + `extra_body.thinking` workaround with first-class `ChatMoonshot`. New top-level `thinking: bool` field on the workspace model config; temperature auto-corrects to 0.6/1.0 with a WARNING log when the framework default (0.7) reaches the provider.
- **First-class `ollama` provider** via the official [langchain-ollama](https://pypi.org/project/langchain-ollama/) — local models, no API key, `max_retries` forced to 0 for fast-fail. Verified end-to-end against `gemma4:31b-it-q4_K_M` (basic chat + tool calling).
- **Hard cutover** on the pre-0.4.3 Moonshot shape — both `provider: openai` + `base_url=api.moonshot.ai` and `extra_body.thinking` under `openai` are rejected at workspace load time AND at model-creation time, with clear migration errors pointing at the new shape. Scoped to `provider == "openai"` so Anthropic's native extended-thinking is unaffected.
- **Cleanup**: dead duplicate `create_chat_model()` in `openpaw/agent/runner.py` removed; `AgentRunner._validate_tool_names` delegates to the shared helper; `THINKING_MODELS` trimmed to the single verified Bedrock entry.

Both new packages ship as optional extras (`[moonshot]` / `[ollama]`). Default install is unchanged.

**Version bump:** 0.4.2 → 0.4.3 (patch — minor 0.5.0 is reserved for the upcoming learning-loops/reasoning theme).

## Verification

- **3065 tests pass**, 0 fail (88 model-related + 15 new in `tests/test_native_providers.py`).
- **mypy clean** across all 237 source files.
- **ruff clean** on every touched file.
- **CI safety**: provider tests use `patch.dict(sys.modules, …)` so they pass with both extras uninstalled — verified by `pip uninstall langchain-moonshot langchain-ollama && pytest tests/test_native_providers.py` (15/15 green).
- **Live smoke against real backends**: Moonshot (`kimi-k2.5`) and Ollama (`gemma4:31b-it-q4_K_M`) — basic chat + tool calling both work.
- **Live workspace dogfood**: Halcyon workspace running on Ollama + Telegram exercised the full agent loop (multi-tool chains, message reactions, queue-collect bundling, heartbeat acknowledge path) for ~35 minutes without errors.
- **Code-review agent pass**: 1 BLOCKER (CI without extras), 2 MAJOR (silent temp override, known_model_keys gap), 4 MINOR (Anthropic extra_body collision, duplicate validate, asymmetric errors, None vs False), 2 NIT — all BLOCKER + MAJORs + actionable MINORs addressed.

## Breaking change (called out in CHANGELOG)

```yaml
# Before (0.4.2)
model:
  provider: openai
  model: kimi-k2.5
  base_url: https://api.moonshot.ai/v1
  extra_body: { thinking: { type: disabled } }

# After (0.4.3)
model:
  provider: moonshot
  model: kimi-k2.5
  api_key: ${MOONSHOT_API_KEY}
  thinking: false
```

## Test plan

- [ ] CI passes on the PR branch
- [ ] Deploy to staging (`ai-runner`) and verify krieger workspace still boots with its existing Bedrock-routed kimi-k2-thinking config
- [ ] Smoke `pip install 'openpaw-ai[moonshot]'` and `pip install 'openpaw-ai[ollama]'` in a fresh venv
- [ ] Confirm `/model list` shows new providers when defined in the catalog