### PR TITLE
docs: de-emphasize stdio channel as a WIP testing tool

### DIFF
--- a/docs/channels.md
+++ b/docs/channels.md
@@ -359,6 +359,8 @@ Discord free-tier bots have a 25 MB file size limit. Files exceeding this limit 
 
 ## Stdio Channel
 
+> **Work in progress.** The stdio channel is handy for quick local testing, but it is **not** recommended for actually operating your bots — log output interleaves with the agent's input and output in the same terminal. Use Telegram or Discord for real use.
+
 The `stdio` channel is a zero-config local interface for testing and development. It reads from stdin and prints agent responses to stdout — no bot tokens, API keys, or external platform setup required.
 
 ### Setup
@@ -377,7 +379,7 @@ Or run with the default when no channel is configured. The `stdio` channel is th
 Start the workspace and type messages directly in your terminal:
 
 ```bash
-poetry run openpaw -c config.yaml -w my-agent
+poetry run openpaw -c config.yaml -w my_agent
 ```
 
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@ This guide walks through installing OpenPaw, creating your first agent workspace
 - **Python 3.11+**
 - **Poetry 2.0+** for dependency management ([installation guide](https://python-poetry.org/docs/#installation))
 - **A channel (choose one):**
-  - **Stdio** — Zero-config terminal channel, no *channel* token needed — you still need an LLM provider key (great for testing)
+  - **Stdio** *(work in progress)* — Zero-config terminal channel for quick local testing; not recommended for actually operating a bot (log output interleaves with the chat)
   - **Telegram** — Bot token from [@BotFather](https://core.telegram.org/bots#botfather)
   - **Discord** — Bot token from [Developer Portal](https://discord.com/developers/applications)
 - **At least one model provider credential:**
@@ -278,33 +278,19 @@ See [scheduling.md](scheduling.md) for detailed configuration.
 
 ## Running Your Agent
 
-### 1. Quick Start with Stdio (No Channel Token Required)
-
-The fastest way to test OpenPaw without setting up Telegram or Discord. No *channel* token is required — you still need one LLM provider key (e.g. `ANTHROPIC_API_KEY`) for the agent to respond:
+### 1. Single Workspace (Telegram / Discord)
 
 ```bash
-# Scaffold a workspace with stdio channel
-poetry run openpaw init my_agent --model anthropic:claude-sonnet-4-20250514 --channel stdio
-
-# Run it
 poetry run openpaw -c config.yaml -w my_agent
 ```
 
-Type messages directly in your terminal. The agent responds to stdout. Press `Ctrl+D` or send an empty line to stop.
-
-### 2. Single Workspace (Telegram / Discord)
-
-```bash
-poetry run openpaw -c config.yaml -w my-agent
-```
-
-### 3. Multiple Workspaces
+### 2. Multiple Workspaces
 
 ```bash
 poetry run openpaw -c config.yaml -w agent1,agent2
 ```
 
-### 4. All Workspaces
+### 3. All Workspaces
 
 ```bash
 # Either syntax works
@@ -312,11 +298,22 @@ poetry run openpaw -c config.yaml --all
 poetry run openpaw -c config.yaml -w "*"
 ```
 
-### 5. Verbose Logging
+### 4. Verbose Logging
 
 ```bash
-poetry run openpaw -c config.yaml -w my-agent -v
+poetry run openpaw -c config.yaml -w my_agent -v
 ```
+
+### Local Testing with Stdio
+
+> **Work in progress.** The `stdio` channel lets you chat from the terminal without a bot token (`--channel stdio`), which is convenient for a quick smoke test. It is **not** recommended for actually operating a bot — log output interleaves with the chat. Use Telegram or Discord for real use.
+
+```bash
+poetry run openpaw init test_agent --model anthropic:claude-sonnet-4-20250514 --channel stdio
+poetry run openpaw -c config.yaml -w test_agent
+```
+
+Type messages directly in your terminal; the agent responds to stdout. Press `Ctrl+D` or send an empty line to stop.
 
 ## Testing Your Agent
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,9 +36,9 @@ Four queue modes handle the reality that users send follow-up messages while age
 
 Agents ship with web search (Brave), browser automation (Playwright), sandboxed file operations, sub-agent spawning, task tracking, self-scheduling, and PDF generation from markdown. Incoming messages are automatically processed — files are saved, voice messages transcribed, and documents converted to markdown.
 
-### Stdio Channel
+### Stdio Channel (testing only)
 
-Test and develop agents locally without any bot tokens or platform setup. The `stdio` channel reads from stdin and prints responses to stdout, with full support for file attachments, approval gates, and message splitting.
+A zero-config local channel for quickly smoke-testing agents from the terminal — no bot tokens or platform setup. It's a **work in progress**: log output interleaves with the chat, so it's fine for a quick check but not for actually operating a bot. Use Telegram or Discord for real use.
 
 ### Scheduling & Heartbeats
 


### PR DESCRIPTION
Follow-up to the README polish (feedback from John): de-emphasize the stdio **channel** throughout the docs and label it a work in progress — fair for quick local testing, but not for actually operating a bot (log output interleaves with the chat).

- `docs/index.md` — highlight retitled "Stdio Channel (testing only)" + WIP note.
- `docs/channels.md` — WIP callout at the top of the Stdio section.
- `docs/getting-started.md` — prereq bullet marked WIP; "Running Your Agent" reordered so Telegram/Discord is the primary path, with stdio demoted to a small "Local Testing with Stdio" note. Fixed stale `my-agent` → `my_agent` in edited blocks.

MCP-transport `stdio` references (unrelated to the channel) are left untouched. Docs-only.