### PR TITLE
fix: isolate Gmail httplib2 transport per-request to stop runner SIGTRAP

### DIFF
--- a/openpaw/builtins/tools/email/gmail/__init__.py
+++ b/openpaw/builtins/tools/email/gmail/__init__.py
@@ -63,9 +63,12 @@ class GmailProvider(EmailProvider):
             if self._service is not None:
                 return self._service
 
+            # Imports are deferred to here (inside the lock) on purpose: the Google
+            # libraries ship only with the optional `email` extra, so importing them
+            # at module load would break workspaces that don't enable email.
             import httplib2
             from google.oauth2 import service_account
-            from google_auth_httplib2 import AuthorizedHttp
+            from google_auth_httplib2 import AuthorizedHttp, Request
             from googleapiclient.discovery import build
             from googleapiclient.http import HttpRequest
 
@@ -81,14 +84,16 @@ class GmailProvider(EmailProvider):
             # TLS connection across threads corrupts OpenSSL's write buffer and
             # SIGTRAPs the whole process. See
             # llm_memory/BUG-gmail-builtin-sigtrap-macos-py314.md
-            #
-            # The credentials object is shared across threads; concurrent refresh()
-            # calls are possible but benign — the Python-level attribute writes are
-            # GIL-serialized, and each AuthorizedHttp has its own Http for the token
-            # endpoint, so the worst case is a redundant token fetch.
             def _build_request(_http: Any, *args: Any, **kwargs: Any) -> Any:
                 thread_local_http = AuthorizedHttp(credentials, http=httplib2.Http())
                 return HttpRequest(thread_local_http, *args, **kwargs)
+
+            # Fetch the initial access token once, here under the lock, so the first
+            # burst of concurrent requests reuses it. Otherwise every worker thread
+            # would find the shared credentials unpopulated and refresh() at once — a
+            # thundering herd of token fetches. Later expiries refresh lazily; those
+            # races are benign (GIL-serialized writes, per-request token transport).
+            credentials.refresh(Request(httplib2.Http()))
 
             discovery_http = AuthorizedHttp(credentials, http=httplib2.Http())
             self._service = build(

--- a/openpaw/builtins/tools/email/gmail/__init__.py
+++ b/openpaw/builtins/tools/email/gmail/__init__.py
@@ -63,15 +63,41 @@ class GmailProvider(EmailProvider):
             if self._service is not None:
                 return self._service
 
+            import httplib2
             from google.oauth2 import service_account
+            from google_auth_httplib2 import AuthorizedHttp
             from googleapiclient.discovery import build
+            from googleapiclient.http import HttpRequest
 
             credentials = service_account.Credentials.from_service_account_file(  # type: ignore
                 self._service_account_file,
                 scopes=_SCOPES,
                 subject=self._delegated_user,
             )
-            self._service = build("gmail", "v1", credentials=credentials)
+
+            # googleapiclient + httplib2 are NOT thread-safe. Gmail fetches fan out
+            # over asyncio.to_thread() worker threads (GmailFetcher.list_messages/
+            # search), so we hand every request its own httplib2.Http. Sharing one
+            # TLS connection across threads corrupts OpenSSL's write buffer and
+            # SIGTRAPs the whole process. See
+            # llm_memory/BUG-gmail-builtin-sigtrap-macos-py314.md
+            #
+            # The credentials object is shared across threads; concurrent refresh()
+            # calls are possible but benign — the Python-level attribute writes are
+            # GIL-serialized, and each AuthorizedHttp has its own Http for the token
+            # endpoint, so the worst case is a redundant token fetch.
+            def _build_request(_http: Any, *args: Any, **kwargs: Any) -> Any:
+                thread_local_http = AuthorizedHttp(credentials, http=httplib2.Http())
+                return HttpRequest(thread_local_http, *args, **kwargs)
+
+            discovery_http = AuthorizedHttp(credentials, http=httplib2.Http())
+            self._service = build(
+                "gmail",
+                "v1",
+                http=discovery_http,            # used only for the discovery doc
+                requestBuilder=_build_request,  # per-request, per-thread Http
+                cache_discovery=False,          # silences oauth2client file_cache warning
+            )
 
         return self._service
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -8359,8 +8359,8 @@ files = [
 cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and python_version < \"3.14\"", "cffi (>=2.0.0b) ; platform_python_implementation != \"PyPy\" and python_version >= \"3.14\""]
 
 [extras]
-all-builtins = ["elevenlabs", "google-api-python-client", "google-auth", "httpx", "langchain-community", "langchain-mcp-adapters", "langchain-moonshot", "langchain-ollama", "openai", "sqlite-vec", "websockets"]
-email = ["google-api-python-client", "google-auth"]
+all-builtins = ["elevenlabs", "google-api-python-client", "google-auth", "google-auth-httplib2", "httpx", "langchain-community", "langchain-mcp-adapters", "langchain-moonshot", "langchain-ollama", "openai", "sqlite-vec", "websockets"]
+email = ["google-api-python-client", "google-auth", "google-auth-httplib2"]
 mcp = ["langchain-mcp-adapters"]
 memory = ["sqlite-vec"]
 moonshot = ["langchain-moonshot"]
@@ -8372,4 +8372,4 @@ web = ["langchain-community"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "b7660d7e2eb19ddcfbda3e34217fda436095214da879a9f3f23aff9de240e09e"
+content-hash = "74242d15c1b29ff674b037f3e680cb721e3fb36081126cc8bb4645195fe1e35e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ researcher = [
 email = [
     "google-auth (>=2.0.0)",              # Google service account auth
     "google-api-python-client (>=2.0.0)", # Gmail API client
+    "google-auth-httplib2 (>=0.2.0)",     # Per-request httplib2 transport (thread safety)
 ]
 moonshot = [
     "langchain-moonshot (>=0.1.0,<1.0.0)",  # Native Kimi (K2.5 etc.) via Moonshot API
@@ -96,6 +97,7 @@ all-builtins = [
     "httpx (>=0.27.0)",
     "google-auth (>=2.0.0)",
     "google-api-python-client (>=2.0.0)",
+    "google-auth-httplib2 (>=0.2.0)",
     "langchain-moonshot (>=0.1.0,<1.0.0)",
     "langchain-ollama (>=1.0.1,<2.0.0)",
     "langchain-mcp-adapters (>=0.3.0,<1.0.0)",

--- a/tests/builtins/email/gmail/test_provider.py
+++ b/tests/builtins/email/gmail/test_provider.py
@@ -192,6 +192,7 @@ class TestGmailProviderBuildWiring:
         # itself so patch() finds it in sys.modules without triggering a real import.
         gah_mod = types.ModuleType("google_auth_httplib2")
         gah_mod.AuthorizedHttp = MagicMock(name="AuthorizedHttp")  # type: ignore[attr-defined]
+        gah_mod.Request = MagicMock(name="Request")  # type: ignore[attr-defined]
 
         return {
             "googleapiclient.http": http_mod,
@@ -287,3 +288,25 @@ class TestGmailProviderBuildWiring:
         assert "credentials" not in captured_kwargs, (
             "build() must NOT receive credentials= — passing both http= and credentials= raises"
         )
+
+    def test_credentials_refreshed_eagerly_under_lock(self) -> None:
+        """_get_service() must prime the access token once before returning.
+
+        Eager refresh avoids a thundering herd: without it, the first burst of
+        concurrent worker threads would each find the shared credentials
+        unpopulated and call refresh() simultaneously.
+        """
+        with patch.dict(sys.modules, self._conftest_gap_stubs()):
+            with (
+                patch("httplib2.Http"),
+                patch("google_auth_httplib2.AuthorizedHttp"),
+                patch("googleapiclient.discovery.build", return_value=MagicMock()),
+                patch(
+                    "google.oauth2.service_account.Credentials.from_service_account_file"
+                ) as mock_from_file,
+            ):
+                prov = self._fresh_provider()
+                prov._get_service()
+
+        credentials = mock_from_file.return_value
+        credentials.refresh.assert_called_once()

--- a/tests/builtins/email/gmail/test_provider.py
+++ b/tests/builtins/email/gmail/test_provider.py
@@ -1,9 +1,24 @@
 """Tests for GmailProvider integration — send, list, get, search."""
 
+import importlib.util
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import MagicMock
 
 from .conftest import _b64, _make_raw_message
+
+# Marker applied to tests that require the email extra (google_auth_httplib2).
+# We use find_spec() rather than importorskip() because find_spec() stat-checks the
+# package without executing its __init__.py: the conftest registers a bare `google`
+# stub that would make a real import of google_auth_httplib2 fail (it needs
+# google.auth.*), so importorskip() would wrongly skip even when the package exists.
+_skip_no_email_extra = pytest.mark.skipif(
+    importlib.util.find_spec("google_auth_httplib2") is None,
+    reason="google_auth_httplib2 not installed (email extra required)",
+)
 
 
 class TestGmailProviderSend:
@@ -131,3 +146,144 @@ class TestGmailProviderListMessages:
 
         result = await provider.list_messages()
         assert result == []
+
+
+@_skip_no_email_extra
+class TestGmailProviderBuildWiring:
+    """Regression guard: _get_service() must isolate httplib2.Http per request.
+
+    These tests verify the fix for the SIGTRAP crash caused by sharing one
+    httplib2.Http object across concurrent asyncio.to_thread workers. Without the
+    fix, GmailFetcher.list_messages/search fan out up to 100 concurrent calls that
+    all drive the same TLS connection, corrupting the OpenSSL write buffer.
+
+    See llm_memory/BUG-gmail-builtin-sigtrap-macos-py314.md for full context.
+
+    Skipped in environments where google_auth_httplib2 is not installed (no email extra).
+    """
+
+    def _fresh_provider(self) -> Any:
+        """GmailProvider with _service=None so _get_service() reaches the build path.
+
+        The shared ``provider`` fixture pre-injects ``_service``, bypassing the
+        build block entirely. These tests need a clean instance.
+        """
+        from openpaw.builtins.tools.email.gmail import GmailProvider
+
+        return GmailProvider(
+            service_account_file="/fake/sa.json",
+            delegated_user="agent@example.com",
+        )
+
+    def _conftest_gap_stubs(self) -> dict[str, Any]:
+        """Stub modules the new _get_service() imports that the conftest does not cover.
+
+        The conftest stubs ``googleapiclient.discovery`` but not
+        ``googleapiclient.http``. It also stubs ``google`` as a bare module, which
+        blocks ``google_auth_httplib2`` from importing (it needs ``google.auth``).
+        We add minimal stubs here so every import inside ``_get_service()``
+        resolves without touching disk or network.
+        """
+        http_mod = types.ModuleType("googleapiclient.http")
+        http_mod.HttpRequest = MagicMock(name="HttpRequest")  # type: ignore[attr-defined]
+
+        # google_auth_httplib2 needs google.auth at import time. Rather than
+        # unwinding the conftest's google stub, we register google_auth_httplib2
+        # itself so patch() finds it in sys.modules without triggering a real import.
+        gah_mod = types.ModuleType("google_auth_httplib2")
+        gah_mod.AuthorizedHttp = MagicMock(name="AuthorizedHttp")  # type: ignore[attr-defined]
+
+        return {
+            "googleapiclient.http": http_mod,
+            "google_auth_httplib2": gah_mod,
+        }
+
+    def test_request_builder_isolates_http_per_call(self) -> None:
+        """requestBuilder must instantiate a fresh httplib2.Http on every invocation.
+
+        Two successive builder calls (simulating two concurrent worker threads) must
+        each produce a distinct Http instance. Sharing one object across threads
+        corrupts the OpenSSL write buffer, causing SIGTRAP on macOS + Python 3.14.
+        """
+        captured_build_kwargs: dict[str, Any] = {}
+        http_instances: list[MagicMock] = []
+
+        def fake_build(*args: Any, **kwargs: Any) -> MagicMock:
+            captured_build_kwargs.update(kwargs)
+            return MagicMock()
+
+        def new_http() -> MagicMock:
+            inst = MagicMock(name=f"Http#{len(http_instances)}")
+            http_instances.append(inst)
+            return inst
+
+        with patch.dict(sys.modules, self._conftest_gap_stubs()):
+            with (
+                patch("httplib2.Http", side_effect=new_http),
+                patch("google_auth_httplib2.AuthorizedHttp"),
+                patch("googleapiclient.discovery.build", side_effect=fake_build),
+                patch("google.oauth2.service_account.Credentials.from_service_account_file"),
+            ):
+                prov = self._fresh_provider()
+                prov._get_service()
+
+                builder = captured_build_kwargs.get("requestBuilder")
+                assert callable(builder), "build() must receive a requestBuilder callable"
+
+                # Simulate two concurrent worker threads each triggering a request.
+                builder(None)
+                builder(None)
+
+        # _get_service() creates one Http for discovery_http, then each builder
+        # call creates another — three total Http() instantiations.
+        assert len(http_instances) >= 3, (
+            f"Expected at least 3 Http() calls (1 discovery + 2 per-request), "
+            f"got {len(http_instances)}"
+        )
+        request_http_1 = http_instances[-2]
+        request_http_2 = http_instances[-1]
+        assert request_http_1 is not request_http_2, (
+            "requestBuilder must create a distinct httplib2.Http per call — "
+            "sharing one instance across threads corrupts TLS (SIGTRAP)."
+        )
+
+    def test_build_called_with_correct_kwargs(self) -> None:
+        """build() must receive requestBuilder, cache_discovery=False, and http= not credentials=.
+
+        Passing both ``http=`` and ``credentials=`` to build() raises; this test
+        guards against accidentally reverting to the old ``credentials=`` form.
+        """
+        captured_args: tuple[Any, ...] = ()
+        captured_kwargs: dict[str, Any] = {}
+
+        def fake_build(*args: Any, **kwargs: Any) -> MagicMock:
+            nonlocal captured_args, captured_kwargs
+            captured_args = args
+            captured_kwargs = kwargs
+            return MagicMock()
+
+        with patch.dict(sys.modules, self._conftest_gap_stubs()):
+            with (
+                patch("httplib2.Http"),
+                patch("google_auth_httplib2.AuthorizedHttp"),
+                patch("googleapiclient.discovery.build", side_effect=fake_build),
+                patch("google.oauth2.service_account.Credentials.from_service_account_file"),
+            ):
+                prov = self._fresh_provider()
+                prov._get_service()
+
+        assert captured_args == ("gmail", "v1"), (
+            f"build() positional args must be ('gmail', 'v1'), got {captured_args!r}"
+        )
+        assert callable(captured_kwargs.get("requestBuilder")), (
+            "build() must receive a requestBuilder callable"
+        )
+        assert captured_kwargs.get("cache_discovery") is False, (
+            "cache_discovery must be False to silence oauth2client file_cache warning"
+        )
+        assert "http" in captured_kwargs, (
+            "build() must receive http= kwarg (AuthorizedHttp for the discovery doc)"
+        )
+        assert "credentials" not in captured_kwargs, (
+            "build() must NOT receive credentials= — passing both http= and credentials= raises"
+        )


### PR DESCRIPTION
## Summary

Fixes a native **SIGTRAP** (`Trace/BPT trap: 5`) that crashes the entire shared `--all` runner — taking down every co-hosted workspace — whenever an agent invokes a Gmail builtin tool on macOS + Python 3.14.

## Root cause

`GmailProvider` built **one** `googleapiclient` service holding a single `httplib2.Http` (one TLS connection) and shared it across **concurrent** threads:

- `GmailFetcher.list_messages()` / `.search()` fan out up to 100 `fetch_message` calls via `asyncio.gather(...)`.
- Each `fetch_message` runs its API call in `asyncio.to_thread(...)` — a thread-pool worker.
- Every worker hit the **same** shared `Http` / TLS connection.

`httplib2.Http` is not thread-safe. Multiple threads driving one OpenSSL connection corrupt the libssl write buffer, matching the crash trace (`tls_write_records` / `ssl3_dispatch_alert` / `SSL_read_ex`). This is why the call works standalone (sequential, single connection) but crashes under the runner — even a lone `check_email` is internally concurrent.

The original report's "two OpenSSL builds" theory is secondary: TLS flows through `_ssl` regardless of HTTP library, so the decisive variable is the shared, non-thread-safe `Http` — not the transport choice.

## The fix

Adopt the official google-api-python-client threading recipe: a `requestBuilder` that hands **every request its own `httplib2.Http`**, so no TLS connection is ever shared across threads.

- `build()` now receives `http=` (discovery doc only) instead of `credentials=` — passing both raises.
- `requestBuilder=` creates a fresh `AuthorizedHttp(credentials, http=httplib2.Http())` per call.
- `cache_discovery=False` silences the `oauth2client<4.0.0` file_cache warning seen in the crash log.
- The shared `credentials` object's refresh race is benign (GIL-serialized attribute writes, per-instance token transport) — documented inline.

## Why not the report's other suggestions

- **Full rewrite onto requests/httpx** — unnecessary; the cause is concurrency, not the HTTP library. Both stacks still use `_ssl`.
- **Subprocess isolation / SIGTRAP fail-safe** — a native signal can't be caught by `try/except`, so only process isolation would *contain* it. That's a larger architectural change; can be tracked separately if still desired.

## Testing

- New regression tests in `tests/builtins/email/gmail/test_provider.py`:
  - per-request `Http` isolation (distinct instances across builder calls — the core guard)
  - `build()` wiring (`requestBuilder` callable, `cache_discovery=False`, `http=` present, `credentials=` absent)
- Full suite: **3144 passed**. mypy clean on the changed module.
- The native SIGTRAP cannot be reproduced off the affected host (macOS + py3.14 + live runner); the per-request-`Http` change removes the shared-connection race that triggers it.

## Dependency change

Declares the previously-transitive `google-auth-httplib2 (>=0.2.0)` explicitly in the `email` and `all-builtins` extras (it's now a direct import); `poetry.lock` regenerated.
