### PR TITLE
fix: Fireworks thinking validation error + harden thinking leak across providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fireworks reasoning models no longer fail with a `thinking` validation error.** The top-level `thinking: bool` config field was forwarded to the Fireworks API as a raw boolean, which the API rejects (`InvalidRequestError` on `thinking.ThinkingConfigEnabled/Disabled/Adaptive`). It is now coerced into the object form Fireworks expects — `{"type": "enabled", "budget_tokens": ...}` or `{"type": "disabled"}` — with the reasoning budget capped below `max_output_tokens`.
+
+### Changed
+
+- **`thinking` is now consumed or explicitly ignored by every provider.** Previously it was only handled for `moonshot` and `fireworks`; on other providers it silently leaked into the request body as a raw boolean (the same failure class as the Fireworks bug above). It is now popped centrally and, on providers that don't support it, ignored with a warning.
+
 ## [0.4.4] - 2026-07-01
 
 A first-run onboarding polish release. Found during an install-and-run evaluation of 0.4.3 across both `poetry` and `pip`, these fixes unblock pip users, trim the default install, and correct docs and CLI output.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -802,6 +802,13 @@ value or remove the override.
 will refuse to load that shape at workspace-load time and point you at this
 native configuration.
 
+**`thinking` on other providers:** the top-level `thinking` toggle is also
+honored for `fireworks` (it becomes the API's `thinking` object —
+`{ type: enabled, budget_tokens: ... }` or `{ type: disabled }`). On providers
+that don't support it, `thinking` is ignored and a warning is logged, so it can
+never leak into the request as a raw boolean. Anthropic's extended-thinking
+budgets use `extra_body.thinking` natively and are unaffected.
+
 ---
 
 ### Ollama (local models)

--- a/openpaw/agent/model_factory.py
+++ b/openpaw/agent/model_factory.py
@@ -33,6 +33,15 @@ THINKING_MODELS = [
 BEDROCK_TOOL_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 MAX_TOOL_NAME_LENGTH = 64
 
+# Fireworks expects `thinking` as an object, not a bool. Enabled requires
+# budget_tokens >= 1024; the docs example uses 4096.
+FIREWORKS_DEFAULT_THINKING_BUDGET = 4096
+
+# Providers whose branch actually consumes the top-level `thinking` toggle.
+# For any other provider, `thinking` is popped and ignored with a warning so
+# it can never leak into the request body as a raw bool.
+THINKING_SUPPORTED_PROVIDERS = {"moonshot", "fireworks"}
+
 
 def create_chat_model(
     model_str: str,
@@ -91,6 +100,18 @@ def create_chat_model(
     if nested_model_kwargs and isinstance(nested_model_kwargs, dict):
         kwargs.update(nested_model_kwargs)
 
+    # Pop `thinking` centrally so it can NEVER leak into a provider constructor as a
+    # raw bool (some SDKs forward unknown kwargs straight into the request body, which
+    # the API rejects — see the Fireworks fix above). Only THINKING_SUPPORTED_PROVIDERS
+    # consume it; everyone else is warned that it's a no-op.
+    thinking = kwargs.pop("thinking", None)
+    if thinking is not None and provider not in THINKING_SUPPORTED_PROVIDERS:
+        logger.warning(
+            f"'thinking' is not supported for provider '{provider}' and will be ignored. "
+            f"Supported: {sorted(THINKING_SUPPORTED_PROVIDERS)}. "
+            f"(Anthropic uses extra_body.thinking for extended-thinking budgets instead.)"
+        )
+
     if provider == "openai":
         from langchain_openai import ChatOpenAI
 
@@ -142,7 +163,7 @@ def create_chat_model(
 
         # ChatMoonshot expects bool — coerce None (the WorkspaceModelConfig default)
         # to False so we don't trip its pydantic validation.
-        thinking = bool(kwargs.get("thinking") or False)
+        thinking = bool(thinking or False)
         kwargs["thinking"] = thinking
 
         # Auto-correct temperature when the caller passed the framework default
@@ -241,6 +262,17 @@ def create_chat_model(
 
         if api_key:
             kwargs["fireworks_api_key"] = api_key
+        if thinking is not None:
+            model_kwargs = kwargs.setdefault("model_kwargs", {})
+            if thinking:
+                budget = FIREWORKS_DEFAULT_THINKING_BUDGET
+                max_tokens = kwargs.get("max_tokens")
+                # budget must leave room for the visible answer; stay above Fireworks' 1024 floor
+                if isinstance(max_tokens, int) and budget >= max_tokens:
+                    budget = max(1024, max_tokens // 2)
+                model_kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
+            else:
+                model_kwargs["thinking"] = {"type": "disabled"}
         logger.info(f"Creating ChatFireworks: model={model_name}")
         model = ChatFireworks(**kwargs)
 

--- a/openpaw/core/config/models/workspace.py
+++ b/openpaw/core/config/models/workspace.py
@@ -34,9 +34,12 @@ class WorkspaceModelConfig(BaseModel):
     thinking: bool | None = Field(
         default=None,
         description=(
-            "Enable native reasoning mode on supported providers. "
+            "Enable native reasoning mode on supported providers (moonshot, fireworks). "
             "Moonshot: maps to ChatMoonshot(thinking=...) — temperature is auto-set "
-            "to 1.0 (thinking=True) or 0.6 (thinking=False) when left at the framework default."
+            "to 1.0 (thinking=True) or 0.6 (thinking=False) when left at the framework default. "
+            "Fireworks: maps to the API's thinking object "
+            "({'type': 'enabled', 'budget_tokens': ...} or {'type': 'disabled'}). "
+            "Ignored (with a warning) on providers that don't support it."
         ),
     )
     max_output_tokens: int | None = Field(

--- a/tests/test_native_providers.py
+++ b/tests/test_native_providers.py
@@ -7,6 +7,7 @@ the ollama equivalent) inside ``create_chat_model`` succeeds with the mock
 regardless of whether the real package is present.
 """
 
+import logging
 import sys
 from unittest.mock import MagicMock, Mock, patch
 
@@ -260,6 +261,89 @@ class TestProviderCatalogIntegration:
         assert mock_cls.call_args[1]["base_url"] == "http://localhost:11434"
 
 
+class TestFireworksThinkingCoercion:
+    """Fireworks `thinking` bool is coerced into the object form the API expects.
+
+    The Fireworks API rejects a raw boolean ``thinking: true``; it requires a
+    discriminated union like ``{"type": "enabled", "budget_tokens": N}`` or
+    ``{"type": "disabled"}``.  These tests verify that ``create_chat_model``
+    performs the coercion before the value reaches ``ChatFireworks``.
+
+    ``max_retries=0`` is passed so the retry-patching block (which monkey-patches
+    ``model._agenerate``) is skipped — the mock instance doesn't need it and
+    skipping it avoids touching live SDK internals.
+    """
+
+    def test_thinking_true_produces_enabled_object(self) -> None:
+        """`thinking=True` → {"type": "enabled", "budget_tokens": 4096}."""
+        module, mock_cls = _mock_module("ChatFireworks")
+        with patch.dict(sys.modules, {"langchain_fireworks": module}):
+            create_chat_model(
+                model_str="fireworks:accounts/fireworks/models/kimi-k2p6",
+                api_key="test-key",
+                temperature=0.6,
+                extra_kwargs={"thinking": True, "max_retries": 0},
+            )
+
+        mock_cls.assert_called_once()
+        assert mock_cls.call_args[1]["model_kwargs"]["thinking"] == {
+            "type": "enabled",
+            "budget_tokens": 4096,
+        }
+
+    def test_thinking_false_produces_disabled_object(self) -> None:
+        """`thinking=False` → {"type": "disabled"}."""
+        module, mock_cls = _mock_module("ChatFireworks")
+        with patch.dict(sys.modules, {"langchain_fireworks": module}):
+            create_chat_model(
+                model_str="fireworks:accounts/fireworks/models/kimi-k2p6",
+                api_key="test-key",
+                temperature=0.6,
+                extra_kwargs={"thinking": False, "max_retries": 0},
+            )
+
+        assert mock_cls.call_args[1]["model_kwargs"]["thinking"] == {"type": "disabled"}
+
+    def test_thinking_budget_capped_when_max_tokens_equals_budget(self) -> None:
+        """`max_tokens=4096` with `thinking=True` → budget capped to 2048.
+
+        The budget must not exceed max_tokens — that would leave no tokens for
+        the visible answer.  When ``budget >= max_tokens`` the cap formula is
+        ``max(1024, max_tokens // 2)``.
+        """
+        module, mock_cls = _mock_module("ChatFireworks")
+        with patch.dict(sys.modules, {"langchain_fireworks": module}):
+            create_chat_model(
+                model_str="fireworks:accounts/fireworks/models/kimi-k2p6",
+                api_key="test-key",
+                temperature=0.6,
+                extra_kwargs={"thinking": True, "max_tokens": 4096, "max_retries": 0},
+            )
+
+        thinking_obj = mock_cls.call_args[1]["model_kwargs"]["thinking"]
+        assert thinking_obj["type"] == "enabled"
+        assert thinking_obj["budget_tokens"] == 2048
+
+    def test_thinking_absent_leaves_no_thinking_in_model_kwargs(self) -> None:
+        """When `thinking` is not provided, no thinking key appears in model_kwargs.
+
+        Regression guard: other providers (openai, anthropic, xai) must not
+        accidentally receive a ``model_kwargs["thinking"]`` entry.
+        """
+        module, mock_cls = _mock_module("ChatFireworks")
+        with patch.dict(sys.modules, {"langchain_fireworks": module}):
+            create_chat_model(
+                model_str="fireworks:accounts/fireworks/models/kimi-k2p6",
+                api_key="test-key",
+                temperature=0.6,
+                extra_kwargs={"max_retries": 0},
+            )
+
+        call_kwargs = mock_cls.call_args[1]
+        model_kwargs = call_kwargs.get("model_kwargs", {})
+        assert "thinking" not in model_kwargs
+
+
 class TestAnthropicExtendedThinkingNotRejected:
     """Regression guard: the legacy validator must not block Anthropic's extra_body.thinking."""
 
@@ -275,3 +359,98 @@ class TestAnthropicExtendedThinkingNotRejected:
             extra_body={"thinking": {"type": "enabled", "budget_tokens": 5000}},
         )
         assert config.provider == "anthropic"
+
+
+class TestThinkingLeakGuard:
+    """`thinking` must never leak into an unsupported provider's constructor.
+
+    When ``thinking`` is passed as a top-level extra_kwarg to a provider that
+    doesn't consume it (i.e., NOT moonshot or fireworks), the central pop in
+    ``create_chat_model`` must:
+
+    1. Remove it from the kwargs before the constructor is called.
+    2. Emit a WARNING containing "not supported for provider".
+
+    Existing moonshot + fireworks tests are unaffected: those providers are in
+    ``THINKING_SUPPORTED_PROVIDERS`` so no warning is emitted and the value is
+    forwarded to the provider branch for proper coercion.
+    """
+
+    @pytest.mark.parametrize(
+        "model_str, module_name, cls_name, region, extra_kwargs",
+        [
+            pytest.param(
+                "openai:gpt-4o",
+                "langchain_openai",
+                "ChatOpenAI",
+                None,
+                {"thinking": True, "max_retries": 0},
+                id="openai",
+            ),
+            pytest.param(
+                "anthropic:claude-sonnet-4-20250514",
+                "langchain_anthropic",
+                "ChatAnthropic",
+                None,
+                {"thinking": True, "max_retries": 0},
+                id="anthropic",
+            ),
+            pytest.param(
+                "xai:grok-3",
+                "langchain_xai",
+                "ChatXAI",
+                None,
+                {"thinking": True, "max_retries": 0},
+                id="xai",
+            ),
+            pytest.param(
+                "bedrock_converse:anthropic.claude-3-5-sonnet-20241022-v2:0",
+                "langchain_aws",
+                "ChatBedrockConverse",
+                "us-east-1",
+                {"thinking": True, "max_retries": 0},
+                id="bedrock_converse",
+            ),
+            pytest.param(
+                "ollama:llama3.1",
+                "langchain_ollama",
+                "ChatOllama",
+                None,
+                {"thinking": True, "max_retries": 0, "base_url": "http://localhost:11434"},
+                id="ollama",
+            ),
+        ],
+    )
+    def test_thinking_never_leaks_to_constructor(
+        self,
+        model_str: str,
+        module_name: str,
+        cls_name: str,
+        region: str | None,
+        extra_kwargs: dict,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """``thinking=True`` is stripped before any unsupported provider constructor is called."""
+        module, mock_cls = _mock_module(cls_name)
+        with caplog.at_level(logging.WARNING, logger="openpaw.agent.model_factory"):
+            with patch.dict(sys.modules, {module_name: module}):
+                create_chat_model(
+                    model_str=model_str,
+                    api_key="test-key",
+                    temperature=0.6,
+                    region=region,
+                    extra_kwargs=extra_kwargs,
+                )
+
+        mock_cls.assert_called_once()
+        constructor_kwargs = mock_cls.call_args[1]
+        assert "thinking" not in constructor_kwargs, (
+            f"'thinking' leaked into {cls_name} constructor kwargs: {constructor_kwargs}"
+        )
+        assert "thinking" not in constructor_kwargs.get("model_kwargs", {}), (
+            f"'thinking' leaked into {cls_name} model_kwargs: {constructor_kwargs.get('model_kwargs')}"
+        )
+        assert any("not supported for provider" in msg for msg in caplog.messages), (
+            f"Expected warning about unsupported 'thinking' for {model_str!r}. "
+            f"Got log messages: {caplog.messages}"
+        )


### PR DESCRIPTION
## Problem

Staging (Krieger, `fireworks:accounts/fireworks/models/kimi-k2p6`) failed every retry:

```
InvalidRequestError: 3 request validation errors: Input should be a valid dictionary
or object to extract fields from, field: 'thinking.ThinkingConfigEnabled', value: True; ...
```

### Root cause

The top-level `thinking: bool` config field (added in 0.4.3) is not in `known_model_keys`, so it flows through `extra_model_kwargs` into `create_chat_model`. The `fireworks` branch passed it straight into `ChatFireworks`, which forwards unknown kwargs into `model_kwargs` — so `thinking: true` reached the API as a **raw boolean**. Fireworks requires `thinking` to be an **object**, not a bool. The `moonshot` branch already coerced it; `fireworks` did not — and neither did the other five providers, where the same value silently leaked.

## Changes

- **Fix:** coerce the Fireworks `thinking` bool into the API's object form — `{"type": "enabled", "budget_tokens": N}` or `{"type": "disabled"}` — with the reasoning budget capped below `max_output_tokens`.
- **Harden:** pop `thinking` centrally; only `moonshot`/`fireworks` (`THINKING_SUPPORTED_PROVIDERS`) consume it. On every other provider it's ignored with a warning instead of leaking as a raw bool — closing the same latent bug on openai/anthropic/xai/bedrock/ollama.
- Updated the `thinking` field description, `docs/configuration.md`, and `CHANGELOG.md [Unreleased]`.

## Testing

- Full suite: **3170 passed**; `mypy` + `ruff` clean.
- 9 new tests: 4 Fireworks coercion (enabled/disabled/budget-cap/absent) + 5 leak-guard (one per unsupported provider).
- ⚠️ **No live Fireworks call yet** — the `test_agent` `FIREWORKS_API_KEY` is a stale placeholder (HTTP 401). Live smoke to be run on the stage server.

## Note for reviewer

`thinking` is **not** a pre-langchain-client leftover — that workaround (`extra_body.thinking` on the openai-compat shape) was already removed in 0.4.3. This field is its native replacement; this PR extends it correctly to Fireworks and makes its cross-provider contract honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)