### PR TITLE
Onboarding polish (0.4.4): resolve #170–#182

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-07-01
+
+A first-run onboarding polish release. Found during an install-and-run evaluation of 0.4.3 across both `poetry` and `pip`, these fixes unblock pip users, trim the default install, and correct docs and CLI output.
+
+### Added
+
+- **`openpaw init` scaffolds a runnable `config.yaml`.** Fresh pip installs were hard-blocked at first run: `init` printed a run command that failed with `Config file not found: config.yaml`, and no `config.example.yaml` ships in the wheel to copy. `init` now writes a minimal, valid top-level `config.yaml` (when one does not already exist) next to the workspaces directory, so `run` works immediately after `init`. (#171)
+- **`[documents]` extra** for the Docling OCR/CV document stack. (#174)
+- **Top-level `openpaw --help` now lists the `init` and `list` subcommands** — previously it showed only the run flags, hiding the first commands a new user needs. (#177)
+- **"Install from PyPI" quickstart** in the README (`pip install` → `init` → run), plus documented extras. The existing steps are labelled as the from-source (Poetry) workflow. (#172)
+
+### Changed
+
+- **Bare `pip install openpaw-ai` is now lean.** `docling`, `easyocr`, and `opencv` were core dependencies, so a default install pulled `torch` and hundreds of MB even for a text-only chat bot. They now live behind the optional `[documents]` extra (`pip install 'openpaw-ai[documents]'`), also included in `all-builtins`. The Docling processor already degrades gracefully when the package is absent. (#174)
+- **`init` "Next steps" show the correct invocation per install mode** — both the `poetry run openpaw …` and bare `openpaw …` forms — instead of a single bare command that failed under Poetry with `command not found`. Telegram/Discord scaffolds also warn that the bot denies all users by default until you add your ID to the allowlist. (#176, #179)
+- **Pinned `fireworks-ai` to the tested line (`>=0.16.4,<0.17.0`).** A bare pip install drifted to 0.19.x, which leaks aiohttp client sessions and prints `Unclosed client session` ERRORs during model init; the pin keeps pip close to `poetry.lock`. (#180)
+- Advertised the token-free `stdio` channel as the fastest first-run path (README Quick Start, CLI `--channel` help) and reworded "no tokens needed" to "no channel token needed (still requires an LLM API key)". (#178)
+
+### Fixed
+
+- **Access-denied reply pointed to the wrong config path.** The Telegram/Discord unauthorized message told users to edit `agent_workspaces/<ws>/agent.yaml`, which does not exist — the file lives under `config/`. (#175)
+- **Suppressed the `langgraph` `allowed_objects` `LangChainPendingDeprecationWarning`** that printed to stderr on every CLI invocation (including `--help`). It is an upstream default we cannot pass through, so it is filtered at the package root. (#181)
+- The `Config file not found` error is now actionable, pointing users to `openpaw init` and the getting-started docs. (#171)
+
+### Documentation
+
+- Logo now uses an absolute raw URL so it renders on the PyPI project page (repo-relative paths do not resolve there). (#170)
+- Replaced the decommissioned Fireworks example model (`deepseek-v3p1`) with `kimi-k2p6` and added a note to verify against the provider's live catalog. (#173)
+- Corrected `docs/channels.md`: non-allowlisted messages are **not** "silently ignored" — the bot replies with an access-denied message and logs a warning. (#179)
+- Getting Started polish: `config.yaml` is scaffolded by `init` (copying `config.example.yaml` is an optional source-only step), the `agent.yaml` `model:` block is commented out unless `--model` is passed, model precedence is documented, and the Playwright browser install is noted as needed only for the browser builtin. (#182)
+
 ## [0.4.3] - 2026-06-30
 
 > **BREAKING:** Workspaces using the pre-0.4.3 Moonshot configuration shape
@@ -189,7 +220,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Various race conditions in approval gate resolution and sub-agent cancellation.
 - Path traversal protection hardened across filesystem tools and inbound processors.
 
-[Unreleased]: https://github.com/johnsosoka/OpenPaw/compare/v0.4.3...HEAD
+[Unreleased]: https://github.com/johnsosoka/OpenPaw/compare/v0.4.4...HEAD
+[0.4.4]: https://github.com/johnsosoka/OpenPaw/compare/v0.4.3...v0.4.4
+[0.4.3]: https://github.com/johnsosoka/OpenPaw/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/johnsosoka/OpenPaw/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/johnsosoka/openpaw/releases/tag/v0.4.1
 [0.4.0]: https://github.com/johnsosoka/openpaw/releases/tag/v0.4.0

--- a/README.md
+++ b/README.md
@@ -103,7 +103,25 @@ Anthropic, OpenAI, AWS Bedrock, xAI, Fireworks, and any OpenAI-compatible endpoi
 
 > **Fastest first run:** scaffold with `--channel stdio` to chat with your agent right in the terminal — no Telegram or Discord token required (you still need one LLM provider API key). Swap in `--channel telegram` or `--channel discord` when you're ready to go live.
 
-### 1. Install
+### Install from PyPI
+
+The quickest path — no clone required:
+
+```bash
+pip install openpaw-ai
+openpaw init my_agent --model anthropic:claude-sonnet-4-20250514 --channel stdio
+openpaw -c config.yaml -w my_agent
+```
+
+`openpaw init` scaffolds the workspace **and** a starter `config.yaml`, so `run` works right away. Add your LLM provider key to `agent_workspaces/my_agent/config/.env` (e.g. `ANTHROPIC_API_KEY=...`) before running.
+
+Optional capabilities install as extras: `pip install 'openpaw-ai[documents]'` (Docling OCR/PDF), plus `[voice]`, `[web]`, `[memory]`, `[email]`, `[mcp]`, or `[all-builtins]`.
+
+### Install from source (Poetry)
+
+The steps below use the from-source workflow; prefix commands with `poetry run`.
+
+#### 1. Install
 
 ```bash
 git clone https://github.com/johnsosoka/OpenPaw.git
@@ -111,7 +129,7 @@ cd OpenPaw
 poetry install
 ```
 
-### 2. Scaffold a workspace
+#### 2. Scaffold a workspace
 
 ```bash
 poetry run openpaw init my_agent \
@@ -119,11 +137,9 @@ poetry run openpaw init my_agent \
   --channel telegram
 ```
 
-### 3. Configure
+This also writes a starter `config.yaml` in the current directory (it won't overwrite an existing one). To start from the fully-commented reference instead, copy it first: `cp config.example.yaml config.yaml`.
 
-```bash
-cp config.example.yaml config.yaml
-```
+#### 3. Configure
 
 Add your API keys to `agent_workspaces/my_agent/config/.env`:
 
@@ -132,7 +148,7 @@ ANTHROPIC_API_KEY=your-key-here
 TELEGRAM_BOT_TOKEN=your-token-here
 ```
 
-### 4. Run
+#### 4. Run
 
 ```bash
 poetry run openpaw -c config.yaml -w my_agent

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Anthropic, OpenAI, AWS Bedrock, xAI, Fireworks, and any OpenAI-compatible endpoi
 
 ## Quick Start
 
+> **Fastest first run:** scaffold with `--channel stdio` to chat with your agent right in the terminal — no Telegram or Discord token required (you still need one LLM provider API key). Swap in `--channel telegram` or `--channel discord` when you're ready to go live.
+
 ### 1. Install
 
 ```bash
@@ -142,7 +144,8 @@ poetry run openpaw -c config.yaml -w my_agent
 |---------|-------------|
 | `openpaw init <name>` | Scaffold a new agent workspace |
 | `openpaw init <name> --model <provider:model>` | Scaffold with a pre-configured model |
-| `openpaw init <name> --channel telegram` | Scaffold with channel pre-configured (`telegram` or `discord`) |
+| `openpaw init <name> --channel stdio` | Scaffold with the local terminal channel (no channel token needed) |
+| `openpaw init <name> --channel telegram` | Scaffold with channel pre-configured (`stdio`, `telegram`, or `discord`) |
 | `openpaw list` | List available workspaces |
 | `openpaw -c config.yaml -w <name>` | Run a single workspace |
 | `openpaw -c config.yaml -w name1,name2` | Run multiple workspaces |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="docs/assets/images/logo.png" alt="OpenPaw" width="400">
+  <img src="https://raw.githubusercontent.com/johnsosoka/OpenPaw/main/docs/assets/images/logo.png" alt="OpenPaw" width="400">
   <p><strong>A Friendly <a href="https://langchain-ai.github.io/langgraph/">LangChain/LangGraph</a> Multi-Agent Runner</strong></p>
   <p>
     <a href="https://github.com/johnsosoka/OpenPaw/actions/workflows/ci.yml"><img src="https://github.com/johnsosoka/OpenPaw/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -30,11 +30,13 @@ lanes:
 
 # Default agent model — applies to all workspaces unless overridden in agent.yaml
 # Format: provider:model_id
+# Provider model IDs change over time — verify against your provider's live
+# catalog before use (e.g. Fireworks retires serverless models periodically).
 # Examples:
 #   anthropic:claude-sonnet-4-20250514
 #   openai:gpt-4o
 #   xai:grok-3-mini
-#   fireworks:accounts/fireworks/models/deepseek-v3p1
+#   fireworks:accounts/fireworks/models/kimi-k2p6
 #   bedrock_converse:moonshot.kimi-k2-thinking
 #   moonshot:kimi-k2.5                      # requires `pip install 'openpaw-ai[moonshot]'`
 #   ollama:llama3.1                         # requires `pip install 'openpaw-ai[ollama]'`

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -125,7 +125,9 @@ To get your Telegram user ID:
 - Message [@userinfobot](https://t.me/userinfobot)
 - It will reply with your user ID
 
-Only listed users can DM the bot. Messages from other users are silently ignored.
+Only listed users can DM the bot. A non-allowlisted user is not silently ignored — the bot replies with an access-denied message (`⛔ Access denied. Your user ID: <id>`) that includes their user ID and the exact YAML to add themselves to `config/agent.yaml` → `channel.allowed_users`, and logs a `Blocked user <id>` warning. On startup with an empty allowlist, the framework also logs `Empty allowlist - all requests will be denied`.
+
+> **Note:** A freshly scaffolded workspace has an empty allowlist and denies everyone by default. Message the bot once to receive your user ID, add it to `allowed_users`, then restart.
 
 #### Group Allowlist
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@ This guide walks through installing OpenPaw, creating your first agent workspace
 - **Python 3.11+**
 - **Poetry 2.0+** for dependency management ([installation guide](https://python-poetry.org/docs/#installation))
 - **A channel (choose one):**
-  - **Stdio** — Zero-config terminal channel, no tokens needed (great for testing)
+  - **Stdio** — Zero-config terminal channel, no *channel* token needed — you still need an LLM provider key (great for testing)
   - **Telegram** — Bot token from [@BotFather](https://core.telegram.org/bots#botfather)
   - **Discord** — Bot token from [Developer Portal](https://discord.com/developers/applications)
 - **At least one model provider credential:**
@@ -270,16 +270,16 @@ See [scheduling.md](scheduling.md) for detailed configuration.
 
 ## Running Your Agent
 
-### 1. Quick Start with Stdio (No Tokens Required)
+### 1. Quick Start with Stdio (No Channel Token Required)
 
-The fastest way to test OpenPaw without setting up Telegram or Discord:
+The fastest way to test OpenPaw without setting up Telegram or Discord. No *channel* token is required — you still need one LLM provider key (e.g. `ANTHROPIC_API_KEY`) for the agent to respond:
 
 ```bash
 # Scaffold a workspace with stdio channel
 poetry run openpaw init my_agent --model anthropic:claude-sonnet-4-20250514 --channel stdio
 
 # Run it
-poetry run openpaw -c config.yaml -w my-agent
+poetry run openpaw -c config.yaml -w my_agent
 ```
 
 Type messages directly in your terminal. The agent responds to stdout. Press `Ctrl+D` or send an empty line to stop.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,10 +31,10 @@ cd OpenPaw
 ### 2. Install Dependencies
 
 ```bash
-# Core installation (includes Docling + Playwright)
+# Core installation (lean — no OCR/CV stack)
 poetry install
 
-# Install Playwright browser
+# Install the Playwright browser (only needed for the browser builtin)
 poetry run playwright install chromium
 ```
 
@@ -43,6 +43,9 @@ poetry run playwright install chromium
 Install additional builtins based on your needs:
 
 ```bash
+# Document conversion + OCR (Docling; pulls torch — large)
+poetry install -E documents
+
 # Voice capabilities (Whisper transcription + ElevenLabs TTS)
 poetry install -E voice
 
@@ -60,12 +63,13 @@ poetry install -E all-builtins
 
 | Extra | Provides | Requires |
 |-------|----------|----------|
+| `documents` | Docling PDF/DOCX/PPTX → markdown conversion with OCR | pulls `torch`, `easyocr`, `opencv` (large) |
 | `voice` | Whisper audio transcription, ElevenLabs text-to-speech | `OPENAI_API_KEY`, `ELEVENLABS_API_KEY` |
 | `web` | Brave Search web search | `BRAVE_API_KEY` |
 | `memory` | Semantic search over conversation archives | `sqlite-vec` package |
 | `all-builtins` | All of the above | All API keys above |
 
-**Note:** Docling (document conversion), Playwright (browser automation), and all LLM providers (Anthropic, OpenAI, AWS Bedrock, xAI, Fireworks.ai) are **core dependencies** installed automatically with `poetry install`.
+**Note:** Playwright (browser automation) and all LLM providers (Anthropic, OpenAI, AWS Bedrock, xAI, Fireworks.ai) are **core dependencies** installed automatically with `poetry install`. Document conversion (Docling) lives behind the `documents` extra because its OCR/CV stack pulls `torch` and hundreds of MB — install it only if you need scanned-PDF/OCR features.
 
 ### 4. Set Up Environment Variables
 
@@ -418,10 +422,10 @@ poetry run playwright install --help
 
 ### Docling OCR Issues
 
-If scanned PDFs produce `<!-- image -->` instead of text:
+First ensure the document stack is installed: `poetry install -E documents` (or `pip install 'openpaw-ai[documents]'`). If scanned PDFs produce `<!-- image -->` instead of text:
 
 - **macOS:** Docling uses native OCR (no additional setup needed)
-- **Linux:** Docling falls back to EasyOCR (auto-installed)
+- **Linux:** Docling falls back to EasyOCR (included in the `documents` extra)
 
 Check logs for OCR-related errors when processing PDFs.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,7 +98,9 @@ export ELEVENLABS_API_KEY="your-elevenlabs-key"      # Text-to-speech
 
 ## Initial Configuration
 
-### 1. Copy the Example Configuration
+### 1. Get a config.yaml
+
+`openpaw init` (in the next section) scaffolds a minimal `config.yaml` for you, so you can skip ahead. To start from the fully-commented reference instead, copy it from the repo (source checkouts only — this file is not shipped in the PyPI wheel):
 
 ```bash
 cp config.example.yaml config.yaml
@@ -158,7 +160,7 @@ Each file includes TODO markers to guide customization.
 
 ### 2. Configure Your Workspace
 
-Edit `config/agent.yaml` with your model and channel settings. If you used `--model` and `--channel` flags, the relevant sections are already populated:
+Edit `config/agent.yaml` with your model and channel settings. If you passed `--model` and `--channel` to `init`, these sections are already populated (as shown below). If you did **not** pass them, `init` leaves the `model:` and `channel:` blocks commented out, and the workspace inherits the global default from `config.yaml`. Uncomment and edit them to override per workspace:
 
 ```yaml
 name: my_agent
@@ -186,6 +188,8 @@ Add your API keys to `config/.env`:
 ANTHROPIC_API_KEY=your-key-here
 TELEGRAM_BOT_TOKEN=your-bot-token
 ```
+
+**Model precedence:** The effective model resolves in this order — the global `config.yaml` `agent.model` default → an optional per-workspace `config/agent.yaml` `model:` override → API keys referenced via `${VAR}` are read from the workspace `config/.env` (or your shell environment).
 
 **Timezone:** Add a `timezone` field (IANA identifier, e.g., `America/New_York`) to control cron timing, heartbeat hours, and display timestamps. Defaults to UTC.
 

--- a/openpaw/__init__.py
+++ b/openpaw/__init__.py
@@ -17,5 +17,5 @@ warnings.filterwarnings(
     message=r"The default value of `allowed_objects` will change",
 )
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 __all__ = ["__version__"]

--- a/openpaw/__init__.py
+++ b/openpaw/__init__.py
@@ -1,4 +1,21 @@
 """OpenPaw - AI Agent Framework with DeepAgents and Multi-Channel Support."""
 
+import warnings
+
+# langgraph's checkpoint serializer emits a PendingDeprecationWarning about the
+# default value of `allowed_objects` from its own internal module, on every CLI
+# invocation (issue #181). It is an upstream default we cannot pass through, so
+# we filter it. langchain_core registers its own "default" filters for the
+# LangChain* warning categories at import time, which would shadow ours, so we
+# import that module first and then prepend our ignore filter above it.
+try:
+    import langchain_core._api.deprecation as _lc_deprecation  # noqa: F401
+except Exception:  # pragma: no cover - langchain_core is a core dependency
+    pass
+warnings.filterwarnings(
+    "ignore",
+    message=r"The default value of `allowed_objects` will change",
+)
+
 __version__ = "0.4.3"
 __all__ = ["__version__"]

--- a/openpaw/channels/helpers/formatting.py
+++ b/openpaw/channels/helpers/formatting.py
@@ -52,7 +52,7 @@ def format_unauthorized_response(
         text += f"Group ID: `{group_id}`\n"
     text += (
         f"\nTo gain access, add your ID to the allowlist:\n"
-        f"`agent_workspaces/{workspace_name}/agent.yaml`\n\n"
+        f"`agent_workspaces/{workspace_name}/config/agent.yaml`\n\n"
         f"```yaml\n"
         f"channel:\n"
         f"  allowed_users:\n"

--- a/openpaw/cli.py
+++ b/openpaw/cli.py
@@ -38,7 +38,18 @@ def parse_workspace_arg(value: str, workspaces_path: Path) -> list[str]:
 
 async def main() -> None:
     """CLI entry point."""
-    parser = argparse.ArgumentParser(description="OpenPaw - AI Agent Framework")
+    parser = argparse.ArgumentParser(
+        description="OpenPaw - AI Agent Framework",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "subcommands:\n"
+            "  init <name>           Scaffold a new agent workspace\n"
+            "  list                  List available workspaces\n"
+            "\n"
+            "Run 'openpaw init --help' or 'openpaw list --help' for subcommand options.\n"
+            "The options below apply when running workspaces (e.g. openpaw -c config.yaml -w <name>)."
+        ),
+    )
     parser.add_argument(
         "-c",
         "--config",

--- a/openpaw/cli_init/commands.py
+++ b/openpaw/cli_init/commands.py
@@ -70,9 +70,10 @@ def _handle_init(args: list[str]) -> None:
         print(f"Error creating workspace: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    from .scaffolder import _print_next_steps
+    from .scaffolder import _ensure_root_config, _print_next_steps
 
-    _print_next_steps(workspace_path, parsed.name)
+    config_path = _ensure_root_config(parsed.path)
+    _print_next_steps(workspace_path, parsed.name, config_path)
 
 
 def _handle_list(args: list[str]) -> None:

--- a/openpaw/cli_init/commands.py
+++ b/openpaw/cli_init/commands.py
@@ -36,7 +36,7 @@ def _handle_init(args: list[str]) -> None:
     parser.add_argument(
         "--channel",
         default=None,
-        help="Pre-configure channel type (e.g., telegram)",
+        help="Pre-configure channel type: stdio (local terminal), telegram, or discord",
     )
     parser.add_argument(
         "--model",

--- a/openpaw/cli_init/commands.py
+++ b/openpaw/cli_init/commands.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 from .scaffolder import (
     _create_workspace,
+    _ensure_root_config,
+    _print_next_steps,
     _validate_workspace_name,
 )
 from .templates import _parse_model_string
@@ -69,8 +71,6 @@ def _handle_init(args: list[str]) -> None:
     except OSError as exc:
         print(f"Error creating workspace: {exc}", file=sys.stderr)
         sys.exit(1)
-
-    from .scaffolder import _ensure_root_config, _print_next_steps
 
     config_path = _ensure_root_config(parsed.path)
     _print_next_steps(workspace_path, parsed.name, config_path, parsed.channel)

--- a/openpaw/cli_init/commands.py
+++ b/openpaw/cli_init/commands.py
@@ -73,7 +73,7 @@ def _handle_init(args: list[str]) -> None:
     from .scaffolder import _ensure_root_config, _print_next_steps
 
     config_path = _ensure_root_config(parsed.path)
-    _print_next_steps(workspace_path, parsed.name, config_path)
+    _print_next_steps(workspace_path, parsed.name, config_path, parsed.channel)
 
 
 def _handle_list(args: list[str]) -> None:

--- a/openpaw/cli_init/scaffolder.py
+++ b/openpaw/cli_init/scaffolder.py
@@ -183,4 +183,6 @@ def _print_next_steps(workspace_path: Path, name: str) -> None:
     print("  2. Add API keys to config/.env")
     print("  3. Customize agent/AGENT.md, agent/USER.md, and agent/SOUL.md")
     print("  4. Review agent/team/ for default sub-agent profiles (edit or remove)")
-    print(f"  5. Run: openpaw -c config.yaml -w {name}")
+    print("  5. Run your agent:")
+    print(f"       from a poetry checkout:  poetry run openpaw -c config.yaml -w {name}")
+    print(f"       from a pip install:      openpaw -c config.yaml -w {name}")

--- a/openpaw/cli_init/scaffolder.py
+++ b/openpaw/cli_init/scaffolder.py
@@ -27,6 +27,7 @@ from openpaw.core.paths import (
 
 from .templates import (
     TEMPLATE_AGENT_MD,
+    TEMPLATE_CONFIG_YAML,
     TEMPLATE_ENV,
     TEMPLATE_HEARTBEAT_MD,
     TEMPLATE_SOUL_MD,
@@ -168,7 +169,38 @@ def _create_workspace(
     return workspace_path
 
 
-def _print_next_steps(workspace_path: Path, name: str) -> None:
+def _ensure_root_config(workspaces_path: Path) -> Path | None:
+    """Scaffold a top-level ``config.yaml`` next to the workspaces directory.
+
+    ``openpaw`` requires a global config file to run. Without one, a freshly
+    scaffolded workspace is unrunnable — a hard block for pip users who have no
+    ``config.example.yaml`` to copy (issue #171). This writes a minimal, valid
+    ``config.yaml`` when one does not already exist.
+
+    The file is written to the parent of ``workspaces_path`` (the directory the
+    user runs ``openpaw`` from), and its ``workspaces_path`` field is set to
+    match the scaffolded workspaces directory.
+
+    Args:
+        workspaces_path: Directory that holds the workspaces (e.g. ``agent_workspaces``).
+
+    Returns:
+        Path to the created config.yaml, or None if one already existed.
+    """
+    config_path = workspaces_path.parent / "config.yaml"
+    if config_path.exists():
+        return None
+
+    config_path.write_text(
+        TEMPLATE_CONFIG_YAML.format(workspaces_path=workspaces_path.name),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def _print_next_steps(
+    workspace_path: Path, name: str, config_path: Path | None
+) -> None:
     """Print the post-creation summary and suggested next steps.
 
     Args:
@@ -177,6 +209,8 @@ def _print_next_steps(workspace_path: Path, name: str) -> None:
     """
     print(f"Created workspace: {name}")
     print(f"  Path: {workspace_path}/")
+    if config_path is not None:
+        print(f"  Config: {config_path} (global defaults — edit as needed)")
     print()
     print("Next steps:")
     print("  1. Edit config/agent.yaml with your model and channel settings")

--- a/openpaw/cli_init/scaffolder.py
+++ b/openpaw/cli_init/scaffolder.py
@@ -199,7 +199,7 @@ def _ensure_root_config(workspaces_path: Path) -> Path | None:
 
 
 def _print_next_steps(
-    workspace_path: Path, name: str, config_path: Path | None
+    workspace_path: Path, name: str, config_path: Path | None, channel: str | None = None
 ) -> None:
     """Print the post-creation summary and suggested next steps.
 
@@ -220,3 +220,10 @@ def _print_next_steps(
     print("  5. Run your agent:")
     print(f"       from a poetry checkout:  poetry run openpaw -c config.yaml -w {name}")
     print(f"       from a pip install:      openpaw -c config.yaml -w {name}")
+    if channel in ("telegram", "discord"):
+        print()
+        print(
+            "  Note: the bot denies all users by default — message it once to get your "
+            "user ID,\n        then add it to config/agent.yaml -> channel.allowed_users "
+            "and restart."
+        )

--- a/openpaw/cli_init/scaffolder.py
+++ b/openpaw/cli_init/scaffolder.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import sys
 from pathlib import Path
 
 from openpaw.core.paths import (
@@ -185,16 +186,27 @@ def _ensure_root_config(workspaces_path: Path) -> Path | None:
         workspaces_path: Directory that holds the workspaces (e.g. ``agent_workspaces``).
 
     Returns:
-        Path to the created config.yaml, or None if one already existed.
+        Path to the created config.yaml, or None if one already existed or could
+        not be written. Failure is non-fatal: the workspace is still usable and
+        the user can author config.yaml themselves.
     """
-    config_path = workspaces_path.parent / "config.yaml"
+    resolved = workspaces_path.resolve()
+    config_path = resolved.parent / "config.yaml"
     if config_path.exists():
         return None
 
-    config_path.write_text(
-        TEMPLATE_CONFIG_YAML.format(workspaces_path=workspaces_path.name),
-        encoding="utf-8",
-    )
+    try:
+        config_path.write_text(
+            TEMPLATE_CONFIG_YAML.format(workspaces_path=resolved.name),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        print(
+            f"Warning: could not write {config_path}: {exc}. "
+            "Create a config.yaml before running (see 'openpaw init --help').",
+            file=sys.stderr,
+        )
+        return None
     return config_path
 
 

--- a/openpaw/cli_init/templates.py
+++ b/openpaw/cli_init/templates.py
@@ -56,6 +56,55 @@ TEMPLATE_HEARTBEAT_MD = """\
 <!-- Leave empty if heartbeat is not configured -->
 """
 
+TEMPLATE_CONFIG_YAML = """\
+# OpenPaw Global Configuration
+# Scaffolded by `openpaw init`. Per-workspace overrides go in each
+# workspace's config/agent.yaml.
+
+# Path to agent workspaces directory
+workspaces_path: {workspaces_path}
+
+# Logging
+logging:
+  level: INFO
+  directory: logs
+  max_size_mb: 10
+  backup_count: 5
+  per_workspace: true
+
+# Message queue defaults (can be overridden per workspace via agent.yaml)
+queue:
+  mode: collect            # collect, steer, followup, interrupt
+  debounce_ms: 1000        # Wait this long after last message before processing
+  cap: 20                  # Max queued messages per session before drop policy fires
+  drop_policy: summarize   # old (drop oldest), new (drop newest), summarize
+
+# Lane concurrency (how many agent runs happen simultaneously per lane)
+lanes:
+  main_concurrency: 4      # User-facing message lanes
+  subagent_concurrency: 8  # Background sub-agent workers
+  cron_concurrency: 2      # Scheduled job runners
+
+# Default agent model — applies to any workspace that does not set its own
+# model in config/agent.yaml. Format: provider:model_id
+# Provider model IDs change over time — verify against your provider's live
+# catalog before use.
+agent:
+  model: anthropic:claude-sonnet-4-20250514
+  max_turns: 50
+  temperature: 0.7
+
+# Provider catalog (optional) — define connection details once and reference
+# providers by name from any workspace. Uncomment and fill in as needed.
+# providers:
+#   anthropic:
+#     api_key: ${{ANTHROPIC_API_KEY}}
+#   openai:
+#     api_key: ${{OPENAI_API_KEY}}
+#   fireworks:
+#     api_key: ${{FIREWORKS_API_KEY}}
+"""
+
 TEMPLATE_ENV = """\
 # API keys for this workspace
 # ANTHROPIC_API_KEY=

--- a/openpaw/core/config/loader.py
+++ b/openpaw/core/config/loader.py
@@ -136,7 +136,11 @@ def load_config(path: Path | str) -> Config:
     """
     config_path = Path(path)
     if not config_path.exists():
-        raise FileNotFoundError(f"Config file not found: {config_path}")
+        raise FileNotFoundError(
+            f"Config file not found: {config_path}. "
+            "Run 'openpaw init <name>' to scaffold a workspace and a starter "
+            "config.yaml, or see https://johnsosoka.github.io/OpenPaw/getting-started/"
+        )
 
     with config_path.open() as f:
         data: dict[str, Any] = yaml.safe_load(f) or {}

--- a/poetry.lock
+++ b/poetry.lock
@@ -8372,4 +8372,4 @@ web = ["langchain-community"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "74242d15c1b29ff674b037f3e680cb721e3fb36081126cc8bb4645195fe1e35e"
+content-hash = "f6ed1e3c1e3555cba89940fabbbced658e74563a1887d5980b713d0b3da13c20"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,9 +4,10 @@
 name = "accelerate"
 version = "1.12.0"
 description = "Accelerate"
-optional = false
+optional = true
 python-versions = ">=3.10.0"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "accelerate-1.12.0-py3-none-any.whl", hash = "sha256:3e2091cd341423207e2f084a6654b1efcd250dc326f2a37d6dde446e07cabb11"},
     {file = "accelerate-1.12.0.tar.gz", hash = "sha256:70988c352feb481887077d2ab845125024b2a137a5090d6d7a32b57d03a45df6"},
@@ -264,9 +265,10 @@ vertex = ["google-auth[requests] (>=2,<3)"]
 name = "antlr4-python3-runtime"
 version = "4.9.3"
 description = "ANTLR 4.9.3 runtime for Python 3.7"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b"},
 ]
@@ -411,9 +413,10 @@ files = [
 name = "beautifulsoup4"
 version = "4.14.3"
 description = "Screen-scraping library"
-optional = false
+optional = true
 python-versions = ">=3.7.0"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb"},
     {file = "beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86"},
@@ -804,15 +807,16 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\"", docs = "platform_system == \"Windows\""}
+markers = {main = "sys_platform == \"win32\" and (extra == \"documents\" or extra == \"all-builtins\") or platform_system == \"Windows\"", dev = "sys_platform == \"win32\"", docs = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorlog"
 version = "6.10.1"
 description = "Add colours to the output of Python's logging module."
-optional = false
+optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c"},
     {file = "colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321"},
@@ -901,10 +905,10 @@ test-randomorder = ["pytest-randomly"]
 name = "cuda-bindings"
 version = "12.9.4"
 description = "Python bindings for CUDA"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
+markers = "platform_system == \"Linux\" and (extra == \"documents\" or extra == \"all-builtins\") and platform_machine == \"x86_64\" and python_version < \"3.13\""
 files = [
     {file = "cuda_bindings-12.9.4-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a022c96b8bd847e8dc0675523431149a4c3e872f440e3002213dbb9e08f0331a"},
     {file = "cuda_bindings-12.9.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d3c842c2a4303b2a580fe955018e31aea30278be19795ae05226235268032e5"},
@@ -943,10 +947,10 @@ test = ["cython (>=3.1,<3.2)", "numpy (>=1.21.1)", "pyglet (>=2.1.9)", "pytest (
 name = "cuda-pathfinder"
 version = "1.3.3"
 description = "Pathfinder for CUDA components"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
+markers = "platform_system == \"Linux\" and (extra == \"documents\" or extra == \"all-builtins\") and platform_machine == \"x86_64\" and python_version < \"3.13\""
 files = [
     {file = "cuda_pathfinder-1.3.3-py3-none-any.whl", hash = "sha256:9984b664e404f7c134954a771be8775dfd6180ea1e1aef4a5a37d4be05d9bbb1"},
 ]
@@ -987,9 +991,10 @@ dev = ["black", "build", "mypy", "pytest", "pyupgrade", "twine", "validate-pypro
 name = "dill"
 version = "0.4.1"
 description = "serialize all of Python"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d"},
     {file = "dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa"},
@@ -1038,9 +1043,10 @@ files = [
 name = "docling"
 version = "2.72.0"
 description = "SDK and CLI for parsing PDF, DOCX, HTML, and more, to a unified document representation for powering downstream workflows such as gen AI applications."
-optional = false
+optional = true
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "docling-2.72.0-py3-none-any.whl", hash = "sha256:261a5fdfa3276783c18a29aa0ec623b259450765421bebeec87de523f07adcf3"},
     {file = "docling-2.72.0.tar.gz", hash = "sha256:3edd48bb7b6e5737647441b96fba8811f69cac495883fa28dbf2444a0322cabd"},
@@ -1088,9 +1094,10 @@ vlm = ["accelerate (>=1.2.1,<2.0.0)", "mlx-vlm (>=0.3.0,<1.0.0) ; python_version
 name = "docling-core"
 version = "2.63.0"
 description = "A python library to define and validate data types in Docling."
-optional = false
+optional = true
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "docling_core-2.63.0-py3-none-any.whl", hash = "sha256:8f39167bf17da13225c8a67d23df98c87a74e2ab39762dbf51fab93d9b90de25"},
     {file = "docling_core-2.63.0.tar.gz", hash = "sha256:946cf97f27cb81a2c6507121045a356be91e40b5a06bbaf028ca7036df78b2f1"},
@@ -1124,9 +1131,10 @@ examples = ["datasets (>=4.0.0)", "matplotlib (>=3.7.0)", "openpyxl (>=3.1.5)", 
 name = "docling-ibm-models"
 version = "3.11.0"
 description = "This package contains the AI models used by the Docling PDF conversion package"
-optional = false
+optional = true
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "docling_ibm_models-3.11.0-py3-none-any.whl", hash = "sha256:68f7961069d643bfdab21b1c9ef24a979db293496f4c2283d95b1025a9ac5347"},
     {file = "docling_ibm_models-3.11.0.tar.gz", hash = "sha256:454401563a8e79cb33b718bc559d9bacca8a0183583e48f8e616c9184c1f5eb1"},
@@ -1155,9 +1163,10 @@ opencv-python-headless = ["opencv-python-headless (>=4.6.0.66,<5.0.0.0)"]
 name = "docling-parse"
 version = "4.7.3"
 description = "Simple package to extract text with coordinates from programmatic PDFs"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "docling_parse-4.7.3-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:65e0653d9617d38e73bab069dc3e7960668ff4a6b0ff45a7635c3790eeed8a08"},
     {file = "docling_parse-4.7.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:978e7e7032760385264896871ae87cb3a04081766cc966c57e9750ce803162ac"},
@@ -1219,9 +1228,10 @@ test = ["pytest"]
 name = "easyocr"
 version = "1.7.2"
 description = "End-to-End Multi-Lingual Optical Character Recognition (OCR) Solution"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "easyocr-1.7.2-py3-none-any.whl", hash = "sha256:5be12f9b0e595d443c9c3d10b0542074b50f0ec2d98b141a109cd961fd1c177c"},
 ]
@@ -1268,9 +1278,10 @@ pyaudio = ["pyaudio (>=0.2.14)"]
 name = "et-xmlfile"
 version = "2.0.0"
 description = "An implementation of lxml.xmlfile for the standard library"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa"},
     {file = "et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54"},
@@ -1280,9 +1291,10 @@ files = [
 name = "faker"
 version = "40.4.0"
 description = "Faker is a Python package that generates fake data for you."
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "faker-40.4.0-py3-none-any.whl", hash = "sha256:486d43c67ebbb136bc932406418744f9a0bdf2c07f77703ea78b58b77e9aa443"},
     {file = "faker-40.4.0.tar.gz", hash = "sha256:76f8e74a3df28c3e2ec2caafa956e19e37a132fdc7ea067bc41783affcfee364"},
@@ -1298,9 +1310,10 @@ tzdata = ["tzdata"]
 name = "filelock"
 version = "3.20.3"
 description = "A platform independent file lock."
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1"},
     {file = "filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1"},
@@ -1310,9 +1323,10 @@ files = [
 name = "filetype"
 version = "1.2.0"
 description = "Infer file type and MIME type of any file/buffer. No external dependencies."
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25"},
     {file = "filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb"},
@@ -1489,9 +1503,10 @@ files = [
 name = "fsspec"
 version = "2026.2.0"
 description = "File-system specification"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437"},
     {file = "fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff"},
@@ -1755,10 +1770,10 @@ hyperframe = ">=6.1,<7"
 name = "hf-xet"
 version = "1.2.0"
 description = "Fast transfer of large files with the Hugging Face Hub."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""
+markers = "(platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\") and (extra == \"documents\" or extra == \"all-builtins\")"
 files = [
     {file = "hf_xet-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ceeefcd1b7aed4956ae8499e2199607765fbd1c60510752003b6cc0b8413b649"},
     {file = "hf_xet-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b70218dd548e9840224df5638fdc94bd033552963cfa97f9170829381179c813"},
@@ -1896,9 +1911,10 @@ wsproto = "*"
 name = "huggingface-hub"
 version = "0.36.2"
 description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
-optional = false
+optional = true
 python-versions = ">=3.8.0"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270"},
     {file = "huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a"},
@@ -1962,9 +1978,10 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 name = "imageio"
 version = "2.37.2"
 description = "Read and write images and video across all major formats. Supports scientific and volumetric data."
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "imageio-2.37.2-py3-none-any.whl", hash = "sha256:ad9adfb20335d718c03de457358ed69f141021a333c40a53e57273d8a5bd0b9b"},
     {file = "imageio-2.37.2.tar.gz", hash = "sha256:0212ef2727ac9caa5ca4b2c75ae89454312f440a756fcfc8ef1993e718f50f8a"},
@@ -2165,9 +2182,10 @@ files = [
 name = "jsonlines"
 version = "4.0.0"
 description = "Library with helpers for the jsonlines file format"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "jsonlines-4.0.0-py3-none-any.whl", hash = "sha256:185b334ff2ca5a91362993f42e83588a360cf95ce4b71a73548502bda52a7c55"},
     {file = "jsonlines-4.0.0.tar.gz", hash = "sha256:0c6d2c09117550c089995247f605ae4cf77dd1533041d366351f6f298822ea74"},
@@ -2207,9 +2225,10 @@ files = [
 name = "jsonref"
 version = "1.1.0"
 description = "jsonref is a library for automatic dereferencing of JSON Reference objects for Python."
-optional = false
+optional = true
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9"},
     {file = "jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552"},
@@ -2219,9 +2238,10 @@ files = [
 name = "jsonschema"
 version = "4.26.0"
 description = "An implementation of JSON Schema validation for Python"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\" or extra == \"mcp\""
 files = [
     {file = "jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce"},
     {file = "jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326"},
@@ -2241,9 +2261,10 @@ format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-
 name = "jsonschema-specifications"
 version = "2025.9.1"
 description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\" or extra == \"mcp\""
 files = [
     {file = "jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe"},
     {file = "jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d"},
@@ -2679,9 +2700,10 @@ vcr = ["vcrpy (>=7.0.0)"]
 name = "latex2mathml"
 version = "3.78.1"
 description = "Pure Python library for LaTeX to MathML conversion"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "latex2mathml-3.78.1-py3-none-any.whl", hash = "sha256:f089b6d75e85b937f99693c93e8c16c0804008672c3dd2a3d25affd36f238100"},
     {file = "latex2mathml-3.78.1.tar.gz", hash = "sha256:f941db80bf41db33f31df87b304e8b588f8166b813b0257c11c98f7a9d0aac71"},
@@ -2691,9 +2713,10 @@ files = [
 name = "lazy-loader"
 version = "0.4"
 description = "Makes it easy to load subpackages and functions on demand."
-optional = false
+optional = true
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "lazy_loader-0.4-py3-none-any.whl", hash = "sha256:342aa8e14d543a154047afb4ba8ef17f5563baad3fc610d7b15b213b0f119efc"},
     {file = "lazy_loader-0.4.tar.gz", hash = "sha256:47c75182589b91a4e1a85a136c074285a5ad4d9f39c63e0d7fb76391c4574cd1"},
@@ -2798,9 +2821,10 @@ files = [
 name = "lxml"
 version = "6.0.2"
 description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "lxml-6.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e77dd455b9a16bbd2a5036a63ddbd479c19572af81b624e79ef422f929eef388"},
     {file = "lxml-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5d444858b9f07cefff6455b983aea9a67f7462ba1f6cbe4a21e8bf6791bf2153"},
@@ -2970,9 +2994,10 @@ testing = ["coverage", "pyyaml"]
 name = "markdown-it-py"
 version = "4.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147"},
     {file = "markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3"},
@@ -2994,9 +3019,10 @@ testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions", "requests"]
 name = "marko"
 version = "2.2.2"
 description = "A markdown parser with high extensibility."
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "marko-2.2.2-py3-none-any.whl", hash = "sha256:f064ae8c10416285ad1d96048dc11e98ef04e662d3342ae416f662b70aa7959e"},
     {file = "marko-2.2.2.tar.gz", hash = "sha256:6940308e655f63733ca518c47a68ec9510279dbb916c83616e4c4b5829f052e8"},
@@ -3165,9 +3191,10 @@ ws = ["websockets (>=15.0.1)"]
 name = "mdurl"
 version = "0.1.2"
 description = "Markdown URL utilities"
-optional = false
+optional = true
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
@@ -3302,9 +3329,10 @@ type = ["mypy (==1.19.1)"]
 name = "mpire"
 version = "2.10.2"
 description = "A Python package for easy multiprocessing, but faster than multiprocessing"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "mpire-2.10.2-py3-none-any.whl", hash = "sha256:d627707f7a8d02aa4c7f7d59de399dec5290945ddf7fbd36cbb1d6ebb37a51fb"},
     {file = "mpire-2.10.2.tar.gz", hash = "sha256:f66a321e93fadff34585a4bfa05e95bd946cf714b442f51c529038eb45773d97"},
@@ -3326,9 +3354,10 @@ testing = ["ipywidgets", "multiprocess (>=0.70.15) ; python_version >= \"3.11\""
 name = "mpmath"
 version = "1.3.0"
 description = "Python library for arbitrary-precision floating-point arithmetic"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c"},
     {file = "mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f"},
@@ -3500,9 +3529,10 @@ files = [
 name = "multiprocess"
 version = "0.70.19"
 description = "better multiprocessing and multithreading in Python"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "multiprocess-0.70.19-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:02e5c35d7d6cd2bdc89c1858867f7bde4012837411023a4696c148c1bdd7c80e"},
     {file = "multiprocess-0.70.19-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:79576c02d1207ec405b00cabf2c643c36070800cca433860e14539df7818b2aa"},
@@ -3602,10 +3632,10 @@ files = [
 name = "networkx"
 version = "3.6"
 description = "Python package for creating and manipulating graphs and networks"
-optional = false
+optional = true
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "python_version >= \"3.12\""
+markers = "python_version >= \"3.12\" and (extra == \"documents\" or extra == \"all-builtins\")"
 files = [
     {file = "networkx-3.6-py3-none-any.whl", hash = "sha256:cdb395b105806062473d3be36458d8f1459a4e4b98e236a66c3a48996e07684f"},
     {file = "networkx-3.6.tar.gz", hash = "sha256:285276002ad1f7f7da0f7b42f004bcba70d381e936559166363707fdad3d72ad"},
@@ -3626,10 +3656,10 @@ test-extras = ["pytest-mpl", "pytest-randomly"]
 name = "networkx"
 version = "3.6.1"
 description = "Python package for creating and manipulating graphs and networks"
-optional = false
+optional = true
 python-versions = "!=3.14.1,>=3.11"
 groups = ["main"]
-markers = "python_version < \"3.13\""
+markers = "(extra == \"documents\" or extra == \"all-builtins\") and python_version < \"3.13\""
 files = [
     {file = "networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762"},
     {file = "networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509"},
@@ -3650,9 +3680,10 @@ test-extras = ["pytest-mpl", "pytest-randomly"]
 name = "ninja"
 version = "1.13.0"
 description = "Ninja is a small build system with a focus on speed"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "ninja-1.13.0-py3-none-macosx_10_9_universal2.whl", hash = "sha256:fa2a8bfc62e31b08f83127d1613d10821775a0eb334197154c4d6067b7068ff1"},
     {file = "ninja-1.13.0-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3d00c692fb717fd511abeb44b8c5d00340c36938c12d6538ba989fe764e79630"},
@@ -3761,10 +3792,10 @@ files = [
 name = "nvidia-cublas-cu12"
 version = "12.6.4.1"
 description = "CUBLAS native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version >= \"3.12\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and (extra == \"documents\" or extra == \"all-builtins\") and python_version >= \"3.12\""
 files = [
     {file = "nvidia_cublas_cu12-12.6.4.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08ed2686e9875d01b58e3cb379c6896df8e76c75e0d4a7f7dace3d7b6d9ef8eb"},
     {file = "nvidia_cublas_cu12-12.6.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:235f728d6e2a409eddf1df58d5b0921cf80cfa9e72b9f2775ccb7b4a87984668"},
@@ -3775,10 +3806,10 @@ files = [
 name = "nvidia-cublas-cu12"
 version = "12.8.4.1"
 description = "CUBLAS native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
+markers = "platform_system == \"Linux\" and (extra == \"documents\" or extra == \"all-builtins\") and platform_machine == \"x86_64\" and python_version < \"3.13\""
 files = [
     {file = "nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b86f6dd8935884615a0683b663891d43781b819ac4f2ba2b0c9604676af346d0"},
     {file = "nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142"},
@@ -3789,10 +3820,10 @@ files = [
 name = "nvidia-cuda-cupti-cu12"
 version = "12.6.80"
 description = "CUDA profiling tools runtime libs."
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version >= \"3.12\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and (extra == \"documents\" or extra == \"all-builtins\") and python_version >= \"3.12\""
 files = [
     {file = "nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:166ee35a3ff1587f2490364f90eeeb8da06cd867bd5b701bf7f9a02b78bc63fc"},
     {file = "nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_aarch64.whl", hash = "sha256:358b4a1d35370353d52e12f0a7d1769fc01ff74a191689d3870b2123156184c4"},
@@ -3805,10 +3836,10 @@ files = [
 name = "nvidia-cuda-cupti-cu12"
 version = "12.8.90"
 description = "CUDA profiling tools runtime libs."
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
+markers = "platform_system == \"Linux\" and (extra == \"documents\" or extra == \"all-builtins\") and platform_machine == \"x86_64\" and python_version < \"3.13\""
 files = [
     {file = "nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4412396548808ddfed3f17a467b104ba7751e6b58678a4b840675c56d21cf7ed"},
     {file = "nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182"},
@@ -3819,10 +3850,10 @@ files = [
 name = "nvidia-cuda-nvrtc-cu12"
 version = "12.6.77"
 description = "NVRTC native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version >= \"3.12\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and (extra == \"documents\" or extra == \"all-builtins\") and python_version >= \"3.12\""
 files = [
     {file = "nvidia_cuda_nvrtc_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:5847f1d6e5b757f1d2b3991a01082a44aad6f10ab3c5c0213fa3e25bddc25a13"},
     {file = "nvidia_cuda_nvrtc_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:35b0cc6ee3a9636d5409133e79273ce1f3fd087abb0532d2d2e8fff1fe9efc53"},
@@ -3833,10 +3864,10 @@ files = [
 name = "nvidia-cuda-nvrtc-cu12"
 version = "12.8.93"
 description = "NVRTC native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
+markers = "platform_system == \"Linux\" and (extra == \"documents\" or extra == \"all-builtins\") and platform_machine == \"x86_64\" and python_version < \"3.13\""
 files = [
     {file = "nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994"},
     {file = "nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc1fec1e1637854b4c0a65fb9a8346b51dd9ee69e61ebaccc82058441f15bce8"},
@@ -3847,10 +3878,10 @@ files = [
 name = "nvidia-cuda-runtime-cu12"
 version = "12.6.77"
 description = "CUDA Runtime native Libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version >= \"3.12\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and (extra == \"documents\" or extra == \"all-builtins\") and python_version >= \"3.12\""
 files = [
     {file = "nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6116fad3e049e04791c0256a9778c16237837c08b27ed8c8401e2e45de8d60cd"},
     {file = "nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:d461264ecb429c84c8879a7153499ddc7b19b5f8d84c204307491989a365588e"},
@@ -3863,10 +3894,10 @@ files = [
 name = "nvidia-cuda-runtime-cu12"
 version = "12.8.90"
 description = "CUDA Runtime native Libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
+markers = "platform_system == \"Linux\" and (extra == \"documents\" or extra == \"all-builtins\") and platform_machine == \"x86_64\" and python_version < \"3.13\""
 files = [
     {file = "nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:52bf7bbee900262ffefe5e9d5a2a69a30d97e2bc5bb6cc866688caa976966e3d"},
     {file = "nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90"},
@@ -3877,10 +3908,10 @@ files = [
 name = "nvidia-cudnn-cu12"
 version = "9.5.1.17"
 description = "cuDNN runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version >= \"3.12\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and (extra == \"documents\" or extra == \"all-builtins\") and python_version >= \"3.12\""
 files = [
     {file = "nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:9fd4584468533c61873e5fda8ca41bac3a38bcb2d12350830c69b0a96a7e4def"},
     {file = "nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:30ac3869f6db17d170e0e556dd6cc5eee02647abc31ca856634d5a40f82c15b2"},
@@ -3894,10 +3925,10 @@ nvidia-cublas-cu12 = "*"
 name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 description = "cuDNN runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
+markers = "platform_system == \"Linux\" and (extra == \"documents\" or extra == \"all-builtins\") and platform_machine == \"x86_64\" and python_version < \"3.13\""
 files = [
     {file = "nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8"},
     {file = "nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8"},
@@ -3911,10 +3942,10 @@ nvidia-cublas-cu12 = "*"
 name = "nvidia-cufft-cu12"
 version = "11.3.0.4"
 description = "CUFFT native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version >= \"3.12\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and (extra == \"documents\" or extra == \"all-builtins\") and python_version >= \"3.12\""
 files = [
     {file = "nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d16079550df460376455cba121db6564089176d9bac9e4f360493ca4741b22a6"},
     {file = "nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8510990de9f96c803a051822618d42bf6cb8f069ff3f48d93a8486efdacb48fb"},
@@ -3930,10 +3961,10 @@ nvidia-nvjitlink-cu12 = "*"
 name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 description = "CUFFT native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
+markers = "platform_system == \"Linux\" and (extra == \"documents\" or extra == \"all-builtins\") and platform_machine == \"x86_64\" and python_version < \"3.13\""
 files = [
     {file = "nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a"},
     {file = "nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74"},
@@ -3947,10 +3978,10 @@ nvidia-nvjitlink-cu12 = "*"
 name = "nvidia-cufile-cu12"
 version = "1.11.1.6"
 description = "cuFile GPUDirect libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version >= \"3.12\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and (extra == \"documents\" or extra == \"all-builtins\") and python_version >= \"3.12\""
 files = [
     {file = "nvidia_cufile_cu12-1.11.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc23469d1c7e52ce6c1d55253273d32c565dd22068647f3aa59b3c6b005bf159"},
     {file = "nvidia_cufile_cu12-1.11.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:8f57a0051dcf2543f6dc2b98a98cb2719c37d3cee1baba8965d57f3bbc90d4db"},
@@ -3960,10 +3991,10 @@ files = [
 name = "nvidia-cufile-cu12"
 version = "1.13.1.3"
 description = "cuFile GPUDirect libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
+markers = "platform_system == \"Linux\" and (extra == \"documents\" or extra == \"all-builtins\") and platform_machine == \"x86_64\" and python_version < \"3.13\""
 files = [
     {file = "nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc"},
     {file = "nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:4beb6d4cce47c1a0f1013d72e02b0994730359e17801d395bdcbf20cfb3bb00a"},
@@ -3973,10 +4004,10 @@ files = [
 name = "nvidia-curand-cu12"
 version = "10.3.7.77"
 description = "CURAND native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version >= \"3.12\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and (extra == \"documents\" or extra == \"all-builtins\") and python_version >= \"3.12\""
 files = [
     {file = "nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:6e82df077060ea28e37f48a3ec442a8f47690c7499bff392a5938614b56c98d8"},
     {file = "nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a42cd1344297f70b9e39a1e4f467a4e1c10f1da54ff7a85c12197f6c652c8bdf"},
@@ -3989,10 +4020,10 @@ files = [
 name = "nvidia-curand-cu12"
 version = "10.3.9.90"
 description = "CURAND native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
+markers = "platform_system == \"Linux\" and (extra == \"documents\" or extra == \"all-builtins\") and platform_machine == \"x86_64\" and python_version < \"3.13\""
 files = [
     {file = "nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:dfab99248034673b779bc6decafdc3404a8a6f502462201f2f31f11354204acd"},
     {file = "nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9"},
@@ -4003,10 +4034,10 @@ files = [
 name = "nvidia-cusolver-cu12"
 version = "11.7.1.2"
 description = "CUDA solver native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version >= \"3.12\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and (extra == \"documents\" or extra == \"all-builtins\") and python_version >= \"3.12\""
 files = [
     {file = "nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0ce237ef60acde1efc457335a2ddadfd7610b892d94efee7b776c64bb1cac9e0"},
     {file = "nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9e49843a7707e42022babb9bcfa33c29857a93b88020c4e4434656a655b698c"},
@@ -4024,10 +4055,10 @@ nvidia-nvjitlink-cu12 = "*"
 name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 description = "CUDA solver native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
+markers = "platform_system == \"Linux\" and (extra == \"documents\" or extra == \"all-builtins\") and platform_machine == \"x86_64\" and python_version < \"3.13\""
 files = [
     {file = "nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0"},
     {file = "nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450"},
@@ -4043,10 +4074,10 @@ nvidia-nvjitlink-cu12 = "*"
 name = "nvidia-cusparse-cu12"
 version = "12.5.4.2"
 description = "CUSPARSE native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version >= \"3.12\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and (extra == \"documents\" or extra == \"all-builtins\") and python_version >= \"3.12\""
 files = [
     {file = "nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d25b62fb18751758fe3c93a4a08eff08effedfe4edf1c6bb5afd0890fe88f887"},
     {file = "nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7aa32fa5470cf754f72d1116c7cbc300b4e638d3ae5304cfa4a638a5b87161b1"},
@@ -4062,10 +4093,10 @@ nvidia-nvjitlink-cu12 = "*"
 name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 description = "CUSPARSE native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
+markers = "platform_system == \"Linux\" and (extra == \"documents\" or extra == \"all-builtins\") and platform_machine == \"x86_64\" and python_version < \"3.13\""
 files = [
     {file = "nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc"},
     {file = "nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b"},
@@ -4079,10 +4110,10 @@ nvidia-nvjitlink-cu12 = "*"
 name = "nvidia-cusparselt-cu12"
 version = "0.6.3"
 description = "NVIDIA cuSPARSELt"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version >= \"3.12\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and (extra == \"documents\" or extra == \"all-builtins\") and python_version >= \"3.12\""
 files = [
     {file = "nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8371549623ba601a06322af2133c4a44350575f5a3108fb75f3ef20b822ad5f1"},
     {file = "nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:e5c8a26c36445dd2e6812f1177978a24e2d37cacce7e090f297a688d1ec44f46"},
@@ -4093,10 +4124,10 @@ files = [
 name = "nvidia-cusparselt-cu12"
 version = "0.7.1"
 description = "NVIDIA cuSPARSELt"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
+markers = "platform_system == \"Linux\" and (extra == \"documents\" or extra == \"all-builtins\") and platform_machine == \"x86_64\" and python_version < \"3.13\""
 files = [
     {file = "nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8878dce784d0fac90131b6817b607e803c36e629ba34dc5b433471382196b6a5"},
     {file = "nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623"},
@@ -4107,10 +4138,10 @@ files = [
 name = "nvidia-nccl-cu12"
 version = "2.26.2"
 description = "NVIDIA Collective Communication Library (NCCL) Runtime"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version >= \"3.12\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and (extra == \"documents\" or extra == \"all-builtins\") and python_version >= \"3.12\""
 files = [
     {file = "nvidia_nccl_cu12-2.26.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c196e95e832ad30fbbb50381eb3cbd1fadd5675e587a548563993609af19522"},
     {file = "nvidia_nccl_cu12-2.26.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:694cf3879a206553cc9d7dbda76b13efaf610fdb70a50cba303de1b0d1530ac6"},
@@ -4120,10 +4151,10 @@ files = [
 name = "nvidia-nccl-cu12"
 version = "2.27.5"
 description = "NVIDIA Collective Communication Library (NCCL) Runtime"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
+markers = "platform_system == \"Linux\" and (extra == \"documents\" or extra == \"all-builtins\") and platform_machine == \"x86_64\" and python_version < \"3.13\""
 files = [
     {file = "nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:31432ad4d1fb1004eb0c56203dc9bc2178a1ba69d1d9e02d64a6938ab5e40e7a"},
     {file = "nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457"},
@@ -4133,10 +4164,10 @@ files = [
 name = "nvidia-nvjitlink-cu12"
 version = "12.6.85"
 description = "Nvidia JIT LTO Library"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version >= \"3.12\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and (extra == \"documents\" or extra == \"all-builtins\") and python_version >= \"3.12\""
 files = [
     {file = "nvidia_nvjitlink_cu12-12.6.85-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:eedc36df9e88b682efe4309aa16b5b4e78c2407eac59e8c10a6a47535164369a"},
     {file = "nvidia_nvjitlink_cu12-12.6.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cf4eaa7d4b6b543ffd69d6abfb11efdeb2db48270d94dfd3a452c24150829e41"},
@@ -4147,10 +4178,10 @@ files = [
 name = "nvidia-nvjitlink-cu12"
 version = "12.8.93"
 description = "Nvidia JIT LTO Library"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
+markers = "platform_system == \"Linux\" and (extra == \"documents\" or extra == \"all-builtins\") and platform_machine == \"x86_64\" and python_version < \"3.13\""
 files = [
     {file = "nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88"},
     {file = "nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:adccd7161ace7261e01bb91e44e88da350895c270d23f744f0820c818b7229e7"},
@@ -4161,10 +4192,10 @@ files = [
 name = "nvidia-nvshmem-cu12"
 version = "3.4.5"
 description = "NVSHMEM creates a global address space that provides efficient and scalable communication for NVIDIA GPU clusters."
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
+markers = "platform_system == \"Linux\" and (extra == \"documents\" or extra == \"all-builtins\") and platform_machine == \"x86_64\" and python_version < \"3.13\""
 files = [
     {file = "nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b48363fc6964dede448029434c6abed6c5e37f823cb43c3bcde7ecfc0457e15"},
     {file = "nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd"},
@@ -4174,10 +4205,10 @@ files = [
 name = "nvidia-nvtx-cu12"
 version = "12.6.77"
 description = "NVIDIA Tools Extension"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version >= \"3.12\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and (extra == \"documents\" or extra == \"all-builtins\") and python_version >= \"3.12\""
 files = [
     {file = "nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f44f8d86bb7d5629988d61c8d3ae61dddb2015dee142740536bc7481b022fe4b"},
     {file = "nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:adcaabb9d436c9761fca2b13959a2d237c5f9fd406c8e4b723c695409ff88059"},
@@ -4190,10 +4221,10 @@ files = [
 name = "nvidia-nvtx-cu12"
 version = "12.8.90"
 description = "NVIDIA Tools Extension"
-optional = false
+optional = true
 python-versions = ">=3"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
+markers = "platform_system == \"Linux\" and (extra == \"documents\" or extra == \"all-builtins\") and platform_machine == \"x86_64\" and python_version < \"3.13\""
 files = [
     {file = "nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615"},
     {file = "nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f"},
@@ -4204,10 +4235,10 @@ files = [
 name = "ocrmac"
 version = "1.0.1"
 description = "A python wrapper to extract text from images on a mac system. Uses the vision framework from Apple."
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "sys_platform == \"darwin\""
+markers = "sys_platform == \"darwin\" and (extra == \"documents\" or extra == \"all-builtins\")"
 files = [
     {file = "ocrmac-1.0.1-py3-none-any.whl", hash = "sha256:1cef25426f7ae6bbd57fe3dc5553b25461ae8ad0d2b428a9bbadbf5907349024"},
     {file = "ocrmac-1.0.1.tar.gz", hash = "sha256:507fe5e4cbd67b2d03f6729a52bbc11f9d0b58241134eb958a5daafd4b9d93d9"},
@@ -4239,9 +4270,10 @@ pydantic = ">=2.9"
 name = "omegaconf"
 version = "2.3.0"
 description = "A flexible configuration library"
-optional = false
+optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "omegaconf-2.3.0-py3-none-any.whl", hash = "sha256:7b4df175cdb08ba400f45cae3bdcae7ba8365db4d165fc65fd04b050ab63b46b"},
     {file = "omegaconf-2.3.0.tar.gz", hash = "sha256:d5d4b6d29955cc50ad50c46dc269bcd92c6e00f5f90d23ab5fee7bfca4ba4cc7"},
@@ -4283,9 +4315,10 @@ voice-helpers = ["numpy (>=2.0.2)", "sounddevice (>=0.5.1)"]
 name = "opencv-python"
 version = "4.13.0.92"
 description = "Wrapper package for OpenCV python bindings."
-optional = false
+optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "opencv_python-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:caf60c071ec391ba51ed00a4a920f996d0b64e3e46068aac1f646b5de0326a19"},
     {file = "opencv_python-4.13.0.92-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:5868a8c028a0b37561579bfb8ac1875babdc69546d236249fff296a8c010ccf9"},
@@ -4304,9 +4337,10 @@ numpy = {version = ">=2", markers = "python_version >= \"3.9\""}
 name = "opencv-python-headless"
 version = "4.13.0.92"
 description = "Wrapper package for OpenCV python bindings."
-optional = false
+optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "opencv_python_headless-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:1a7d040ac656c11b8c38677cc8cccdc149f98535089dbe5b081e80a4e5903209"},
     {file = "opencv_python_headless-4.13.0.92-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:3e0a6f0a37994ec6ce5f59e936be21d5d6384a4556f2d2da9c2f9c5dc948394c"},
@@ -4325,9 +4359,10 @@ numpy = {version = ">=2", markers = "python_version >= \"3.9\""}
 name = "openpyxl"
 version = "3.1.5"
 description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2"},
     {file = "openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050"},
@@ -4495,9 +4530,10 @@ files = [
 name = "pandas"
 version = "2.3.3"
 description = "Powerful data structures for data analysis, time series, and statistics"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "pandas-2.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:376c6446ae31770764215a6c937f72d917f214b43560603cd60da6408f183b6c"},
     {file = "pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e19d192383eab2f4ceb30b412b22ea30690c9e618f78870357ae1d682912015a"},
@@ -4778,6 +4814,7 @@ files = [
     {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
     {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
 ]
+markers = {main = "extra == \"documents\" or extra == \"all-builtins\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
@@ -4787,9 +4824,10 @@ testing = ["coverage", "pytest", "pytest-benchmark"]
 name = "polyfactory"
 version = "3.2.0"
 description = "Mock data generation factories"
-optional = false
+optional = true
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "polyfactory-3.2.0-py3-none-any.whl", hash = "sha256:5945799cce4c56cd44ccad96fb0352996914553cc3efaa5a286930599f569571"},
     {file = "polyfactory-3.2.0.tar.gz", hash = "sha256:879242f55208f023eee1de48522de5cb1f9fd2d09b2314e999a9592829d596d1"},
@@ -4982,9 +5020,10 @@ files = [
 name = "psutil"
 version = "7.2.2"
 description = "Cross-platform lib for process and system monitoring."
-optional = false
+optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b"},
     {file = "psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea"},
@@ -5046,9 +5085,10 @@ pyasn1 = ">=0.6.1,<0.7.0"
 name = "pyclipper"
 version = "1.4.0"
 description = "Cython wrapper for the C++ translation of the Angus Johnson's Clipper library (ver. 6.4.2)"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "pyclipper-1.4.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bafad70d2679c187120e8c44e1f9a8b06150bad8c0aecf612ad7dfbfa9510f73"},
     {file = "pyclipper-1.4.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0b74a9dd44b22a7fd35d65fb1ceeba57f3817f34a97a28c3255556362e491447"},
@@ -5261,9 +5301,10 @@ typing-extensions = ">=4.14.1"
 name = "pydantic-settings"
 version = "2.12.0"
 description = "Settings management using Pydantic"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\" or extra == \"web\" or extra == \"mcp\""
 files = [
     {file = "pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809"},
     {file = "pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0"},
@@ -5310,6 +5351,7 @@ files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
 ]
+markers = {main = "extra == \"documents\" or extra == \"all-builtins\""}
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
@@ -5337,9 +5379,10 @@ crypto = ["cryptography (>=3.4.0)"]
 name = "pylatexenc"
 version = "2.10"
 description = "Simple LaTeX parser providing latex-to-unicode and unicode-to-latex conversion"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "pylatexenc-2.10.tar.gz", hash = "sha256:3dd8fd84eb46dc30bee1e23eaab8d8fb5a7f507347b23e5f38ad9675c84f40d3"},
 ]
@@ -5367,10 +5410,10 @@ extra = ["pygments (>=2.19.1)"]
 name = "pyobjc-core"
 version = "12.1"
 description = "Python<->ObjC Interoperability Module"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "sys_platform == \"darwin\""
+markers = "sys_platform == \"darwin\" and (extra == \"documents\" or extra == \"all-builtins\")"
 files = [
     {file = "pyobjc_core-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:93418e79c1655f66b4352168f8c85c942707cb1d3ea13a1da3e6f6a143bacda7"},
     {file = "pyobjc_core-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c918ebca280925e7fcb14c5c43ce12dcb9574a33cccb889be7c8c17f3bcce8b6"},
@@ -5386,10 +5429,10 @@ files = [
 name = "pyobjc-framework-cocoa"
 version = "12.1"
 description = "Wrappers for the Cocoa frameworks on macOS"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "sys_platform == \"darwin\""
+markers = "sys_platform == \"darwin\" and (extra == \"documents\" or extra == \"all-builtins\")"
 files = [
     {file = "pyobjc_framework_cocoa-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9b880d3bdcd102809d704b6d8e14e31611443aa892d9f60e8491e457182fdd48"},
     {file = "pyobjc_framework_cocoa-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f52228bcf38da64b77328787967d464e28b981492b33a7675585141e1b0a01e6"},
@@ -5408,10 +5451,10 @@ pyobjc-core = ">=12.1"
 name = "pyobjc-framework-coreml"
 version = "12.1"
 description = "Wrappers for the framework CoreML on macOS"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "sys_platform == \"darwin\""
+markers = "sys_platform == \"darwin\" and (extra == \"documents\" or extra == \"all-builtins\")"
 files = [
     {file = "pyobjc_framework_coreml-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:df4e9b4f97063148cc481f72e2fbe3cc53b9464d722752aa658d7c0aec9f02fd"},
     {file = "pyobjc_framework_coreml-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:16dafcfb123f022e62f47a590a7eccf7d0cb5957a77fd5f062b5ee751cb5a423"},
@@ -5431,10 +5474,10 @@ pyobjc-framework-Cocoa = ">=12.1"
 name = "pyobjc-framework-quartz"
 version = "12.1"
 description = "Wrappers for the Quartz frameworks on macOS"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "sys_platform == \"darwin\""
+markers = "sys_platform == \"darwin\" and (extra == \"documents\" or extra == \"all-builtins\")"
 files = [
     {file = "pyobjc_framework_quartz-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c6f312ae79ef8b3019dcf4b3374c52035c7c7bc4a09a1748b61b041bb685a0ed"},
     {file = "pyobjc_framework_quartz-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:19f99ac49a0b15dd892e155644fe80242d741411a9ed9c119b18b7466048625a"},
@@ -5454,10 +5497,10 @@ pyobjc-framework-Cocoa = ">=12.1"
 name = "pyobjc-framework-vision"
 version = "12.1"
 description = "Wrappers for the framework Vision on macOS"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "sys_platform == \"darwin\""
+markers = "sys_platform == \"darwin\" and (extra == \"documents\" or extra == \"all-builtins\")"
 files = [
     {file = "pyobjc_framework_vision-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a30c3fff926348baecc3ce1f6da8ed327d0cbd55ca1c376d018e31023b79c0ab"},
     {file = "pyobjc_framework_vision-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1edbf2fc18ce3b31108f845901a88f2236783ae6bf0bc68438d7ece572dc2a29"},
@@ -5495,9 +5538,10 @@ diagrams = ["jinja2", "railroad-diagrams"]
 name = "pypdfium2"
 version = "5.3.0"
 description = "Python bindings to PDFium"
-optional = false
+optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "pypdfium2-5.3.0-py3-none-android_23_arm64_v8a.whl", hash = "sha256:885df6c78d41600cb086dc0c76b912d165b5bd6931ca08138329ea5a991b3540"},
     {file = "pypdfium2-5.3.0-py3-none-android_23_armeabi_v7a.whl", hash = "sha256:6e53dee6b333ee77582499eff800300fb5aa0c7eb8f52f95ccb5ca35ebc86d48"},
@@ -5569,9 +5613,10 @@ testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 name = "python-bidi"
 version = "0.6.7"
 description = "Python Bidi layout wrapping the Rust crate unicode-bidi"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "python_bidi-0.6.7-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:94dbfd6a6ec0ae64b5262290bf014d6063f9ac8688bda9ec668dc175378d2c80"},
     {file = "python_bidi-0.6.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d8274ff02d447cca026ba00f56070ba15f95e184b2d028ee0e4b6c9813d2aaf9"},
@@ -5702,9 +5747,10 @@ six = ">=1.5"
 name = "python-docx"
 version = "1.2.0"
 description = "Create, read, and update Microsoft Word .docx files."
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "python_docx-1.2.0-py3-none-any.whl", hash = "sha256:3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7"},
     {file = "python_docx-1.2.0.tar.gz", hash = "sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce"},
@@ -5746,9 +5792,10 @@ files = [
 name = "python-pptx"
 version = "1.0.2"
 description = "Create, read, and update PowerPoint 2007+ (.pptx) files."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba"},
     {file = "python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095"},
@@ -5847,9 +5894,10 @@ dev = ["black", "build", "mypy", "pytest", "pytest-cov", "setuptools", "tox", "t
 name = "pytz"
 version = "2025.2"
 description = "World timezone definitions, modern and historical"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
     {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
@@ -5859,10 +5907,10 @@ files = [
 name = "pywin32"
 version = "311"
 description = "Python for Window Extensions"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
+markers = "sys_platform == \"win32\" and (extra == \"documents\" or extra == \"all-builtins\" or extra == \"mcp\") or (extra == \"documents\" or extra == \"all-builtins\") and platform_system == \"Windows\""
 files = [
     {file = "pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3"},
     {file = "pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b"},
@@ -5973,9 +6021,10 @@ files = [
 name = "rapidocr"
 version = "3.6.0"
 description = "Awesome OCR Library"
-optional = false
+optional = true
 python-versions = "<4,>=3.6"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "rapidocr-3.6.0-py3-none-any.whl", hash = "sha256:d16b43872fc4dfa1e60996334dcd0dc3e3f1f64161e2332bc1873b9f65754e6b"},
 ]
@@ -5997,9 +6046,10 @@ tqdm = "*"
 name = "referencing"
 version = "0.37.0"
 description = "JSON Referencing + Python"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\" or extra == \"mcp\""
 files = [
     {file = "referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231"},
     {file = "referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8"},
@@ -6192,9 +6242,10 @@ requests = ">=2.0.1,<3.0.0"
 name = "rich"
 version = "14.3.2"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
-optional = false
+optional = true
 python-versions = ">=3.8.0"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "rich-14.3.2-py3-none-any.whl", hash = "sha256:08e67c3e90884651da3239ea668222d19bea7b589149d8014a21c633420dbb69"},
     {file = "rich-14.3.2.tar.gz", hash = "sha256:e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8"},
@@ -6211,9 +6262,10 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 name = "rpds-py"
 version = "0.30.0"
 description = "Python bindings to Rust's persistent data structures (rpds)"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\" or extra == \"mcp\""
 files = [
     {file = "rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288"},
     {file = "rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00"},
@@ -6336,9 +6388,10 @@ files = [
 name = "rtree"
 version = "1.4.1"
 description = "R-Tree spatial index for Python GIS"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "rtree-1.4.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:d672184298527522d4914d8ae53bf76982b86ca420b0acde9298a7a87d81d4a4"},
     {file = "rtree-1.4.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a7e48d805e12011c2cf739a29d6a60ae852fb1de9fc84220bbcef67e6e595d7d"},
@@ -6401,9 +6454,10 @@ crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
 name = "safetensors"
 version = "0.7.0"
 description = ""
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517"},
     {file = "safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57"},
@@ -6453,9 +6507,10 @@ torch = ["packaging", "safetensors[numpy]", "torch (>=1.10)"]
 name = "scikit-image"
 version = "0.26.0"
 description = "Image processing in Python"
-optional = false
+optional = true
 python-versions = ">=3.11"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "scikit_image-0.26.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b1ede33a0fb3731457eaf53af6361e73dd510f449dac437ab54573b26788baf0"},
     {file = "scikit_image-0.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7af7aa331c6846bd03fa28b164c18d0c3fd419dbb888fb05e958ac4257a78fdd"},
@@ -6532,9 +6587,10 @@ test = ["numpydoc (>=1.7)", "pooch (>=1.6.0) ; sys_platform != \"emscripten\"", 
 name = "scipy"
 version = "1.17.0"
 description = "Fundamental algorithms for scientific computing in Python"
-optional = false
+optional = true
 python-versions = ">=3.11"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "scipy-1.17.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:2abd71643797bd8a106dff97894ff7869eeeb0af0f7a5ce02e4227c6a2e9d6fd"},
     {file = "scipy-1.17.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:ef28d815f4d2686503e5f4f00edc387ae58dfd7a2f42e348bb53359538f01558"},
@@ -6611,9 +6667,10 @@ test = ["Cython", "array-api-strict (>=2.3.1)", "asv", "gmpy2", "hypothesis (>=6
 name = "semchunk"
 version = "2.2.2"
 description = "A fast and lightweight Python library for splitting text into semantically meaningful chunks."
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "semchunk-2.2.2-py3-none-any.whl", hash = "sha256:94ca19020c013c073abdfd06d79a7c13637b91738335f3b8cdb5655ee7cc94d2"},
     {file = "semchunk-2.2.2.tar.gz", hash = "sha256:940e89896e64eeb01de97ba60f51c8c7b96c6a3951dfcf574f25ce2146752f52"},
@@ -6627,10 +6684,10 @@ tqdm = "*"
 name = "setuptools"
 version = "81.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version >= \"3.12\""
+markers = "(extra == \"documents\" or extra == \"all-builtins\") and python_version >= \"3.12\""
 files = [
     {file = "setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6"},
     {file = "setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a"},
@@ -6649,9 +6706,10 @@ type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.deve
 name = "shapely"
 version = "2.1.2"
 description = "Manipulation and analysis of geometric objects"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "shapely-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7ae48c236c0324b4e139bea88a306a04ca630f49be66741b340729d380d8f52f"},
     {file = "shapely-2.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:eba6710407f1daa8e7602c347dfc94adc02205ec27ed956346190d66579eb9ea"},
@@ -6723,9 +6781,10 @@ test = ["pytest", "pytest-cov", "scipy-doctest"]
 name = "shellingham"
 version = "1.5.4"
 description = "Tool to Detect Surrounding Shell"
-optional = false
+optional = true
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
     {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
@@ -6759,9 +6818,10 @@ files = [
 name = "soupsieve"
 version = "2.8.3"
 description = "A modern CSS selector implementation for Beautiful Soup."
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95"},
     {file = "soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349"},
@@ -6929,9 +6989,10 @@ full = ["httpx (>=0.27.0,<0.29.0)", "httpx2 (>=2.0.0)", "itsdangerous", "jinja2"
 name = "sympy"
 version = "1.14.0"
 description = "Computer algebra system (CAS) in Python"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5"},
     {file = "sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517"},
@@ -6947,9 +7008,10 @@ dev = ["hypothesis (>=6.70.0)", "pytest (>=7.1.0)"]
 name = "tabulate"
 version = "0.9.0"
 description = "Pretty-print tabular data"
-optional = false
+optional = true
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f"},
     {file = "tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c"},
@@ -6978,9 +7040,10 @@ test = ["pytest", "tornado (>=4.5)", "typeguard"]
 name = "tifffile"
 version = "2026.2.20"
 description = "Read and write TIFF files"
-optional = false
+optional = true
 python-versions = ">=3.11"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "tifffile-2026.2.20-py3-none-any.whl", hash = "sha256:a83e0e991647e39d5912369998ef02d858f89effe30064403a1a123b5daef8fb"},
     {file = "tifffile-2026.2.20.tar.gz", hash = "sha256:b98a7fc6ea4fa0e9919734857eebc6e2cb2c3a95468a930d4a948a9a49646ab7"},
@@ -7075,9 +7138,10 @@ blobfile = ["blobfile (>=2)"]
 name = "tokenizers"
 version = "0.22.2"
 description = ""
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c"},
     {file = "tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001"},
@@ -7117,10 +7181,10 @@ testing = ["datasets", "numpy", "pytest", "pytest-asyncio", "requests", "ruff", 
 name = "torch"
 version = "2.7.1"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
-optional = false
+optional = true
 python-versions = ">=3.9.0"
 groups = ["main"]
-markers = "python_version >= \"3.12\""
+markers = "python_version >= \"3.12\" and (extra == \"documents\" or extra == \"all-builtins\")"
 files = [
     {file = "torch-2.7.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:a103b5d782af5bd119b81dbcc7ffc6fa09904c423ff8db397a1e6ea8fd71508f"},
     {file = "torch-2.7.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:fe955951bdf32d182ee8ead6c3186ad54781492bf03d547d31771a01b3d6fb7d"},
@@ -7180,10 +7244,10 @@ optree = ["optree (>=0.13.0)"]
 name = "torch"
 version = "2.10.0"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version < \"3.13\""
+markers = "(extra == \"documents\" or extra == \"all-builtins\") and python_version < \"3.13\""
 files = [
     {file = "torch-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5276fa790a666ee8becaffff8acb711922252521b28fbce5db7db5cf9cb2026d"},
     {file = "torch-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:aaf663927bcd490ae971469a624c322202a2a1e68936eb952535ca4cd3b90444"},
@@ -7250,10 +7314,10 @@ pyyaml = ["pyyaml"]
 name = "torchvision"
 version = "0.22.1"
 description = "image and video datasets and models for torch deep learning"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version >= \"3.12\""
+markers = "python_version >= \"3.12\" and (extra == \"documents\" or extra == \"all-builtins\")"
 files = [
     {file = "torchvision-0.22.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3b47d8369ee568c067795c0da0b4078f39a9dfea6f3bc1f3ac87530dfda1dd56"},
     {file = "torchvision-0.22.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:990de4d657a41ed71680cd8be2e98ebcab55371f30993dc9bd2e676441f7180e"},
@@ -7294,10 +7358,10 @@ scipy = ["scipy"]
 name = "torchvision"
 version = "0.25.0"
 description = "image and video datasets and models for torch deep learning"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "python_version < \"3.13\""
+markers = "(extra == \"documents\" or extra == \"all-builtins\") and python_version < \"3.13\""
 files = [
     {file = "torchvision-0.25.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a95c47abb817d4e90ea1a8e57bd0d728e3e6b533b3495ae77d84d883c4d11f56"},
     {file = "torchvision-0.25.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:acc339aba4a858192998c2b91f635827e40d9c469d9cf1455bafdda6e4c28ea4"},
@@ -7364,9 +7428,10 @@ telegram = ["requests"]
 name = "transformers"
 version = "4.57.6"
 description = "State-of-the-art Machine Learning for JAX, PyTorch and TensorFlow"
-optional = false
+optional = true
 python-versions = ">=3.9.0"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550"},
     {file = "transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3"},
@@ -7439,9 +7504,10 @@ vision = ["Pillow (>=10.0.1,<=15.0)"]
 name = "tree-sitter"
 version = "0.25.2"
 description = "Python bindings to the Tree-sitter parsing library"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "tree-sitter-0.25.2.tar.gz", hash = "sha256:fe43c158555da46723b28b52e058ad444195afd1db3ca7720c59a254544e9c20"},
     {file = "tree_sitter-0.25.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72a510931c3c25f134aac2daf4eb4feca99ffe37a35896d7150e50ac3eee06c7"},
@@ -7489,9 +7555,10 @@ tests = ["tree-sitter-html (>=0.23.2)", "tree-sitter-javascript (>=0.23.1)", "tr
 name = "tree-sitter-c"
 version = "0.24.1"
 description = "C grammar for tree-sitter"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "tree_sitter_c-0.24.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9c06ac26a1efdcc8b26a8a6970fbc6997c4071857359e5837d4c42892d45fe1e"},
     {file = "tree_sitter_c-0.24.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:942bcd7cbecd810dcf7ca6f8f834391ebf0771a89479646d891ba4ca2fdfdc88"},
@@ -7510,9 +7577,10 @@ core = ["tree-sitter (>=0.24,<1.0)"]
 name = "tree-sitter-javascript"
 version = "0.25.0"
 description = "JavaScript grammar for tree-sitter"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "tree_sitter_javascript-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b70f887fb269d6e58c349d683f59fa647140c410cfe2bee44a883b20ec92e3dc"},
     {file = "tree_sitter_javascript-0.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8264a996b8845cfce06965152a013b5d9cbb7d199bc3503e12b5682e62bb1de1"},
@@ -7532,9 +7600,10 @@ core = ["tree-sitter (>=0.24,<1.0)"]
 name = "tree-sitter-python"
 version = "0.25.0"
 description = "Python grammar for tree-sitter"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "tree_sitter_python-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:14a79a47ddef72f987d5a2c122d148a812169d7484ff5c75a3db9609d419f361"},
     {file = "tree_sitter_python-0.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:480c21dbd995b7fe44813e741d71fed10ba695e7caab627fb034e3828469d762"},
@@ -7554,9 +7623,10 @@ core = ["tree-sitter (>=0.24,<1.0)"]
 name = "tree-sitter-typescript"
 version = "0.23.2"
 description = "TypeScript and TSX grammars for tree-sitter"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "tree_sitter_typescript-0.23.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3cd752d70d8e5371fdac6a9a4df9d8924b63b6998d268586f7d374c9fba2a478"},
     {file = "tree_sitter_typescript-0.23.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c7cc1b0ff5d91bac863b0e38b1578d5505e718156c9db577c8baea2557f66de8"},
@@ -7575,10 +7645,10 @@ core = ["tree-sitter (>=0.23,<1.0)"]
 name = "triton"
 version = "3.3.1"
 description = "A language and compiler for custom Deep Learning operations"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version >= \"3.12\""
+markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and (extra == \"documents\" or extra == \"all-builtins\") and python_version >= \"3.12\""
 files = [
     {file = "triton-3.3.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b74db445b1c562844d3cfad6e9679c72e93fdfb1a90a24052b03bb5c49d1242e"},
     {file = "triton-3.3.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b31e3aa26f8cb3cc5bf4e187bf737cbacf17311e1112b781d4a059353dfd731b"},
@@ -7600,10 +7670,10 @@ tutorials = ["matplotlib", "pandas", "tabulate"]
 name = "triton"
 version = "3.6.0"
 description = "A language and compiler for custom Deep Learning operations"
-optional = false
+optional = true
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\" and python_version < \"3.13\""
+markers = "platform_system == \"Linux\" and (extra == \"documents\" or extra == \"all-builtins\") and platform_machine == \"x86_64\" and python_version < \"3.13\""
 files = [
     {file = "triton-3.6.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c723cfb12f6842a0ae94ac307dba7e7a44741d720a40cf0e270ed4a4e3be781"},
     {file = "triton-3.6.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6550fae429e0667e397e5de64b332d1e5695b73650ee75a6146e2e902770bea"},
@@ -7630,9 +7700,10 @@ tutorials = ["matplotlib", "pandas", "tabulate"]
 name = "typer"
 version = "0.21.1"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "typer-0.21.1-py3-none-any.whl", hash = "sha256:7985e89081c636b88d172c2ee0cfe33c253160994d47bdfdc302defd7d1f1d01"},
     {file = "typer-0.21.1.tar.gz", hash = "sha256:ea835607cd752343b6b2b7ce676893e5a0324082268b48f27aa058bdb7d2145d"},
@@ -7707,6 +7778,7 @@ description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 groups = ["main"]
+markers = "platform_system == \"Windows\" or extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1"},
     {file = "tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7"},
@@ -7800,7 +7872,7 @@ description = "The lightning-fast ASGI server."
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "sys_platform != \"emscripten\" and (extra == \"mcp\" or extra == \"all-builtins\")"
+markers = "(extra == \"mcp\" or extra == \"all-builtins\") and sys_platform != \"emscripten\""
 files = [
     {file = "uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f"},
     {file = "uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3"},
@@ -7912,9 +7984,10 @@ h11 = ">=0.16.0,<1"
 name = "xlsxwriter"
 version = "3.2.9"
 description = "A Python module for creating Excel XLSX files."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"documents\" or extra == \"all-builtins\""
 files = [
     {file = "xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3"},
     {file = "xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c"},
@@ -8359,7 +8432,8 @@ files = [
 cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and python_version < \"3.14\"", "cffi (>=2.0.0b) ; platform_python_implementation != \"PyPy\" and python_version >= \"3.14\""]
 
 [extras]
-all-builtins = ["elevenlabs", "google-api-python-client", "google-auth", "google-auth-httplib2", "httpx", "langchain-community", "langchain-mcp-adapters", "langchain-moonshot", "langchain-ollama", "openai", "sqlite-vec", "websockets"]
+all-builtins = ["docling", "easyocr", "elevenlabs", "google-api-python-client", "google-auth", "google-auth-httplib2", "httpx", "langchain-community", "langchain-mcp-adapters", "langchain-moonshot", "langchain-ollama", "openai", "opencv-python-headless", "sqlite-vec", "websockets"]
+documents = ["docling", "easyocr", "opencv-python-headless"]
 email = ["google-api-python-client", "google-auth", "google-auth-httplib2"]
 mcp = ["langchain-mcp-adapters"]
 memory = ["sqlite-vec"]
@@ -8372,4 +8446,4 @@ web = ["langchain-community"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "f6ed1e3c1e3555cba89940fabbbced658e74563a1887d5980b713d0b3da13c20"
+content-hash = "16e3a44c16a38a78eb2a15c2c1a5dceeff47bdf45c886a5bb1a4ab2d1d7cb49e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,11 @@ dependencies = [
     "pyyaml (>=6.0.3,<7.0.0)",
     "apscheduler (>=3.10.0,<4.0.0)",
     "python-dotenv (>=1.2.1,<2.0.0)",
-    # Document processing and browser automation
-    "docling (>=2.72.0,<3.0.0)",
-    "easyocr (>=1.7.2,<2.0.0)",
-    "opencv-python-headless (>=4.13.0.92,<5.0.0.0)",
+    # Browser automation
     "playwright (>=1.58.0,<2.0.0)",
+    # NOTE: The OCR/CV document stack (docling, easyocr, opencv) lives behind the
+    # optional [documents] extra — it pulls torch and hundreds of MB, which a
+    # bare install should not incur (issue #174).
 ]
 
 [project.urls]
@@ -65,6 +65,11 @@ Changelog = "https://github.com/johnsosoka/OpenPaw/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 # Optional builtins — install extras for specific capabilities
+documents = [
+    "docling (>=2.72.0,<3.0.0)",              # PDF/DOCX/PPTX → markdown conversion
+    "easyocr (>=1.7.2,<2.0.0)",               # OCR for scanned/image PDFs (Linux)
+    "opencv-python-headless (>=4.13.0.92,<5.0.0.0)",  # image preprocessing for OCR
+]
 voice = [
     "openai (>=1.0.0)",      # Whisper transcription
     "elevenlabs (>=1.0.0)",  # Text-to-speech
@@ -94,6 +99,9 @@ mcp = [
     "langchain-mcp-adapters (>=0.3.0,<1.0.0)",  # MCP server adapter for LangChain tools
 ]
 all-builtins = [
+    "docling (>=2.72.0,<3.0.0)",
+    "easyocr (>=1.7.2,<2.0.0)",
+    "opencv-python-headless (>=4.13.0.92,<5.0.0.0)",
     "openai (>=1.0.0)",
     "elevenlabs (>=1.0.0)",
     "langchain-community (>=0.4.0)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openpaw-ai"
-version = "0.4.3"
+version = "0.4.4"
 description = "OpenPaw - Multi-Channel AI Agent Framework with LangGraph"
 authors = [
     {name = "John Sosoka"}
@@ -151,7 +151,7 @@ warn_unused_ignores = false
 
 [tool.poetry]
 name = "openpaw-ai"
-version = "0.4.3"
+version = "0.4.4"
 description = "OpenPaw - Multi-Channel AI Agent Framework with LangGraph"
 authors = ["John Sosoka"]
 packages = [{include = "openpaw"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ dependencies = [
     # blocks that Fireworks' API rejects). <1.4.0 keeps us on the stable fireworks-ai
     # 0.x SDK; 1.4.x requires an alpha SDK that relocates fireworks.client.error.
     "langchain-fireworks (>=1.3.1,<1.4.0)",
+    # Pin the Fireworks SDK to the tested line. langchain-fireworks allows a wide
+    # range, so a bare `pip install` drifts to fireworks-ai 0.19.x, which leaks
+    # aiohttp client sessions ("Unclosed client session" ERRORs) during model
+    # init. 0.16.x matches poetry.lock and does not leak (issue #180).
+    "fireworks-ai (>=0.16.4,<0.17.0)",
     # Channel adapters
     "python-telegram-bot[job-queue] (>=22.6,<23.0)",
     "discord.py (>=2.6.0,<3.0.0)",

--- a/tests/channels/test_helpers.py
+++ b/tests/channels/test_helpers.py
@@ -162,6 +162,11 @@ class TestFormatUnauthorizedResponse:
         result = format_unauthorized_response(12345, "test_ws")
         assert "⛔" in result
 
+    def test_config_path_includes_config_segment(self) -> None:
+        # The allowlist lives at config/agent.yaml, not agent.yaml (issue #175).
+        result = format_unauthorized_response(12345, "test_ws")
+        assert "agent_workspaces/test_ws/config/agent.yaml" in result
+
 
 # ---------------------------------------------------------------------------
 # map_mime_type_to_attachment_type

--- a/tests/cli_init/test_commands.py
+++ b/tests/cli_init/test_commands.py
@@ -54,6 +54,23 @@ class TestHandleInit:
         assert "Next steps:" in captured.out
         assert "openpaw -c config.yaml -w my_agent" in captured.out
 
+    def test_scaffolds_root_config_yaml(self, tmp_path: Path) -> None:
+        # init must leave a runnable config.yaml so `run` works immediately (#171).
+        ws_root = tmp_path / "agent_workspaces"
+        _handle_init(["my_agent", "--path", str(ws_root)])
+        config_path = tmp_path / "config.yaml"
+        assert config_path.exists()
+        data = yaml.safe_load(config_path.read_text())
+        assert data["workspaces_path"] == "agent_workspaces"
+        assert data["agent"]["model"]
+
+    def test_does_not_clobber_existing_config(self, tmp_path: Path) -> None:
+        ws_root = tmp_path / "agent_workspaces"
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("workspaces_path: custom\n", encoding="utf-8")
+        _handle_init(["my_agent", "--path", str(ws_root)])
+        assert config_path.read_text() == "workspaces_path: custom\n"
+
     def test_model_flag_passed_through(self, tmp_path: Path) -> None:
         _handle_init(["agent_x", "--path", str(tmp_path), "--model", "anthropic:claude-sonnet-4-20250514"])
         data = yaml.safe_load((tmp_path / "agent_x" / "config" / "agent.yaml").read_text())


### PR DESCRIPTION
Tiny **0.4.4** onboarding-polish release. Resolves the 13 `[Onboarding 0.4.4]` issues found during a first-run install-and-run evaluation of 0.4.3 (across both `poetry` and `pip`). One commit per issue.

## Fixes (critical → low)
- **#171 (critical)** — `openpaw init` now scaffolds a runnable top-level `config.yaml`; pip users are no longer hard-blocked at first run. Config-not-found error is now actionable.
- **#175** — access-denied reply points to the correct `config/agent.yaml` path.
- **#176** — `init` "Next steps" show the correct invocation for poetry vs pip.
- **#181** — suppressed the noisy `langgraph` `allowed_objects` deprecation warning on every CLI run.
- **#180** — pinned `fireworks-ai` to the tested line to stop `Unclosed client session` ERRORs on pip.

## Enhancements
- **#174** — moved the OCR/CV stack (`docling`/`easyocr`/`opencv`, which pull `torch`) behind a `[documents]` extra; bare install is now lean.
- **#177** — top-level `--help` now lists the `init`/`list` subcommands.

## Docs
- **#170** logo absolute URL (renders on PyPI) · **#172** Install-from-PyPI quickstart · **#173** current Fireworks example model · **#178** stdio onramp promoted · **#179** corrected Telegram access-denied docs · **#182** Getting Started polish (model precedence, config-copy ordering, playwright note).

## Verification
- 3161 tests pass; `ruff` and `mypy` clean.
- pip flow verified end-to-end: `init` → `config.yaml` scaffolded → `load_config` succeeds.
- Passed a code-reviewer pass (config-scaffolder hardening applied: OSError guard + `--path .` edge).

Closes #170, #171, #172, #173, #174, #175, #176, #177, #178, #179, #180, #181, #182