### PR TITLE
Silence langgraph allowed_objects warning under pytest (#181 QA follow-up)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,3 +163,9 @@ testpaths = ["tests"]
 markers = [
     "integration: marks tests as integration tests (run against real subprocesses/servers)",
 ]
+filterwarnings = [
+    # langgraph's checkpoint serde emits an upstream deprecation about the default
+    # `allowed_objects` value. The CLI filters it in openpaw/__init__.py, but the
+    # test harness imports langgraph directly, so silence it here too (issue #181).
+    "ignore:The default value of `allowed_objects` will change:",
+]


### PR DESCRIPTION
QA follow-up on #181. The CLI-level filter in `openpaw/__init__.py` cleared the warning from `openpaw --help` (verified), but the test harness imports `langgraph` directly and bypasses the package filter, so the deprecation still printed once under `pytest`.

Adds a targeted `filterwarnings` entry to `[tool.pytest.ini_options]`. Only that specific message is suppressed — the other 5 pre-existing warnings still surface. 3161 tests pass.

Refs #181.