### PR TITLE
fix: ultra triage no longer resurrects concluded tasks (short-circuit + timeout hygiene)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -241,7 +241,7 @@ A triage node routes each message: simple turns go straight to the plain react l
 
 **Per-node telemetry** — harness nodes emit `node.completed` events with token counts and latency; per-node rows land in `token_usage.jsonl` alongside the unchanged run-level records.
 
-See [Configuration](configuration.md) for the full `harness:` field reference.
+See [Harnesses](harnesses.md) for a full tour of the three tiers, the ultra graph, and the reasoning modules — and [Configuration](configuration.md) for the full `harness:` field reference.
 
 ### Learning Loop
 

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -1,0 +1,316 @@
+# Agent Harnesses
+
+OpenPaw ships three interchangeable agent **harnesses**, selected per workspace by `harness.type` (`react` | `balanced` | `ultra`). They all program against one `AgentHarness` seam (`openpaw/agent/harness/base.py`), so `MessageProcessor`, `WorkspaceRunner`, and the slash commands are topology-agnostic — every `create_agent` internal lives behind the seam. The `react` loop is the untouched default; `balanced` and `ultra` add plan visibility and (for `ultra`) planning, reflection, and per-node model routing on top of it.
+
+---
+
+## The three tiers
+
+| | `react` | `balanced` | `ultra` |
+|---|---|---|---|
+| **Topology** | bare `create_agent` loop | one loop + plan middleware | LangGraph `StateGraph` around the loop |
+| **Plan visibility** | none | live todo-driven checklist | live graph-driven checklist |
+| **Per-turn harness LLM overhead** | 0 | 0 (plan rides inside work turns) | triage + brief + plan + reflect×steps + synthesize (≈4–8+) |
+| **Step context** | one shared | one shared | **fresh, unpersisted per step** (isolation) |
+| **Per-node models** | no | no | yes (each node points at a catalog model) |
+| **Creative strategy** | none | `explore_lenses` tool (zero LLM) | `ideonomy` reasoning module |
+| **Reflection** | none | organic + optional checkpoint | `light` / `full` modules, or `off` |
+| **Best for** | chat, simple turns | everyday multi-step work you want to watch, at react cost | long-horizon work needing step isolation + model routing |
+
+The insight behind the middle tier: the three features that make `ultra` expensive — triage branching, per-node models, and step-scoped context isolation — are exactly the features `balanced` omits, so their absence *is* the point. `balanced` was ADR-101's own "middleware-only harness" fallback, promoted to a peer.
+
+All three tiers inherit the same middleware stack (approval gates, steer/interrupt, tool timeouts, status updates) and the same learning loop (skills, `manage_skill`, the Phase-2 evaluator) — those are workspace-level, orthogonal to `harness.type`. In `ultra`, they apply to every planned step *by construction* because each step re-invokes the same compiled react loop.
+
+---
+
+## Choosing a harness
+
+```mermaid
+flowchart TD
+    q1{"Multi-step work you want to watch happen?"}
+    q1 -->|"no — a simple ask or chat"| react["react"]
+    q1 -->|"yes"| q2{"Need step isolation and per-node model routing?"}
+    q2 -->|"no — just low-cost visibility"| balanced["balanced"]
+    q2 -->|"yes — long-horizon, fragile, or expensive"| ultra["ultra"]
+```
+
+- **`react`** — a direct answer or a couple of tool calls. No plan, no overhead. Workspaces that never set `harness:` behave exactly as before 0.5.0.
+- **`balanced`** — everyday multi-step tasks where the user should see a live checklist, but the work does not justify per-step LLM planning. Zero extra harness LLM calls: the plan is just the agent's own todo list.
+- **`ultra`** — long-horizon or fragile work that benefits from an explicit plan, per-step context isolation, reflection between steps, and routing cheap nodes (triage, selector) to a fast model while planning runs on a strong one.
+
+---
+
+## React harness
+
+The baseline: the compiled `create_agent` ReAct loop, wrapped unchanged.
+
+```mermaid
+flowchart LR
+    user(["User message"]) --> agent["Agent"]
+    agent <-->|"tool calls"| tools[("Tools")]
+    agent --> reply(["Reply"])
+```
+
+There is nothing harness-specific to configure. Everything below is about the two tiers layered on top of it.
+
+---
+
+## Balanced harness
+
+`BalancedHarness` (`openpaw/agent/harness/balanced.py`) *is* the react loop — it subclasses `AgentRunner` and adds a small middleware stack at build time. No new graph, one shared context, zero harness LLM calls.
+
+```mermaid
+flowchart TD
+    user(["User message"]) --> agent["Agent (single react loop)"]
+    agent <-->|"tool calls"| tools[("Tools + write_todos + explore_lenses")]
+    agent -.->|"write_todos call"| bridge["PlanEventBridge"]
+    bridge -.->|"diff into plan.* events"| checklist["Live edited-in-place checklist"]
+    agent --> reply(["Final message = the answer"])
+```
+
+**How the checklist works (zero extra LLM calls).** A thin custom `TodoListMiddleware` (`openpaw/agent/middleware/todo_list.py`) contributes a `write_todos` tool whose list lives in agent state and checkpoints per thread. `PlanEventBridge` (`plan_event_bridge.py`) wraps that tool, diffs each new list against the previous one, and emits the *same* `plan.*` status events the `ultra` checklist renderer already consumes:
+
+- first non-empty list → `plan.created`
+- an item flips to `in_progress` → `plan.step_started`
+- flips to `completed` → `plan.step_completed`
+- any content/order change beyond status → an authoritative `plan.revised`
+
+Because the todo list has no stable step IDs, IDs are synthesized positionally and diffing is by content — spurious revisions are tolerated, spurious completions are not. Every update rides inside a turn the model was already taking, so the live checklist costs nothing extra.
+
+**Statuses.** The custom todo tool forks the stock middleware to add two things John required: a first-class `failed` status (renders ✗) and an optional one-line `note` (why / what next), surfaced as a progress line without any extra call. Full status set: `pending` / `in_progress` / `completed` / `failed`.
+
+**Survives compaction.** Auto-compact rotates to a fresh thread and strips the tool-message echoes the model relies on to remember its plan. `render_todo_reminder()` re-injects the current todos as a system reminder after compaction so the checklist survives conversation rotation.
+
+**Reflection.** Organic by default: in one shared context the model sees every tool failure and its own checklist, so self-correction happens on the next turn and a todo rewrite *is* the replan. `harness.reflection.mode: checkpoint` escalates to one structured verdict call every N completed steps (immediately on a failed one), reusing `LightReflection`'s schema; the verdict is appended to the `write_todos` tool result as a course-correction nudge.
+
+**Creative asks.** The `explore_lenses` tool (`harness.ideation`) runs ideonomy's deterministic lens selector and hands the model the selected themes and question lenses as tool output — the agent thinks them through in the same turn. **Zero LLM passes** in selection; contrast the full `ideonomy` module below, which spends one LLM call per lens. The full parallel module remains `ultra`-exclusive.
+
+**Subagents** run as plain react regardless of the parent harness.
+
+See `llm_memory/balanced-harness/DESIGN.md` for the full rationale and the reference-harness research (DeepAgents, OpenClaw, Hermes, Claude Code, Manus) that converged on this single-loop + in-context-todo shape.
+
+---
+
+## Ultra harness
+
+`ultra` is a thin custom `StateGraph` (`openpaw/agent/harness/ultra/graph.py`) that owns *deliberation*; the embedded `create_agent` loop owns *action*. The `react` node is the existing compiled loop embedded directly (shared `messages` key — byte-for-byte identical behavior); each `execute_step` invokes that same compiled graph with a fresh, step-scoped message list and checkpointing disabled, so every step runs in isolated, unpersisted context while still inheriting all middleware.
+
+### Core topology
+
+```mermaid
+flowchart TD
+    start(["START"]) --> triage["triage"]
+    triage -.-> react["react"]
+    triage -.-> ideate["ideate"]
+    triage -.-> plan["plan"]
+    triage -.-> execute_step["execute_step"]
+    ideate --> plan
+    plan --> execute_step
+    execute_step --> reflect["reflect"]
+    reflect -.-> execute_step
+    reflect -.-> synthesize["synthesize"]
+    react --> done(["END"])
+    synthesize --> done
+```
+
+### Full flow (with the conditionally-added nodes)
+
+The `brief` and `equip` nodes are only added to the graph when enabled, and they route via `Command(goto=...)` rather than static edges — so a compiled-graph render can't show their wiring. The complete flow, with both features on:
+
+```mermaid
+flowchart TD
+    start(["START"]) --> triage{"triage"}
+    triage -.->|"[SYSTEM] batch / ack / simple / fail-open"| react["react"]
+    triage -.->|"resume a paused step"| execute_step["execute_step"]
+    triage -.->|"multi-step  → plan route"| brief["brief"]
+    triage -.->|"open-ended → ideate route"| brief
+    brief -.->|"plan route"| equip["equip"]
+    brief -.->|"ideate route"| ideate["ideate"]
+    equip --> plan["plan"]
+    ideate --> plan
+    plan --> execute_step
+    execute_step -.->|"request_tools (≤1× per step)"| equip
+    execute_step --> reflect["reflect"]
+    reflect -.->|"advance / insert_step / revise_plan"| execute_step
+    reflect -.->|"abort_to_user / plan complete"| synthesize["synthesize"]
+    react --> done(["END"])
+    synthesize --> done
+```
+
+> When `brief` is disabled, `triage` routes straight to `equip`/`ideate`/`plan`. When equipping is disabled, the `equip` node is absent and `brief`/`ideate` route straight to `plan`. When `reflection.module: off`, the `reflect` node is absent and `execute_step` loops directly on plan state. The diagram shows the fully-featured path.
+
+**Node by node:**
+
+- **`triage`** — classifies each batch and routes, with deterministic short-circuits *before* the LLM call (see below). Fails open to `react` on any error — the harness is never less reliable than the plain loop.
+- **`brief`** (ADR-108, `harness.brief`, **on by default**) — on the plan/ideate paths only, one structured-output call reads the **full session history** — token-budgeted against the brief model's actual context window, not a fixed cutoff — and distills a `ContextBrief` (situation, constraints, prior attempts, preferences). It flows to planning/creative/reflection modules, step execution, and synthesis. React traffic never pays for it; a brief failure falls open to a role-labeled, dialogue-only digest.
+- **`equip`** (ADR-104, `harness.tool_equipping`, off by default) — one structured call selects a tool subset for the task before planning, or re-equips mid-plan when a step calls `request_tools` (max once per step). Fails open to the full toolset.
+- **`ideate`** — runs the configured creative module (see [Creative strategies](#creative-strategies)); its `IdeationResult` feeds the planner.
+- **`plan`** — synthesizes the `Plan` via the configured planning module, with a `direct` → synthetic-single-step fallback chain so it never dead-ends.
+- **`execute_step`** — runs the react loop scoped to the current `PlanStep` (objective + checklist + brief injected), unpersisted. Approval/interrupt errors propagate out exactly as in the plain loop; `UltraHarness` owns the resume/clear contracts.
+- **`reflect`** — evaluates the step outcome via a reflection module and updates plan state (see [Reflection strategies](#reflection-strategies)).
+- **`synthesize`** — composes the final user-facing response from the plan and step results; falls back to raw step results if the call fails.
+
+Plans are first-class checkpointed state, so a restart resumes mid-plan for free; `/compact` and `/new` drop plan state with the conversation, which is correct by definition.
+
+### Triage short-circuits
+
+Triage is fed the wrong thing if it classifies the whole conversation digest — a compliment after a large project can be misread as "continue the multi-step work" and re-run the entire thing (this actually happened; see `llm_memory/triage-shortcircuit/DESIGN.md`). The current code guards this in three layers (`graph.py`):
+
+1. **`[SYSTEM]` batches → `react`.** A batch whose latest message starts with `[SYSTEM]` (sub-agent completion, cron/heartbeat injection) short-circuits to `react` before any LLM call — belt-and-braces to the same detection in `MessageProcessor`.
+2. **Terminal acknowledgments → `react`.** `_is_terminal_acknowledgment()` is a conservative, deterministic matcher: it normalizes the latest message, drops filler words, and routes to `react` only if every remaining token is an acknowledgment word (`thanks`, `great`, `ok`, …) and the message is short. Any content word ("do", "summarize", "fix") blocks the match, so it fails *toward* the LLM — a missed ack is harmless. It is a cost/latency optimization and safety net, not the correctness fix.
+3. **LLM classify — latest message weighted.** The remaining case sends the recent conversation as *reference-only context* plus the latest message set apart as the thing to classify (`TRIAGE_INPUT_TEMPLATE`, `prompts.py`). The prompt instructs the model to classify only the latest message and to treat a post-task acknowledgment as `react` even when the prior task was large.
+
+A `resume_step_id` on the thread (approval-resume) is handled first: triage jumps straight back to the paused `execute_step`.
+
+Blast radius is bounded by `harness.execution.timeout_seconds` and `harness.execution.max_steps`. Note: the timeout path clears plan state (matching the interrupt path) so a timed-out run leaves no live-looking plan debris.
+
+---
+
+## Planning strategies
+
+The planning, creative, and reflection nodes are pluggable behind one `ReasoningModule` ABC (ADR-102): `name`, `kind` (`PLANNING` | `CREATIVE` | `REFLECTION`), a one-line `tagline`, a `build(workspace)` factory, and an async `run(ctx) -> ReasoningArtifact`. Modules never call each other — the graph owns composition — so each is independently testable and substitutable. Adding one is a single class plus a `MODULE_REGISTRY` entry (`modules/registry.py`).
+
+Selection is per-kind (`modules/selector.py`), resolved at graph-build time:
+
+- **Pinned name** → bind directly, no selector node, zero cost.
+- **`auto` with one candidate** → short-circuit bind, no LLM call (`reason: "only candidate"`).
+- **`auto` with ≥2 candidates** → one structured-output call over the candidates' taglines picks the best fit; any failure falls open to the kind default (`direct` / `ideonomy` / `light`).
+
+Every path emits `module.selected`, so "which module planned this?" is answerable from the session log.
+
+### Shipped planning modules
+
+| Module | Kind | Tagline |
+|---|---|---|
+| `direct` | PLANNING | Fast single-call plan synthesis; reliable baseline (and the fallback when richer modules fail) |
+| `self_discover` | PLANNING | Composes a task-specific reasoning structure before planning; best for novel, hard, multi-step tasks |
+
+### self_discover (deep dive)
+
+A faithful adaptation of Self-Discover (Zhou et al. 2024), implemented as a compiled LangGraph subgraph behind the unchanged `run()` contract (ADR-109). Two stages: **discovery** (SELECT → ADAPT → IMPLEMENT over 39 seed reasoning modules, three structured-output calls) produces a reusable reasoning *structure*; **solve** (one call) follows the structure to synthesize a `Plan`.
+
+```mermaid
+flowchart TD
+    start(["START"]) --> load_cache{"load_cache"}
+    load_cache -.->|"hit"| solve["solve"]
+    load_cache -.->|"miss"| select["select"]
+    select --> adapt["adapt"]
+    adapt --> implement["implement"]
+    implement --> store_cache["store_cache"]
+    store_cache --> solve
+    solve --> done(["END"])
+```
+
+- **SELECT** returns *indices* into the numbered seed-module list (maximally parse-reliable); out-of-range picks are dropped, an empty selection falls back to a core default set.
+- **ADAPT** rephrases the selected modules for the task; **IMPLEMENT** returns an ordered `{name, instruction}` step list (structured output replaces the old freeform-JSON parse). The result is cached as an insertion-ordered `{name: instruction}` dict — the cache entry shape is unchanged, so old cached structures stay valid.
+- **Per-task-type cache** (`modules/self_discover/cache.py`, workspace-local) keyed by a task-type signature: a **hit skips discovery entirely** and goes straight to solve (1 call instead of 4). Discovery prompts are deliberately task-only — no tools, no digest — so cached structures transfer across toolsets and models (the paper's transferability finding; per-node models let discovery run on a stronger model than solve).
+
+**When it's worth it:** novel, hard, multi-step tasks where a bespoke reasoning structure pays for the three discovery calls — amortized to near-zero on repeat task types. The subgraph runs unpersisted; its stages appear as namespaced nodes in the outer stream and emit `module.phase` / `module.insight` (cache-hit vs discover, each stage, a structure snapshot).
+
+---
+
+## Creative strategies
+
+| Module | Kind | Tagline |
+|---|---|---|
+| `ideonomy` | CREATIVE | Divergent ideation through ideonomic lenses; strongest for open-ended or creative tasks |
+
+### ideonomy (deep dive)
+
+Ideonomy is Patrick Gunkel's "science of ideas" (<https://ideonomy.mit.edu>); the division data and selection mechanics are ported with attribution from the MIT-licensed [Morpheis/ideonomy-engine](https://github.com/Morpheis/ideonomy-engine). Lens *selection* is deterministic and costs no tokens — it keyword-scores the task against curated ideonomic divisions and emits lenses (a core question plus guiding questions). The module then spends one LLM call per selected lens and one synthesis call.
+
+```mermaid
+flowchart TD
+    start(["START"]) --> select_lenses["select_lenses"]
+    select_lenses -.->|"Send × N lenses (concurrent)"| explore_lens["explore_lens"]
+    explore_lens --> synthesize["synthesize"]
+    synthesize --> done(["END"])
+```
+
+`select_lenses` is zero-token; `_fan_out` emits one LangGraph `Send` per lens, so the **lens explorations run concurrently** (wall-clock ≈ two sequential calls regardless of lens count). A failed lens contributes nothing (an `operator.add` reducer tolerates it); `synthesize` raises only if *every* lens failed. The final `IdeationResult` (ideas, evaluations, recommended directions) feeds the planner on the ideate path.
+
+**Contrast with balanced's `explore_lenses` tool:** same deterministic selector, but the balanced tool returns the lenses as tool output for the agent to think through in-context — **zero LLM passes**, no fan-out, no discrete artifact. The full parallel subgraph is `ultra`-exclusive.
+
+---
+
+## Reflection strategies
+
+Reflection is a module kind, not a hardcoded node — `harness.reflection.module` selects the behavior (`ultra`):
+
+| Module | Kind | Behavior |
+|---|---|---|
+| `light` (default) | REFLECTION | One structured verdict per step; never rewrites the plan (`revise_plan` is coerced to `advance`, notes preserved) |
+| `full` | REFLECTION | Verdict as in light; on `revise_plan`, a second call rewrites only the remaining steps |
+| `off` | — | Omits the `reflect` node entirely — `execute_step` marks the step done and advances directly |
+
+Each verdict picks one action: **`advance`** (next step), **`insert_step`** (add one corrective step), **`revise_plan`** (rewrite the remaining tail — `full` only), or **`abort_to_user`** (stop and surface to the user). `light` is the cheap default; `full` is for long or fragile plans where the tail may need rewriting mid-flight.
+
+```mermaid
+flowchart LR
+    plan["plan"] --> execute_step["execute_step"]
+    execute_step --> reflect["reflect"]
+    reflect -.->|"advance / insert_step / revise_plan"| execute_step
+    reflect -.->|"abort_to_user / plan complete / budget reached"| synthesize["synthesize"]
+```
+
+The loop continues while pending steps remain, within `execution.max_steps`, and no abort is set. A reflection failure fails open to `advance` — a broken reflector must not stall the plan.
+
+---
+
+## Observability
+
+Every observable happening — runs, tools, sub-agents, node transitions, plan lifecycle, module selection/phases, reflection verdicts, skill and learning events — is a machine-readable `StatusEvent` (ADR-106, `model/status_event.py`) fanned through a per-workspace `StatusBus` to pluggable sinks: the channel renderer (the live edited-in-place checklist) and a JSONL event log, with a web portal as a future consumer. Emission is best-effort and never blocks or fails a run.
+
+`balanced` and `ultra` share the same event vocabulary — that is exactly why `balanced`'s `PlanEventBridge` can emit `plan.*` events that the `ultra` checklist renderer draws unchanged. Inside the `ultra` graph, reasoning-module stages emit over LangGraph's custom stream; `UltraHarness` forwards them to the bus and stamps run identity centrally. Harness nodes also emit `node.completed` with token counts and latency, landing per-node rows in `token_usage.jsonl`.
+
+---
+
+## Config quick reference
+
+Field names and defaults from `openpaw/core/config/models/harness.py`. New 0.5.0 groups use `extra="forbid"` — typos fail fast. A bare `harness: {type: ultra}` validates and runs with every node inheriting the workspace model.
+
+```yaml
+harness:
+  type: react                     # react | balanced | ultra   (default: react)
+
+  # --- balanced-only groups (ignored by react/ultra) ---
+  plan:
+    visibility: true              # PlanEventBridge -> live checklist
+  ideation:
+    lens_tool: true               # register the zero-LLM explore_lenses tool
+    lens_count: 3                 # lenses per call (1–7)
+
+  # --- ultra node model pointers (catalog name or "provider:model"); unset = inherit ---
+  triage:   {model: null}
+  planning: {module: direct, model: null, allowed: null}   # direct | self_discover | auto
+  creative: {module: ideonomy, model: null, allowed: null} # ideonomy | auto
+  reflection:
+    module: light                 # off | light | full | auto     (ultra)
+    mode: organic                 # organic | checkpoint           (balanced)
+    every: 3                      # checkpoint mode: verdict every N steps
+    model: null
+  selector:  {model: null}        # module: auto selection call
+  synthesize: {model: null}
+
+  # --- context brief (ultra, ADR-108) ---
+  brief:
+    enabled: true                 # on by default for ultra; react routes skip it
+    max_input_tokens: null        # optional transcript cap; null = model window - headroom
+    model: null
+
+  # --- optional tool equipping (ultra, ADR-104) ---
+  tool_equipping:
+    enabled: false
+    always_equip: [group:filesystem, send_message]
+    max_tools: 25
+    react_selector: false         # stock LLMToolSelectorMiddleware on the react path
+    model: null
+
+  # --- execution budgets (balanced + ultra) ---
+  execution:
+    max_steps: 12                 # ultra plan-step budget (1–100)
+    max_turns: null               # inner-runner turn cap; null = workspace model.max_turns
+    timeout_seconds: null         # wall-clock budget; null = workspace timeout
+```
+
+See [Configuration](configuration.md) for the full `harness:` reference and [Architecture](architecture.md#agent-harness) for how the harness seam fits the rest of the system.

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,6 +97,7 @@ For a deeper understanding, start with [Concepts](concepts.md) for the mental mo
 | [Workspaces](workspaces.md) | Workspace structure, identity files, and custom tools |
 | [Scheduling](scheduling.md) | Cron jobs, heartbeats, and dynamic scheduling |
 | [Built-ins](builtins.md) | Optional tools (search, browser, spawn) and processors (Whisper, Docling) |
+| [Harnesses](harnesses.md) | The three agent harnesses (react, balanced, ultra) and reasoning strategies |
 | [MCP Servers](mcp.md) | Per-workspace MCP server connections (HTTP and stdio) |
 | [Channels](channels.md) | Channel adapters, access control, and adding new providers |
 | [Queue System](queue-system.md) | Message queueing and the four queue modes |

--- a/openpaw/agent/harness/ultra/graph.py
+++ b/openpaw/agent/harness/ultra/graph.py
@@ -47,6 +47,7 @@ fake subgraph.
 """
 
 import logging
+import re
 import time
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
@@ -101,6 +102,7 @@ from openpaw.agent.harness.ultra.prompts import (
     STEP_EXECUTION_TEMPLATE,
     SYNTHESIZE_ABORT_BLOCK,
     SYNTHESIZE_TEMPLATE,
+    TRIAGE_INPUT_TEMPLATE,
     TRIAGE_SYSTEM_PROMPT,
 )
 from openpaw.agent.harness.ultra.state import (
@@ -178,6 +180,45 @@ def _last_human_text(messages: list[Any]) -> str:
         if isinstance(msg, HumanMessage):
             return extract_message_text(msg.content)
     return ""
+
+
+# ponytail: hand-curated word sets — a heuristic, not a classifier. It exists
+# to short-circuit the obvious "great work!" case; the triage LLM (fed the
+# latest message, see TRIAGE_INPUT_TEMPLATE) is the correctness backstop, so
+# this is *allowed* to miss. Upgrade path: swap for a tiny "is this a task?"
+# classifier model if paraphrased or multilingual acks ("merci!", "you rock",
+# "top job") start slipping through in practice.
+_ACK_WORDS = frozenset({
+    "thanks", "thank", "thankyou", "thx", "ty", "great", "nice", "awesome",
+    "perfect", "cool", "ok", "okay", "k", "kk", "yes", "yep", "yup", "yeah",
+    "lol", "haha", "hahaha", "good", "love", "loved", "wow", "gg", "sweet",
+    "excellent", "amazing", "brilliant", "fantastic", "wonderful", "beautiful",
+    "solid", "legend", "done", "nailed", "best", "congrats",
+})
+
+# Removed before the all-ack check so filler around an ack word ("great WORK
+# DUDE", "thanks SO MUCH", "well done" → "well") does not block a match.
+_ACK_FILLER = frozenset({
+    "work", "job", "dude", "man", "bro", "buddy", "mate", "you", "u", "so",
+    "much", "very", "really", "the", "that", "this", "it", "a", "for", "well",
+    "there", "my", "friend", "and", "all",
+})
+
+
+def _is_terminal_acknowledgment(text: str) -> bool:
+    """True IFF ``text`` is a bare acknowledgment (thanks/compliment/ok).
+
+    Conservative by construction — fails toward the LLM (§6): any content word
+    that is not an ack ("do", "summarize", "fix") blocks the match, and messages
+    longer than the brevity gate never match. False negatives are harmless (the
+    ack goes to triage, which routes it correctly anyway); false positives —
+    swallowing a real task — are what this must avoid.
+    """
+    tokens = re.sub(r"[^\w\s]", " ", text.lower()).split()
+    if not tokens or len(tokens) > 6:  # real multi-step asks are longer
+        return False
+    content = [t for t in tokens if t not in _ACK_FILLER]
+    return bool(content) and all(t in _ACK_WORDS for t in content)
 
 
 def _conversation_digest(messages: list[Any]) -> str:
@@ -368,6 +409,21 @@ def build_ultra_graph(
                 goto="react",
             )
 
+        # Deterministic ack short-circuit: a bare "thanks"/"great work!" never
+        # needs the triage LLM and must never resurrect a concluded task. Same
+        # Command shape as the [SYSTEM] block above; fails toward the LLM by
+        # construction (any content word blocks the match).
+        if _is_terminal_acknowledgment(last_text):
+            await _emit(
+                StatusEventKind.NODE_ENTERED,
+                "triage",
+                {"route": "react", "reason": "acknowledgment"},
+            )
+            return Command(
+                update={"route": "react", "objective": last_text[:200], "context_brief": None},
+                goto="react",
+            )
+
         # Entry event (no "route" key) — renders the "Thinking..." status
         # while the triage model decides; the post-decision event below
         # carries the chosen route (feedback round 1).
@@ -377,7 +433,12 @@ def build_ultra_graph(
                 decision = await node_models.triage.with_structured_output(TriageDecision).ainvoke(
                     [
                         SystemMessage(TRIAGE_SYSTEM_PROMPT),
-                        HumanMessage(_conversation_digest(state.get("messages", []))),
+                        HumanMessage(
+                            TRIAGE_INPUT_TEMPLATE.format(
+                                digest=_conversation_digest(state.get("messages", [])),
+                                latest=last_text,
+                            )
+                        ),
                     ]
                 )
                 if not isinstance(decision, TriageDecision):

--- a/openpaw/agent/harness/ultra/harness.py
+++ b/openpaw/agent/harness/ultra/harness.py
@@ -470,6 +470,10 @@ class UltraHarness:
             await self._record_resume_marker(config)
             raise
         except TimeoutError:
+            # A timed-out run is, from the plan's perspective, abandoned —
+            # clear plan state exactly as the interrupt path does so stale,
+            # live-looking plan state cannot outlive the concluded turn.
+            await self._clear_plan_state(config)
             duration_ms = (time.monotonic() - start_time) * 1000
             self._last_metrics = extract_metrics_from_callback(usage_callback, duration_ms, self.model_id)
             self._last_metrics.is_partial = True

--- a/openpaw/agent/harness/ultra/prompts.py
+++ b/openpaw/agent/harness/ultra/prompts.py
@@ -5,17 +5,31 @@ constants are harness-internal and not user-visible configuration.
 """
 
 TRIAGE_SYSTEM_PROMPT = """\
-You are a triage classifier for an AI agent. Classify the user's latest \
-request into exactly one route:
+You are a triage classifier for an AI agent. Classify ONLY the LATEST \
+MESSAGE into exactly one route. The recent conversation is context for \
+resolving references (e.g. "do it", "summarize that") — it is NOT work to \
+resume or continue. A short acknowledgment, thanks, or compliment is `react`, \
+even when the prior task was large.
 
 - react: simple or conversational — a direct answer or a couple of tool \
-calls suffices. When in doubt, choose react.
+calls suffices; also acknowledgments and small talk. When in doubt, choose react.
 - plan: genuinely multi-step work — several distinct actions that benefit \
 from an explicit ordered plan (research + build + verify, long-horizon tasks).
 - ideate: open-ended creative work where exploring directions first would \
 improve the result (brainstorming, naming, design concepts).
 
-Also restate the task as a one-sentence objective."""
+Restate the objective of the LATEST MESSAGE only, in one sentence."""
+
+# Triage input: the recent conversation as reference-only context, plus the
+# latest message set apart as the thing to classify (ADR-101; triage
+# short-circuit design §B). The prompt classifies the latter, using the
+# former only to resolve references.
+TRIAGE_INPUT_TEMPLATE = """\
+Recent conversation (context only — do NOT treat as work to continue or resume):
+{digest}
+
+LATEST MESSAGE TO CLASSIFY:
+{latest}"""
 
 # {context_block} is the optional "Session context:" block (ADR-108) —
 # render_context_block() yields "" (byte-identical prompt) when no brief.

--- a/tests/test_ultra_graph.py
+++ b/tests/test_ultra_graph.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Annotated, Any, TypedDict, cast
 
 import aiosqlite
+import pytest
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, AnyMessage, HumanMessage
 from langgraph.checkpoint.memory import MemorySaver
@@ -21,6 +22,7 @@ from openpaw.agent.harness.modules.reflection import FullReflection, LightReflec
 from openpaw.agent.harness.ultra.graph import (
     UltraNodeModels,
     TriageDecision,
+    _is_terminal_acknowledgment,
     build_ultra_graph,
 )
 from openpaw.agent.harness.ultra.prompts import FALLBACK_STEP_DESCRIPTION
@@ -258,6 +260,124 @@ async def test_system_batch_routes_react_without_llm_call() -> None:
     # The short-circuit (not the fail-open fallback) handled it — no LLM call.
     triage_events = [e for e in emitter.events if e.node == "triage"]
     assert triage_events[0].payload["reason"] == "system batch"
+
+
+# ---------------------------------------------------------------------------
+# Terminal-acknowledgment short-circuit (A2) + latest-message weighting (B)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "great work dude!",
+        "thanks!",
+        "thanks so much",
+        "nice",
+        "ok",
+        "lol",
+        "perfect 👍",
+        "great job",
+        "well done",
+    ],
+)
+def test_terminal_acknowledgment_matches(text: str) -> None:
+    assert _is_terminal_acknowledgment(text) is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "summarize that",
+        "do it",
+        "great, now do the next step",
+        "thanks, can you also fix X",
+        "nice — one more thing",
+        "",
+        "Please research the top ten films. Then cross-reference every rating. "
+        "Finally write a ranked summary for me.",
+    ],
+)
+def test_terminal_acknowledgment_falls_through(text: str) -> None:
+    # Fail toward the LLM: any content word / imperative / long message must not match.
+    assert _is_terminal_acknowledgment(text) is False
+
+
+async def test_terminal_ack_short_circuits_to_react_without_triage_llm() -> None:
+    """A bare compliment routes react deterministically — the triage LLM is skipped."""
+    calls: list[str] = []
+    triage_model = FakeModel()  # must NOT be called
+    emitter = CaptureEmitter()
+    graph = build_ultra_graph(
+        react_graph=make_fake_react(["you're welcome"], calls),
+        node_models=UltraNodeModels(
+            triage=cast(BaseChatModel, triage_model),
+            planning=fake(),
+            creative=fake(),
+            reflection=fake(),
+            selector=fake(),
+            synthesize=fake(),
+        ),
+        harness_config=HarnessConfig(type="ultra"),
+        candidates=default_candidates(),
+        emitter=emitter,
+        workspace_info=WorkspaceInfo(name="testws", timezone="UTC", workspace_path=Path("/tmp/ws")),
+        tools_summary=[],
+        run_context=UltraRunContext(),
+        checkpointer=None,
+        inner_recursion_limit=20,
+    )
+    result = await graph.ainvoke({"messages": [HumanMessage("great work dude!")]})
+
+    assert triage_model.call_count == 0  # deterministic short-circuit, no LLM
+    assert result["route"] == "react"
+    assert result["messages"][-1].content == "you're welcome"
+    triage_events = [e for e in emitter.events if e.node == "triage"]
+    assert triage_events[0].payload["reason"] == "acknowledgment"
+
+
+async def test_triage_input_isolates_latest_message_and_does_not_force_react() -> None:
+    """B: the model receives the latest message set apart; the route is the model's.
+
+    A non-ack follow-up ("summarize that") after a large prior project reaches
+    the triage LLM with a distinct LATEST-MESSAGE section, and the mechanism
+    honors whatever the model returns (here: plan) — it does not hard-code react.
+    """
+    triage_model = FakeModel(plan_decision("summarize the ghibli research"))
+    graph = build_ultra_graph(
+        react_graph=make_fake_react(["r1"], []),
+        node_models=UltraNodeModels(
+            triage=cast(BaseChatModel, triage_model),
+            planning=fake(_PlanSchema(steps=["one"])),
+            creative=fake(),
+            reflection=fake(advance()),
+            selector=fake(),
+            synthesize=fake(AIMessage(content="done")),
+        ),
+        harness_config=HarnessConfig(type="ultra"),
+        candidates=default_candidates(),
+        emitter=CaptureEmitter(),
+        workspace_info=WorkspaceInfo(name="testws", timezone="UTC", workspace_path=Path("/tmp/ws")),
+        tools_summary=[],
+        run_context=UltraRunContext(),
+        checkpointer=None,
+        inner_recursion_limit=20,
+    )
+    messages = [
+        HumanMessage("build me a huge ranked zine of every studio ghibli film"),
+        AIMessage("...massive multi-step research output about every ghibli film..."),
+        HumanMessage("summarize that"),
+    ]
+    result = await graph.ainvoke({"messages": messages})
+
+    prompt = triage_model.prompts[0]
+    latest_section = prompt.split("LATEST MESSAGE TO CLASSIFY:")[1]
+    assert "summarize that" in latest_section
+    # The digest is framed as reference context, not work to resume.
+    assert "context only" in prompt
+    assert "massive multi-step research output" in prompt  # prior project in the digest
+    # Not forced to react — the model's plan route is honored.
+    assert result["route"] == "plan"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ultra_harness.py
+++ b/tests/test_ultra_harness.py
@@ -260,6 +260,23 @@ async def test_timeout_returns_notification_with_partial_metrics(harness: UltraH
     assert harness.last_metrics.is_partial is True
 
 
+async def test_timeout_clears_plan_state(harness: UltraHarness) -> None:
+    """A timed-out run abandons the plan — same cleanup as the interrupt path."""
+    stub = StubGraph(delay=5.0)
+    harness._graph = stub
+    harness.timeout_seconds = 0.05
+
+    response = await harness.run("long task", thread_id="telegram:1:conv1")
+
+    assert response == TIMEOUT_NOTIFICATION_GENERIC.format(timeout=0)  # notification unchanged
+    assert len(stub.state_updates) == 1
+    values, as_node = stub.state_updates[0]
+    assert values["plan"] is None
+    assert values["current_step_id"] is None
+    assert values["resume_step_id"] is None
+    assert as_node == "plan"
+
+
 # ---------------------------------------------------------------------------
 # run() end-to-end over a fake ultra graph (real astream/updates parsing)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
The ULTRA harness `triage` node was handed the whole conversation **digest** while its prompt claimed to classify *the latest request*. After a large task, an acknowledgment ("great work dude!") read as "multi-step research in progress" and triage routed `plan`, **re-creating and re-executing the entire finished project** — a costly self-reinforcing loop (timeout → subagents complete → re-inject → re-trigger). Real incident: Krieger re-ran a 7-step Studio Ghibli zine project on a compliment.

Root cause is input-shape, not classification quality. Design: `llm_memory/triage-shortcircuit/DESIGN.md`.

## Changes (recommendation items B, D, A2 — ultra-only)
- **B — latest-message weighting (the fix):** triage input restructured into explicit `Recent conversation (context only — do not resume)` vs `LATEST MESSAGE TO CLASSIFY` blocks (reusing the already-computed `_last_human_text`); `TRIAGE_SYSTEM_PROMPT` tightened to classify only the latest message and treat a post-task ack as `react`.
- **D — timeout hygiene:** the `TimeoutError` path now calls the existing `_clear_plan_state` (as the interrupt path already does), so a timed-out plan can't linger as live-looking state.
- **A2 — conservative ack short-circuit:** a pure `_is_terminal_acknowledgment()` slotted into the existing `[SYSTEM]` short-circuit — deterministic, skips the triage LLM for bare thanks/compliments, and **fails toward the LLM** (any task word blocks the match; "do it", "summarize that", "great, now do X" all fall through).

Deferred (documented, not built): task-boundary state tracking and a per-session cost cap.

## Tests / verification
Table-driven ack MATCH/NO-MATCH corpus, triage-input-shape assertions, timeout-clears-state, and `[SYSTEM]`/happy-path regressions. Full suite 3,814 green, mypy strict clean, ruff clean.

## Scope note
`react` and `balanced` have no triage node, so this is ultra-only. Krieger is temporarily on `balanced` as the immediate mitigation; this is the durable ultra fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)