### PR TITLE
ci: install mcp extra in publish test job (unblock 0.4.3 publish)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,8 +96,16 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
+      - name: Free disk space
+        run: |
+          echo "Before:"; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/boost || true
+          sudo docker image prune --all --force || true
+          echo "After:"; df -h /
+
       - name: Install dependencies
-        run: poetry install --no-interaction
+        run: poetry install -E mcp --no-interaction
 
       - name: Run linting
         run: poetry run ruff check openpaw/


### PR DESCRIPTION
The `v0.4.3` PyPI publish failed: `publish.yml`'s "Run Full Test Suite" job installed deps with `poetry install --no-interaction` (no `mcp` extra), so `langchain-mcp-adapters` was absent — 20 MCP test failures + 6 HTTP integration errors. Build/TestPyPI/PyPI jobs were skipped (they `need` the test job), so nothing was published.

Fix mirrors `ci.yml`: install with `-E mcp` and add the free-disk-space step (the mcp extra pulls torch/triton).

After merge, the `v0.4.3` tag must be re-pointed at the new `main` HEAD to re-run publish. This fix also needs to land on `develop`.